### PR TITLE
Fix: Generic backend: Include stream: True in payload for streaming requests

### DIFF
--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -77,12 +77,16 @@ class OpenAIAdapter(APIAdapter):
         tools: list[AvailableTool] | None,
         max_tokens: int | None,
         tool_choice: StrToolChoice | AvailableTool | None,
+        enable_streaming: bool = False,
     ) -> dict[str, Any]:
         payload = {
             "model": model_name,
             "messages": converted_messages,
             "temperature": temperature,
         }
+
+        if enable_streaming:
+            payload["stream"] = True
 
         if tools:
             payload["tools"] = [tool.model_dump(exclude_none=True) for tool in tools]
@@ -119,7 +123,13 @@ class OpenAIAdapter(APIAdapter):
         converted_messages = [msg.model_dump(exclude_none=True) for msg in messages]
 
         payload = self.build_payload(
-            model_name, converted_messages, temperature, tools, max_tokens, tool_choice
+            model_name,
+            converted_messages,
+            temperature,
+            tools,
+            max_tokens,
+            tool_choice,
+            enable_streaming,
         )
 
         headers = self.build_headers(api_key)


### PR DESCRIPTION
# Generic backend: Streaming requests don't include `stream: True` in payload

Fixes #11 

## Description

`GenericBackend.complete_streaming()` expects a streaming SSE response but doesn't include `stream: True` in the request payload sent to OpenAI-compatible APIs (like vLLM). This causes the server to return a non-streaming response, which the code then tries to parse as SSE format and fails.

## Steps to Reproduce

1. Configure a provider with `backend = "generic"` and `api_style = "openai"` pointing to an OpenAI-compatible API (e.g., vLLM)
2. Enable streaming (e.g., via `Agent(enable_streaming=True)` or programmatic mode with streaming output)
3. Make a request that triggers `complete_streaming()`
4. Observe the error: "Error: API error from vllm (model: mistralai/Ministral-3-14B-Instruct-2512): line should look like key: value"

## Expected Behavior

When `complete_streaming()` is called, the request payload should include `stream: True`, causing the server to return a streaming SSE response that can be parsed correctly.

## Actual Behavior

The payload sent to the server is `{"model": "...", "messages": [...], "temperature": 0.2}` (missing `stream: True`). The server returns a non-streaming JSON response (`application/json`), but the code tries to parse it as SSE format and fails with "Streamed completion returned no chunks".

## Root Cause

`OpenAIAdapter.build_payload()` doesn't accept the `enable_streaming` parameter, even though:
- `complete_streaming()` sets `enable_streaming=True` when calling `prepare_request()` (line 307)
- `prepare_request()` receives it but doesn't pass it to `build_payload()` (line 121)

**File**: `vibe/core/llm/backend/generic.py`

```python
# complete_streaming() sets enable_streaming=True (line 307)
endpoint, headers, body = adapter.prepare_request(..., enable_streaming=True, ...)

# prepare_request() receives it but doesn't pass to build_payload() (line 121)
payload = self.build_payload(..., tool_choice)  # enable_streaming missing!

# build_payload() doesn't accept enable_streaming parameter (line 72)
def build_payload(..., tool_choice):  # No enable_streaming parameter
    payload = {"model": ..., "messages": ...}  # stream: True never added
```

## Solution

1. Add `enable_streaming` parameter to `build_payload()`:
```python
def build_payload(..., enable_streaming: bool = False):
    payload = {...}
    if enable_streaming:
        payload["stream"] = True
    return payload
```

2. Update `prepare_request()` to pass it:
```python
payload = self.build_payload(..., enable_streaming)
```

## Environment

- Python version: 3.12+
- Operating system: Any (tested on macOS)
- Vibe version: Latest (from main branch)

## Error Messages

```
Error: API error from vllm (model: mistralai/Ministral-3-14B-Instruct-2512): line should look like key: value
```

## Configuration

```toml
[[providers]]
name = "vllm"
api_base = "http://192.168.1.17:8000/v1"
api_key_env_var = ""
api_style = "openai"
backend = "generic"
```

## Additional Notes

- The Mistral backend (`MistralBackend`) works correctly because it uses a different SDK that handles streaming internally
- After applying the fix, streaming works correctly with OpenAI-compatible backends
