### PR TITLE
Add LMStudio as default provider

### DIFF
--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -250,6 +250,12 @@ DEFAULT_PROVIDERS = [
         api_base="http://127.0.0.1:8080/v1",
         api_key_env_var="",  # NOTE: if you wish to use --api-key in llama-server, change this value
     ),
+    ProviderConfig(
+        name="lmstudio",
+        api_base="http://localhost:1234/v1",
+        api_key_env_var="",
+        backend=Backend.GENERIC,
+    ),
 ]
 
 DEFAULT_MODELS = [
@@ -271,6 +277,14 @@ DEFAULT_MODELS = [
         name="devstral",
         provider="llamacpp",
         alias="local",
+        input_price=0.0,
+        output_price=0.0,
+    ),
+    ModelConfig(
+        name="mistralai/devstral-small-2-2512",
+        provider="lmstudio",
+        alias="devstral-2-small-local",
+        temperature=0.7,
         input_price=0.0,
         output_price=0.0,
     ),


### PR DESCRIPTION
This PR adds LMStudio as a default provider option, making it easier for users to use local models via LMStudio.

## Changes

- Add LMStudio provider with default localhost:1234 endpoint
- Add devstral-2-small-local model alias for mistralai/devstral-small-2-2512
- Configured for OpenAI-compatible API (no API key required)
- Model configured with temperature 0.7 and zero pricing (local execution)

## Benefits

- Users can now use LMStudio without manual config.toml editing
- Provides a ready-to-use local model option
- Follows the same pattern as existing llamacpp provider