### PR TITLE
Enable Linux ARM64 builds

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -17,9 +17,9 @@ jobs:
           - runner: ubuntu-22.04
             os: linux
             arch: x86_64
-          # - runner: ubuntu-22.04-arm # ubuntu-22.04-arm, ubuntu-24.04-arm and windows-11-arm are not supported yet for private repositories
-          #   os: linux
-          #   arch: aarch64
+          - runner: ubuntu-22.04-arm
+            os: linux
+            arch: aarch64
 
           # macOS
           - runner: macos-15-intel
@@ -33,7 +33,7 @@ jobs:
           - runner: windows-2022
             os: windows
             arch: x86_64
-          # - runner: windows-11-arm # ubuntu-22.04-arm, ubuntu-24.04-arm and windows-11-arm are not supported yet for private repositories
+          # - runner: windows-11-arm # dependencies are failing to build
           #   os: windows
           #   arch: aarch64
     runs-on: ${{ matrix.runner }}

--- a/distribution/zed/extension.toml
+++ b/distribution/zed/extension.toml
@@ -18,9 +18,9 @@ cmd = "./vibe-acp"
 archive = "https://github.com/mistralai/mistral-vibe/releases/download/v1.0.4/vibe-acp-darwin-x86_64-1.0.4.zip"
 cmd = "./vibe-acp"
 
-# [agent_servers.mistral-vibe.targets.linux-aarch64]
-# archive = "https://github.com/mistralai/mistral-vibe/releases/download/v1.0.4/vibe-acp-linux-aarch64-1.0.4.zip"
-# cmd = "./vibe-acp"
+[agent_servers.mistral-vibe.targets.linux-aarch64]
+archive = "https://github.com/mistralai/mistral-vibe/releases/download/v1.0.4/vibe-acp-linux-aarch64-1.0.4.zip"
+cmd = "./vibe-acp"
 
 [agent_servers.mistral-vibe.targets.linux-x86_64]
 archive = "https://github.com/mistralai/mistral-vibe/releases/download/v1.0.4/vibe-acp-linux-x86_64-1.0.4.zip"


### PR DESCRIPTION
I noticed that Linux ARM64 runner was commented out due to it not being available in private repos. Now that Mistral Vibe is public, it should be enabled.

This PR enables the release for the `linux-aarch64` target along with uncommenting the respective line in the Zed extension.

I tried enabling the Windows ARM64 build too, but it failed due to the [typos](https://github.com/crate-ci/typos) dependency not being available for Windows ARM. I updated the comment on the Action runner Windows ARM target to reflect this.