### PR TITLE
Add API key management to config settings

### DIFF
--- a/vibe/cli/textual_ui/widgets/config_app.py
+++ b/vibe/cli/textual_ui/widgets/config_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, ClassVar, TypedDict
 
 from textual import events
@@ -8,7 +9,7 @@ from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical
 from textual.message import Message
 from textual.theme import BUILTIN_THEMES
-from textual.widgets import Static
+from textual.widgets import Input, Static
 
 if TYPE_CHECKING:
     from vibe.core.config import VibeConfig
@@ -22,6 +23,15 @@ class SettingDefinition(TypedDict):
     type: str
     options: list[str]
     value: str
+
+
+def _mask_api_key(api_key: str | None) -> str:
+    """Mask API key showing only first 3 and last 4 characters."""
+    if not api_key:
+        return "Not set"
+    if len(api_key) <= 7:
+        return "•" * len(api_key)
+    return f"{api_key[:3]}...{api_key[-4:]}"
 
 
 class ConfigApp(Container):
@@ -51,6 +61,17 @@ class ConfigApp(Container):
         self.config = config
         self.selected_index = 0
         self.changes: dict[str, str] = {}
+        self._editing_api_key = False
+        self._api_key_input: Input | None = None
+
+        # Get current API key value
+        try:
+            active_model = self.config.get_active_model()
+            provider = self.config.get_provider_for_model(active_model)
+            api_key_env_var = provider.api_key_env_var
+            current_api_key = os.getenv(api_key_env_var) if api_key_env_var else None
+        except (ValueError, AttributeError):
+            current_api_key = None
 
         self.settings: list[SettingDefinition] = [
             {
@@ -66,6 +87,13 @@ class ConfigApp(Container):
                 "type": "cycle",
                 "options": THEMES,
                 "value": self.config.textual_theme,
+            },
+            {
+                "key": "api_key",
+                "label": "API Key",
+                "type": "api_key",
+                "options": [],
+                "value": current_api_key or "",
             },
         ]
 
@@ -85,6 +113,15 @@ class ConfigApp(Container):
                 self.setting_widgets.append(widget)
                 yield widget
 
+            # Hidden input for API key editing
+            self._api_key_input = Input(
+                password=True,
+                placeholder="Enter API key",
+                id="api-key-input",
+                classes="settings-api-key-input",
+            )
+            yield self._api_key_input
+
             yield Static("")
 
             self.help_widget = Static(
@@ -94,6 +131,8 @@ class ConfigApp(Container):
 
     def on_mount(self) -> None:
         self._update_display()
+        if self._api_key_input:
+            self._api_key_input.display = False
         self.focus()
 
     def _update_display(self) -> None:
@@ -101,12 +140,19 @@ class ConfigApp(Container):
             zip(self.settings, self.setting_widgets, strict=True)
         ):
             is_selected = i == self.selected_index
+            is_editing = is_selected and setting["type"] == "api_key" and self._editing_api_key
             cursor = "› " if is_selected else "  "
 
             label: str = setting["label"]
             value: str = self.changes.get(setting["key"], setting["value"])
 
-            text = f"{cursor}{label}: {value}"
+            # Mask API key for display
+            if setting["type"] == "api_key":
+                display_value = _mask_api_key(value) if not is_editing else "[editing...]"
+            else:
+                display_value = value
+
+            text = f"{cursor}{label}: {display_value}"
 
             widget.update(text)
 
@@ -119,26 +165,66 @@ class ConfigApp(Container):
             else:
                 widget.add_class("settings-value-cycle-unselected")
 
+        # Show/hide API key input
+        if self._api_key_input:
+            if self._editing_api_key:
+                self._api_key_input.display = True
+                self._api_key_input.focus()
+            else:
+                self._api_key_input.display = False
+
+        # Update help text
+        if self.help_widget:
+            if (
+                self.settings
+                and self.settings[self.selected_index]["type"] == "api_key"
+                and not self._editing_api_key
+            ):
+                help_text = "↑↓ navigate  Enter to edit  ESC exit"
+            elif self._editing_api_key:
+                help_text = "Type API key  Enter to save  ESC to cancel"
+            else:
+                help_text = "↑↓ navigate  Space/Enter toggle  ESC exit"
+            self.help_widget.update(help_text)
+
     def action_move_up(self) -> None:
+        if self._editing_api_key:
+            self._editing_api_key = False
         self.selected_index = (self.selected_index - 1) % len(self.settings)
         self._update_display()
 
     def action_move_down(self) -> None:
+        if self._editing_api_key:
+            self._editing_api_key = False
         self.selected_index = (self.selected_index + 1) % len(self.settings)
         self._update_display()
 
     def action_toggle_setting(self) -> None:
         setting = self.settings[self.selected_index]
         key: str = setting["key"]
+
+        # Handle API key editing
+        if setting["type"] == "api_key":
+            if not self._editing_api_key:
+                # Start editing
+                self._editing_api_key = True
+                if self._api_key_input:
+                    current_value = self.changes.get(key, setting["value"])
+                    self._api_key_input.value = current_value
+                self._update_display()
+            return
+
+        # Handle cycle type settings
         current: str = self.changes.get(key, setting["value"])
 
         options: list[str] = setting["options"]
+        new_value: str
         try:
             current_idx = options.index(current)
             next_idx = (current_idx + 1) % len(options)
-            new_value: str = options[next_idx]
+            new_value = options[next_idx]
         except (ValueError, IndexError):
-            new_value: str = options[0] if options else current
+            new_value = options[0] if options else current
 
         self.changes[key] = new_value
 
@@ -149,8 +235,32 @@ class ConfigApp(Container):
     def action_cycle(self) -> None:
         self.action_toggle_setting()
 
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Handle API key input submission."""
+        if event.input == self._api_key_input and self._editing_api_key:
+            setting = self.settings[self.selected_index]
+            key: str = setting["key"]
+            new_value: str = event.value.strip()
+
+            if new_value:
+                self.changes[key] = new_value
+                self.post_message(self.SettingChanged(key=key, value=new_value))
+
+            self._editing_api_key = False
+            self._update_display()
+            self.focus()
+
     def action_close(self) -> None:
+        # Cancel API key editing if active
+        if self._editing_api_key:
+            self._editing_api_key = False
+            self._update_display()
+            return
+
         self.post_message(self.ConfigClosed(changes=self.changes.copy()))
 
     def on_blur(self, event: events.Blur) -> None:
+        # Don't refocus if we're editing API key
+        if self._editing_api_key and event.widget == self._api_key_input:
+            return
         self.call_after_refresh(self.focus)

--- a/vibe/cli/textual_ui/widgets/config_app.py
+++ b/vibe/cli/textual_ui/widgets/config_app.py
@@ -261,6 +261,6 @@ class ConfigApp(Container):
 
     def on_blur(self, event: events.Blur) -> None:
         # Don't refocus if we're editing API key
-        if self._editing_api_key and event.widget == self._api_key_input:
+        if self._editing_api_key:
             return
         self.call_after_refresh(self.focus)


### PR DESCRIPTION
This PR adds API key management to the config settings UI, allowing users to view and change their API key without manually editing the .env file.

## Changes

- Add API key setting to config menu with masked display (shows first 3 and last 4 characters)
- Allow editing API key via password-masked input field
- Save API key changes to ~/.vibe/.env file
- Reload environment variables after saving
- Update help text dynamically based on context (editing vs navigating)

## Benefits

- Users can now easily change their API key through the config UI
- API key is displayed in a secure, masked format
- No need to manually edit .env file

## Screenshots
<img width="866" height="492" alt="image" src="https://github.com/user-attachments/assets/73e6e540-c3cb-4f5f-8364-2cc00e3ddf34" />
<img width="498" height="561" alt="image" src="https://github.com/user-attachments/assets/9907b39a-4cbc-4953-8340-8c3c32b7c8c4" />
