### PR TITLE
Allow to define env var for stdio MCP server

### DIFF
--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -223,6 +223,7 @@ class MCPStdio(_MCPBase):
     transport: Literal["stdio"]
     command: str | list[str]
     args: list[str] = Field(default_factory=list)
+    env: dict[str, str] | None = None
 
     def argv(self) -> list[str]:
         base = (

--- a/vibe/core/tools/manager.py
+++ b/vibe/core/tools/manager.py
@@ -207,7 +207,7 @@ class ToolManager:
             return 0
 
         try:
-            tools: list[RemoteTool] = await list_tools_stdio(cmd)
+            tools: list[RemoteTool] = await list_tools_stdio(cmd, srv.env)
         except Exception as exc:
             logger.warning("MCP stdio discovery failed for %r: %s", cmd, exc)
             return 0
@@ -216,7 +216,7 @@ class ToolManager:
         for remote in tools:
             try:
                 proxy_cls = create_mcp_stdio_proxy_tool_class(
-                    command=cmd, remote=remote, alias=srv.name, server_hint=srv.prompt
+                    command=cmd, remote=remote, alias=srv.name, server_hint=srv.prompt, env=srv.env
                 )
                 self._available[proxy_cls.get_name()] = proxy_cls
                 added += 1

--- a/vibe/core/tools/mcp.py
+++ b/vibe/core/tools/mcp.py
@@ -207,8 +207,10 @@ def create_mcp_http_proxy_tool_class(
     return MCPHttpProxyTool
 
 
-async def list_tools_stdio(command: list[str]) -> list[RemoteTool]:
-    params = StdioServerParameters(command=command[0], args=command[1:])
+async def list_tools_stdio(
+    command: list[str], env: dict[str, str] | None = None
+) -> list[RemoteTool]:
+    params = StdioServerParameters(command=command[0], args=command[1:], env=env)
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
@@ -217,9 +219,9 @@ async def list_tools_stdio(command: list[str]) -> list[RemoteTool]:
 
 
 async def call_tool_stdio(
-    command: list[str], tool_name: str, arguments: dict[str, Any]
+    command: list[str], tool_name: str, arguments: dict[str, Any], env: dict[str, str] | None = None
 ) -> MCPToolResult:
-    params = StdioServerParameters(command=command[0], args=command[1:])
+    params = StdioServerParameters(command=command[0], args=command[1:], env=env)
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
@@ -233,6 +235,7 @@ def create_mcp_stdio_proxy_tool_class(
     remote: RemoteTool,
     alias: str | None = None,
     server_hint: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> type[BaseTool[_OpenArgs, MCPToolResult, BaseToolConfig, BaseToolState]]:
     def _alias_from_command(cmd: list[str]) -> str:
         prog = Path(cmd[0]).name.replace(".", "_") if cmd else "mcp"
@@ -258,6 +261,7 @@ def create_mcp_stdio_proxy_tool_class(
         _stdio_command: ClassVar[list[str]] = command
         _remote_name: ClassVar[str] = remote.name
         _input_schema: ClassVar[dict[str, Any]] = remote.input_schema
+        _env: ClassVar[dict[str, str] | None] = env
 
         @classmethod
         def get_name(cls) -> str:
@@ -271,7 +275,7 @@ def create_mcp_stdio_proxy_tool_class(
             try:
                 payload = args.model_dump(exclude_none=True)
                 result = await call_tool_stdio(
-                    self._stdio_command, self._remote_name, payload
+                    self._stdio_command, self._remote_name, payload, env=self._env
                 )
                 return result
             except Exception as exc:


### PR DESCRIPTION
This PR adds support for defining environment variables needed by some MCP servers over stdio (i.e. IntelliJ MCP). 

Key Changes:
- Added "env" field into MCPStdio

Example of config:

```
[[mcp_servers]]
name = "intellij"
transport = "stdio"
env = { IJ_MCP_SERVER_PORT = "64342" }
command = "/home/user/.local/share/JetBrains/Toolbox/apps/intellij-idea-ultimate/jbr/bin/java"
args = [
    "-classpath",
    "<long classpath>",
    "com.intellij.mcpserver.stdio.McpStdioRunnerKt",
]
```


Related issue:
https://github.com/mistralai/mistral-vibe/issues/59

