### PR TITLE
feat(agent-md): support AGENT.md project conventions file

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ system_prompt_id = "my_custom_prompt"
 
 This will load the prompt from `~/.vibe/prompts/my_custom_prompt.md`.
 
+### Project Conventions with AGENT.md
+
+Mistral Vibe automatically detects and incorporates project-specific coding conventions from an `AGENT.md` or `agent.md` file in your project's root directory. This file can contain any coding guidelines, style preferences, or project-specific instructions that should be followed by the AI assistant.
+
+To enable or configure AGENT.md behavior, you can modify the `agent_md` section in your config.toml:
+
+```toml
+[agent_md]
+enabled = true  # Set to false to disable the feature
+filename = "AGENT.md"  # Specify the filename to look for (default: "AGENT.md")
+```
+
+When enabled, Vibe will automatically load the content from `AGENT.md` (or `agent.md`) and append it to the system prompt as "Project Coding Conventions". This allows the AI to learn and follow your project's specific coding standards and practices.
+
 ### Custom Agent Configurations
 
 You can create custom agent configurations for specific use cases (e.g., red-teaming, specialized tasks) by adding agent-specific TOML files in the `~/.vibe/agents/` directory.

--- a/tests/test_agent_md.py
+++ b/tests/test_agent_md.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from vibe.core.config import VibeConfig
+from vibe.core.system_prompt import get_universal_system_prompt, _load_agent_md
+from vibe.core.tools.manager import ToolManager
+
+
+def test_load_agent_md_file_found():
+    """Test that _load_agent_md correctly loads content when file exists."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        agent_md_path = temp_path / "AGENT.md"
+        agent_md_content = "# My Project Conventions\n\n- Use 4 spaces for indentation\n- Use single quotes for strings"
+        agent_md_path.write_text(agent_md_content)
+
+        result = _load_agent_md(temp_path, 10000, enabled=True)
+        assert result == agent_md_content
+
+
+def test_load_agent_md_file_not_found():
+    """Test that _load_agent_md returns empty string when file doesn't exist."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        result = _load_agent_md(temp_path, 10000, enabled=True)
+        assert result == ""
+
+
+def test_load_agent_md_disabled():
+    """Test that _load_agent_md returns empty string when disabled."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        agent_md_path = temp_path / "AGENT.md"
+        agent_md_path.write_text("# My Project Conventions")
+
+        result = _load_agent_md(temp_path, 10000, enabled=False)
+        assert result == ""
+
+
+def test_load_agent_md_lowercase_filename():
+    """Test that _load_agent_md can load lowercase agent.md files."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        agent_md_path = temp_path / "agent.md"
+        agent_md_content = "# My Project Conventions"
+        agent_md_path.write_text(agent_md_content)
+
+        result = _load_agent_md(temp_path, 10000, enabled=True)
+        assert result == agent_md_content
+
+
+def test_load_agent_md_custom_filename():
+    """Test that _load_agent_md can load custom filename when specified."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        custom_agent_md_path = temp_path / "custom_agent.md"
+        agent_md_content = "# My Custom Conventions"
+        custom_agent_md_path.write_text(agent_md_content)
+
+        # When a custom filename is provided, it should be tried first
+        result = _load_agent_md(temp_path, 10000, enabled=True, filename="custom_agent.md")
+        assert result == agent_md_content
+
+
+def test_agent_md_integration_enabled():
+    """Test that AGENT.md content is included in the universal system prompt when enabled."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        agent_md_path = temp_path / "AGENT.md"
+        agent_md_content = "# My Project Conventions\n\n- Use 4 spaces for indentation"
+        agent_md_path.write_text(agent_md_content)
+
+        config = VibeConfig(
+            system_prompt_id="tests",
+            include_project_context=True,
+            include_prompt_detail=False,
+            include_model_info=False,
+            workdir=temp_path,
+            agent_md={"enabled": True, "filename": "AGENT.md"}
+        )
+        tool_manager = ToolManager(config)
+
+        prompt = get_universal_system_prompt(tool_manager, config)
+
+        assert "## Project Coding Conventions (from AGENT.md)" in prompt
+        assert "# My Project Conventions" in prompt
+        assert "- Use 4 spaces for indentation" in prompt
+
+
+def test_agent_md_integration_disabled():
+    """Test that AGENT.md content is not included in the universal system prompt when disabled."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        agent_md_path = temp_path / "AGENT.md"
+        agent_md_content = "# My Project Conventions"
+        agent_md_path.write_text(agent_md_content)
+
+        config = VibeConfig(
+            system_prompt_id="tests",
+            include_project_context=True,
+            include_prompt_detail=False,
+            include_model_info=False,
+            workdir=temp_path,
+            agent_md={"enabled": False, "filename": "AGENT.md"}
+        )
+        tool_manager = ToolManager(config)
+
+        prompt = get_universal_system_prompt(tool_manager, config)
+
+        assert "## Project Coding Conventions (from AGENT.md)" not in prompt
+        assert "# My Project Conventions" not in prompt
+
+
+def test_agent_md_integration_default_enabled():
+    """Test that AGENT.md content is included by default when enabled is not set."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        agent_md_path = temp_path / "AGENT.md"
+        agent_md_content = "# My Project Conventions"
+        agent_md_path.write_text(agent_md_content)
+
+        config = VibeConfig(
+            system_prompt_id="tests",
+            include_project_context=True,
+            include_prompt_detail=False,
+            include_model_info=False,
+            workdir=temp_path
+        )
+        tool_manager = ToolManager(config)
+
+        prompt = get_universal_system_prompt(tool_manager, config)
+
+        assert "## Project Coding Conventions (from AGENT.md)" in prompt
+        assert "# My Project Conventions" in prompt

--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -56,6 +56,7 @@ PROMPT_DIR = CONFIG_DIR / "prompts"
 INSTRUCTIONS_FILE = CONFIG_DIR / "instructions.md"
 HISTORY_FILE = CONFIG_DIR / "vibehistory"
 PROJECT_DOC_FILENAMES = ["AGENTS.md", "VIBE.md", ".vibe.md"]
+AGENT_MD_FILENAMES = ["AGENT.md", "agent.md"]
 
 
 class MissingAPIKeyError(RuntimeError):
@@ -112,6 +113,11 @@ class TomlFileSettingsSource(PydanticBaseSettingsSource):
 
     def __call__(self) -> dict[str, Any]:
         return self.toml_data
+
+
+class AgentMdConfig(BaseSettings):
+    enabled: bool = True
+    filename: str = "AGENT.md"
 
 
 class ProjectContextConfig(BaseSettings):
@@ -316,6 +322,7 @@ class VibeConfig(BaseSettings):
     models: list[ModelConfig] = Field(default_factory=lambda: list(DEFAULT_MODELS))
 
     project_context: ProjectContextConfig = Field(default_factory=ProjectContextConfig)
+    agent_md: AgentMdConfig = Field(default_factory=AgentMdConfig)
     session_logging: SessionLoggingConfig = Field(default_factory=SessionLoggingConfig)
     tools: dict[str, BaseToolConfig] = Field(default_factory=dict)
     tool_paths: list[str] = Field(


### PR DESCRIPTION
This PR adds support for automatically loading project-specific coding conventions
from an AGENT.md (or agent.md) file in the project root. The content is appended
to the system prompt, allowing Vibe to learn repository coding conventions.

### Key Features
- AgentMdConfig with `enabled` + `filename`
- Supports both AGENT.md and agent.md
- Automatic system prompt injection when enabled
- Configurable filename in config.toml
- Tests added
- README updated
- Backward compatible

### Why
Helps Vibe follow project-specific coding rules, similar to Cursor/Claude/Windsurf-style `.md` convention files.

Ready for review.
