### PR TITLE
Specify bash timeout argument as seconds

### DIFF
--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -153,7 +153,7 @@ class BashToolConfig(BaseToolConfig):
 class BashArgs(BaseModel):
     command: str
     timeout: int | None = Field(
-        default=None, description="Override the default command timeout."
+        default=None, description="Override the default command timeout in seconds."
     )
 
 


### PR DESCRIPTION
Specify seconds so the model doesn't think `timeout` argument mean milliseconds, minutes, hours, or another unit. Address #138 