### PR TITLE
Implement accept-edits mode.

### DIFF
--- a/tests/acp/test_set_mode.py
+++ b/tests/acp/test_set_mode.py
@@ -97,6 +97,76 @@ class TestACPSetMode:
         assert acp_session.agent.auto_approve is True
 
     @pytest.mark.asyncio
+    async def test_set_mode_to_ACCEPT_EDITS(self, acp_agent: VibeAcpAgent) -> None:
+        session_response = await acp_agent.newSession(
+            NewSessionRequest(cwd=str(Path.cwd()), mcpServers=[])
+        )
+        session_id = session_response.sessionId
+        acp_session = next(
+            (s for s in acp_agent.sessions.values() if s.id == session_id), None
+        )
+        assert acp_session is not None
+
+        response = await acp_agent.setSessionMode(
+            SetSessionModeRequest(
+                sessionId=session_id, modeId=VibeSessionMode.ACCEPT_EDITS
+            )
+        )
+
+        assert response is not None
+        assert acp_session.mode_id == VibeSessionMode.ACCEPT_EDITS
+        assert acp_session.agent._current_mode == VibeSessionMode.ACCEPT_EDITS
+        assert acp_session.agent.auto_approve is False
+        assert acp_session.agent.approval_callback is not None
+
+    @pytest.mark.asyncio
+    async def test_accept_edits_restricts_paths_to_workdir(
+        self, acp_agent: VibeAcpAgent
+    ) -> None:
+        """Test that ACCEPT_EDITS mode only auto-approves files within workdir."""
+        from pydantic import BaseModel
+
+        session_response = await acp_agent.newSession(
+            NewSessionRequest(cwd=str(Path.cwd()), mcpServers=[])
+        )
+        session_id = session_response.sessionId
+        acp_session = next(
+            (s for s in acp_agent.sessions.values() if s.id == session_id), None
+        )
+        assert acp_session is not None
+
+        agent = acp_session.agent
+
+        # Create mock args with path field
+        class MockArgs(BaseModel):
+            path: str
+
+        read_file_tool = agent.tool_manager.get("read_file")
+        search_replace_tool = agent.tool_manager.get("search_replace")
+
+        # Test 1: Relative path within workdir should return True
+        args_inside = MockArgs(path="test.txt")
+        assert agent._is_path_within_workdir(read_file_tool, args_inside) is True
+
+        # Test 2: Absolute path outside workdir should return False
+        args_outside = MockArgs(path="/etc/passwd")
+        assert agent._is_path_within_workdir(read_file_tool, args_outside) is False
+
+        # Test 3: Absolute path within workdir should return True
+        args_inside_abs = MockArgs(path=str(Path.cwd() / "test.txt"))
+        assert agent._is_path_within_workdir(read_file_tool, args_inside_abs) is True
+
+        # Test 4: search_replace with file_path field
+        class MockSearchReplaceArgs(BaseModel):
+            file_path: str
+
+        args_sr_inside = MockSearchReplaceArgs(file_path="test.txt")
+        assert agent._is_path_within_workdir(search_replace_tool, args_sr_inside) is True
+
+        args_sr_outside = MockSearchReplaceArgs(file_path="/tmp/test.txt")
+        assert agent._is_path_within_workdir(search_replace_tool, args_sr_outside) is False
+
+    @pytest.mark.asyncio
     async def test_set_mode_invalid_mode_returns_none(
         self, acp_agent: VibeAcpAgent
     ) -> None:

--- a/vibe/acp/utils.py
+++ b/vibe/acp/utils.py
@@ -10,6 +10,7 @@ from acp.schema import PermissionOption, SessionMode
 class VibeSessionMode(enum.StrEnum):
     APPROVAL_REQUIRED = enum.auto()
     AUTO_APPROVE = enum.auto()
+    ACCEPT_EDITS = enum.auto()
 
     def to_acp_session_mode(self) -> SessionMode:
         match self:
@@ -24,6 +25,12 @@ class VibeSessionMode(enum.StrEnum):
                     id=VibeSessionMode.AUTO_APPROVE,
                     name="Auto Approve",
                     description="Automatically approves all tool executions",
+                )
+            case self.ACCEPT_EDITS:
+                return SessionMode(
+                    id=VibeSessionMode.ACCEPT_EDITS,
+                    name="Accept Edits",
+                    description="Auto-approves file editing tools (grep, read_file, search_replace, todo, write_file), requires approval for others",
                 )
 
     @classmethod

--- a/vibe/cli/textual_ui/app.tcss
+++ b/vibe/cli/textual_ui/app.tcss
@@ -90,6 +90,18 @@ Screen {
     &.border-warning {
         border: round $warning;
     }
+
+    &.mode-approval {
+        border: round $primary;
+    }
+
+    &.mode-edits {
+        border: round $warning;
+    }
+
+    &.mode-auto {
+        border: round $error;
+    }
 }
 
 #input-body {
@@ -651,16 +663,19 @@ ModeIndicator {
     background: transparent;
     padding: 0;
     margin: 0 0 0 1;
-    color: $warning;
     align: left middle;
+}
 
-    &.mode-on {
-        color: $warning;
-    }
+.mode-approval {
+    color: $primary;
+}
 
-    &.mode-off {
-        color: $text-muted;
-    }
+.mode-edits {
+    color: $warning;
+}
+
+.mode-auto {
+    color: $error;
 }
 
 PathDisplay {

--- a/vibe/cli/textual_ui/widgets/chat_input/container.py
+++ b/vibe/cli/textual_ui/widgets/chat_input/container.py
@@ -7,6 +7,8 @@ from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.message import Message
 
+from vibe.acp.utils import VibeSessionMode
+
 from vibe.cli.autocompletion.path_completion import PathCompletionController
 from vibe.cli.autocompletion.slash_command import SlashCommandController
 from vibe.cli.commands import CommandRegistry
@@ -22,6 +24,9 @@ from vibe.core.autocompletion.completers import CommandCompleter, PathCompleter
 class ChatInputContainer(Vertical):
     ID_INPUT_BOX = "input-box"
     BORDER_WARNING_CLASS = "border-warning"
+    BORDER_APPROVAL_CLASS = "mode-approval"
+    BORDER_EDITS_CLASS = "mode-edits"
+    BORDER_AUTO_CLASS = "mode-auto"
 
     class Submitted(Message):
         def __init__(self, value: str) -> None:
@@ -155,3 +160,21 @@ class ChatInputContainer(Vertical):
             input_box.add_class(self.BORDER_WARNING_CLASS)
         else:
             input_box.remove_class(self.BORDER_WARNING_CLASS)
+
+    def set_mode(self, mode: VibeSessionMode) -> None:
+        """Set the border color based on the current mode."""
+        input_box = self.get_widget_by_id(self.ID_INPUT_BOX)
+        
+        # Remove all mode classes first
+        input_box.remove_class(self.BORDER_APPROVAL_CLASS)
+        input_box.remove_class(self.BORDER_EDITS_CLASS)
+        input_box.remove_class(self.BORDER_AUTO_CLASS)
+
+        # Add the appropriate class for the current mode
+        match mode:
+            case VibeSessionMode.APPROVAL_REQUIRED:
+                input_box.add_class(self.BORDER_APPROVAL_CLASS)
+            case VibeSessionMode.ACCEPT_EDITS:
+                input_box.add_class(self.BORDER_EDITS_CLASS)
+            case VibeSessionMode.AUTO_APPROVE:
+                input_box.add_class(self.BORDER_AUTO_CLASS)

--- a/vibe/cli/textual_ui/widgets/mode_indicator.py
+++ b/vibe/cli/textual_ui/widgets/mode_indicator.py
@@ -2,24 +2,44 @@ from __future__ import annotations
 
 from textual.widgets import Static
 
+from vibe.acp.utils import VibeSessionMode
+
 
 class ModeIndicator(Static):
-    def __init__(self, auto_approve: bool = False) -> None:
+    def __init__(self, mode: VibeSessionMode = VibeSessionMode.APPROVAL_REQUIRED) -> None:
         super().__init__()
         self.can_focus = False
-        self._auto_approve = auto_approve
+        self._mode = mode
         self._update_display()
 
     def _update_display(self) -> None:
-        if self._auto_approve:
-            self.update("⏵⏵ auto-approve on (shift+tab to toggle)")
-            self.add_class("mode-on")
-            self.remove_class("mode-off")
-        else:
-            self.update("⏵ auto-approve off (shift+tab to toggle)")
-            self.add_class("mode-off")
-            self.remove_class("mode-on")
+        # Clear all mode classes first
+        self.remove_class("mode-approval")
+        self.remove_class("mode-edits")
+        self.remove_class("mode-auto")
+
+        match self._mode:
+            case VibeSessionMode.APPROVAL_REQUIRED:
+                self.update("⏵ approval required (shift+tab to toggle)")
+                self.add_class("mode-approval")
+
+            case VibeSessionMode.ACCEPT_EDITS:
+                self.update("⏵⏵ accept-edits (shift+tab to toggle)")
+                self.add_class("mode-edits")
+
+            case VibeSessionMode.AUTO_APPROVE:
+                self.update("⏵⏵⏵ auto-approve ALL (shift+tab to toggle)")
+                self.add_class("mode-auto")
+
+    def set_mode(self, mode: VibeSessionMode) -> None:
+        """Set the current mode and update display."""
+        self._mode = mode
+        self._update_display()
 
     def set_auto_approve(self, enabled: bool) -> None:
-        self._auto_approve = enabled
+        """Backward compatibility: convert boolean to mode."""
+        self._mode = (
+            VibeSessionMode.AUTO_APPROVE if enabled
+            else VibeSessionMode.APPROVAL_REQUIRED
+        )
         self._update_display()

--- a/vibe/core/tools/base.py
+++ b/vibe/core/tools/base.py
@@ -281,3 +281,15 @@ class BaseTool[
         Base implementation returns None. Override in subclasses for specific logic.
         """
         return None
+
+    def is_path_within_workdir(self, args: ToolArgs) -> bool:
+        """Check if the file path(s) in args are within the project directory.
+
+        Returns:
+            True if path is within workdir or tool has no path restrictions
+            False if path is outside workdir
+
+        Base implementation returns True (no restriction).
+        Override in file operation tools to enforce workdir boundaries.
+        """
+        return True

--- a/vibe/core/tools/builtins/grep.py
+++ b/vibe/core/tools/builtins/grep.py
@@ -324,3 +324,19 @@ class Grep(
     def get_status_text(cls) -> str:
         """Return status message for spinner."""
         return "Searching files"
+
+    def is_path_within_workdir(self, args: GrepArgs) -> bool:
+        """Check if the search path is within the project directory."""
+        from pathlib import Path
+
+        path = Path(args.path).expanduser()
+        if not path.is_absolute():
+            path = self.config.effective_workdir / path
+        path = path.resolve()
+
+        workdir = self.config.effective_workdir.resolve()
+        try:
+            path.relative_to(workdir)
+            return True
+        except ValueError:
+            return False

--- a/vibe/core/tools/builtins/read_file.py
+++ b/vibe/core/tools/builtins/read_file.py
@@ -102,6 +102,20 @@ class ReadFile(
 
         return None
 
+    def is_path_within_workdir(self, args: ReadFileArgs) -> bool:
+        """Check if the file path is within the project directory."""
+        file_path = Path(args.path).expanduser()
+        if not file_path.is_absolute():
+            file_path = self.config.effective_workdir / file_path
+        file_path = file_path.resolve()
+
+        workdir = self.config.effective_workdir.resolve()
+        try:
+            file_path.relative_to(workdir)
+            return True
+        except ValueError:
+            return False
+
     def _prepare_and_validate_path(self, args: ReadFileArgs) -> Path:
         self._validate_inputs(args)
 

--- a/vibe/core/tools/builtins/search_replace.py
+++ b/vibe/core/tools/builtins/search_replace.py
@@ -114,6 +114,22 @@ class SearchReplace(
     def get_status_text(cls) -> str:
         return "Editing files"
 
+    def is_path_within_workdir(self, args: SearchReplaceArgs) -> bool:
+        """Check if the file path is within the project directory."""
+        from pathlib import Path
+
+        file_path = Path(args.file_path).expanduser()
+        if not file_path.is_absolute():
+            file_path = self.config.effective_workdir / file_path
+        file_path = file_path.resolve()
+
+        workdir = self.config.effective_workdir.resolve()
+        try:
+            file_path.relative_to(workdir)
+            return True
+        except ValueError:
+            return False
+
     @final
     async def run(self, args: SearchReplaceArgs) -> SearchReplaceResult:
         file_path, search_replace_blocks = self._prepare_and_validate_args(args)


### PR DESCRIPTION
Adds `ACCEPT_EDITS` mode - a safer middle ground between manual approval and full auto-approve. File editing tools (grep, read_file, search_replace, todo, write_file) are auto-approved while other tools require manual approval. Files outside the project directory still require approval for safety.

## Changes
- New `VibeSessionMode.ACCEPT_EDITS` enum value
- Mode cycling (Shift+Tab) now includes all three modes with distinct visual indicators
- File tools validate paths are within project directory before auto-approval
- Backward compatible - maintains existing `auto_approve` boolean

## Key Features
- Auto-approves file editing tools only
- Requires approval for tools outside project directory
- Distinct UI indicators for each mode
- Comprehensive path validation and security checks

**NB**: This needs more testing. I opened a PR early to get feedback sooner rather than later.