### PR TITLE
Feat: Add Ollama provider support for local LLM inference

### DIFF
--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -297,6 +297,31 @@ DEFAULT_MODELS = [
         output_price=0.0,
     ),
     # Ollama models - run `ollama pull <model>` to download
+    # Vision & Architecture - thinking + vision combo
+    ModelConfig(
+        name="qwen3-next:80b-cloud",
+        provider="ollama",
+        alias="ollama-qwen3-vision",
+        input_price=0.0,
+        output_price=0.0,
+    ),
+    # Code, Reasoning, Security, Performance - DeepSeek with thinking mode
+    ModelConfig(
+        name="deepseek-v3.2:cloud",
+        provider="ollama",
+        alias="ollama-deepseek",
+        input_price=0.0,
+        output_price=0.0,
+    ),
+    # General purpose - 675B powerhouse
+    ModelConfig(
+        name="mistral-large-3:675b-cloud",
+        provider="ollama",
+        alias="ollama-mistral-large",
+        input_price=0.0,
+        output_price=0.0,
+    ),
+    # Common local models
     ModelConfig(
         name="codestral:latest",
         provider="ollama",
@@ -308,34 +333,6 @@ DEFAULT_MODELS = [
         name="qwen2.5-coder:latest",
         provider="ollama",
         alias="ollama-qwen-coder",
-        input_price=0.0,
-        output_price=0.0,
-    ),
-    ModelConfig(
-        name="qwen2.5-coder:32b",
-        provider="ollama",
-        alias="ollama-qwen-coder-32b",
-        input_price=0.0,
-        output_price=0.0,
-    ),
-    ModelConfig(
-        name="deepseek-coder-v2:latest",
-        provider="ollama",
-        alias="ollama-deepseek-coder",
-        input_price=0.0,
-        output_price=0.0,
-    ),
-    ModelConfig(
-        name="llama3.1:latest",
-        provider="ollama",
-        alias="ollama-llama3",
-        input_price=0.0,
-        output_price=0.0,
-    ),
-    ModelConfig(
-        name="mistral:latest",
-        provider="ollama",
-        alias="ollama-mistral",
         input_price=0.0,
         output_price=0.0,
     ),

--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -267,6 +267,11 @@ DEFAULT_PROVIDERS = [
         api_base="http://127.0.0.1:8080/v1",
         api_key_env_var="",  # NOTE: if you wish to use --api-key in llama-server, change this value
     ),
+    ProviderConfig(
+        name="ollama",
+        api_base="http://localhost:11434/v1",
+        api_key_env_var="",  # Ollama doesn't require authentication by default
+    ),
 ]
 
 DEFAULT_MODELS = [
@@ -288,6 +293,49 @@ DEFAULT_MODELS = [
         name="devstral",
         provider="llamacpp",
         alias="local",
+        input_price=0.0,
+        output_price=0.0,
+    ),
+    # Ollama models - run `ollama pull <model>` to download
+    ModelConfig(
+        name="codestral:latest",
+        provider="ollama",
+        alias="ollama-codestral",
+        input_price=0.0,
+        output_price=0.0,
+    ),
+    ModelConfig(
+        name="qwen2.5-coder:latest",
+        provider="ollama",
+        alias="ollama-qwen-coder",
+        input_price=0.0,
+        output_price=0.0,
+    ),
+    ModelConfig(
+        name="qwen2.5-coder:32b",
+        provider="ollama",
+        alias="ollama-qwen-coder-32b",
+        input_price=0.0,
+        output_price=0.0,
+    ),
+    ModelConfig(
+        name="deepseek-coder-v2:latest",
+        provider="ollama",
+        alias="ollama-deepseek-coder",
+        input_price=0.0,
+        output_price=0.0,
+    ),
+    ModelConfig(
+        name="llama3.1:latest",
+        provider="ollama",
+        alias="ollama-llama3",
+        input_price=0.0,
+        output_price=0.0,
+    ),
+    ModelConfig(
+        name="mistral:latest",
+        provider="ollama",
+        alias="ollama-mistral",
         input_price=0.0,
         output_price=0.0,
     ),

--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -321,21 +321,6 @@ DEFAULT_MODELS = [
         input_price=0.0,
         output_price=0.0,
     ),
-    # Common local models
-    ModelConfig(
-        name="codestral:latest",
-        provider="ollama",
-        alias="ollama-codestral",
-        input_price=0.0,
-        output_price=0.0,
-    ),
-    ModelConfig(
-        name="qwen2.5-coder:latest",
-        provider="ollama",
-        alias="ollama-qwen-coder",
-        input_price=0.0,
-        output_price=0.0,
-    ),
 ]
 
 


### PR DESCRIPTION
This PR introduces support for local LLM inference using [Ollama](https://ollama.com/), allowing users to run models locally without incurring API costs. It registers ollama as a new provider and configures a specific lineup of high-performance models optimized for local execution.

Key Changes
New Provider: Added ollama to ProviderConfig pointing to the default local endpoint http://localhost:11434/v1.

New Models: Added configurations for the following models with input_price and output_price set to 0.0:

Vision/Architecture: qwen3-next:80b-cloud (Alias: ollama-qwen3-vision)

Reasoning/Code: deepseek-v3.2:cloud (Alias: ollama-deepseek)

General Purpose: mistral-large-3:675b-cloud (Alias: ollama-mistral-large)

Setup & Usage
To use these new models, the user must have Ollama running locally.

Install Ollama: Follow instructions at [ollama.com](https://ollama.com/).

Pull Models: Run the following commands to download the models referenced in this config:

Bash

ollama pull qwen3-next:80b-cloud
ollama pull deepseek-v3.2:cloud
ollama pull mistral-large-3:675b-cloud
Run: Use the new aliases when running the application (e.g., --model ollama-deepseek).

Motivation
Cost Efficiency: Enables free inference for development and testing.

Privacy: Keeps data local for sensitive operations.

Offline Capability: Allows the tool to function without an internet connection once models are downloaded.