### PR TITLE
feat: interactive session selector for --resume

### DIFF
--- a/tests/session_selector/test_session_selector.py
+++ b/tests/session_selector/test_session_selector.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from pathlib import Path
+
+import pytest
+
+from vibe.cli.session_selector import SessionSelectorApp
+from vibe.cli.session_selector.screen import SessionSelectorScreen
+from vibe.core.config import SessionLoggingConfig
+
+
+def create_session_file(
+    save_dir: Path,
+    session_id: str,
+    start_time: datetime,
+    working_directory: str,
+    message_count: int,
+    git_branch: str | None = None,
+) -> Path:
+    """Helper to create a test session file."""
+    timestamp = start_time.strftime("%Y%m%d_%H%M%S")
+    filename = f"session_{timestamp}_{session_id[:8]}.json"
+    filepath = save_dir / filename
+
+    data = {
+        "metadata": {
+            "session_id": session_id,
+            "start_time": start_time.isoformat(),
+            "end_time": start_time.isoformat(),
+            "git_branch": git_branch,
+            "environment": {"working_directory": working_directory},
+            "total_messages": message_count,
+        },
+        "messages": [],
+    }
+
+    filepath.write_text(json.dumps(data), encoding="utf-8")
+    return filepath
+
+
+@pytest.mark.asyncio
+async def test_session_selector_exits_with_none_when_no_sessions(
+    config_dir: Path,
+) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    app = SessionSelectorApp(config)
+
+    async with app.run_test() as pilot:
+        # App should exit immediately with None when no sessions
+        await pilot.pause(0.1)
+
+    assert app.return_value is None
+
+
+@pytest.mark.asyncio
+async def test_session_selector_shows_sessions(config_dir: Path) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create test sessions
+    create_session_file(
+        session_dir,
+        "abc12345-uuid",
+        datetime(2024, 12, 17, 14, 30, 0),
+        "/home/user/project",
+        10,
+        "main",
+    )
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    app = SessionSelectorApp(config)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.1)
+
+        # Check the screen is correct
+        assert isinstance(app.screen, SessionSelectorScreen)
+
+        # Check sessions were loaded
+        screen = app.screen
+        assert len(screen._sessions) == 1
+        assert screen._sessions[0].session_id == "abc12345"
+
+
+@pytest.mark.asyncio
+async def test_session_selector_navigation(config_dir: Path) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create multiple sessions
+    for i in range(3):
+        create_session_file(
+            session_dir,
+            f"session{i:02d}-uuid",
+            datetime(2024, 12, 17, 10 + i, 0, 0),
+            f"/path/{i}",
+            i * 10,
+        )
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    app = SessionSelectorApp(config)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.1)
+        screen = app.screen
+        assert isinstance(screen, SessionSelectorScreen)
+
+        # Initial selection is 0
+        assert screen._selected_index == 0
+
+        # Navigate down
+        await pilot.press("down")
+        assert screen._selected_index == 1
+
+        await pilot.press("down")
+        assert screen._selected_index == 2
+
+        # Wrap around
+        await pilot.press("down")
+        assert screen._selected_index == 0
+
+        # Navigate up (wrap)
+        await pilot.press("up")
+        assert screen._selected_index == 2
+
+
+@pytest.mark.asyncio
+async def test_session_selector_select_with_enter(config_dir: Path) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    filepath = create_session_file(
+        session_dir,
+        "selected1-uuid",
+        datetime(2024, 12, 17, 14, 0, 0),
+        "/home/user/project",
+        5,
+    )
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    app = SessionSelectorApp(config)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.1)
+        await pilot.press("enter")
+        await pilot.pause(0.1)
+
+    assert app.return_value == filepath
+
+
+@pytest.mark.asyncio
+async def test_session_selector_cancel_with_escape(config_dir: Path) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    create_session_file(
+        session_dir,
+        "session01-uuid",
+        datetime(2024, 12, 17, 14, 0, 0),
+        "/home/user/project",
+        5,
+    )
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    app = SessionSelectorApp(config)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.1)
+        await pilot.press("escape")
+        await pilot.pause(0.1)
+
+    assert app.return_value is None
+
+
+@pytest.mark.asyncio
+async def test_session_selector_select_second_session(config_dir: Path) -> None:
+    import os
+    import time
+
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create two sessions with controlled mtime order
+    # First file is older (will be second in list, sorted by most recent first)
+    first_file = create_session_file(
+        session_dir, "first000-uuid", datetime(2024, 12, 17, 14, 0, 0), "/path/first", 5
+    )
+    # Second file is newer (will be first in list)
+    create_session_file(
+        session_dir,
+        "second00-uuid",
+        datetime(2024, 12, 17, 15, 0, 0),
+        "/path/second",
+        10,
+    )
+
+    # Set mtime so first_file is older
+    os.utime(first_file, (time.time() - 1000, time.time() - 1000))
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    app = SessionSelectorApp(config)
+
+    async with app.run_test() as pilot:
+        await pilot.pause(0.1)
+        # Navigate to second session (first_file, the older one)
+        await pilot.press("down")
+        await pilot.press("enter")
+        await pilot.pause(0.1)
+
+    # After pressing down, we select the second item (first_file, the older one)
+    assert app.return_value == first_file

--- a/tests/test_session_list.py
+++ b/tests/test_session_list.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from pathlib import Path
+
+from vibe.core.config import SessionLoggingConfig
+from vibe.core.interaction_logger import InteractionLogger, SessionListEntry
+
+
+def create_session_file(
+    save_dir: Path,
+    session_id: str,
+    start_time: datetime,
+    working_directory: str,
+    message_count: int,
+    git_branch: str | None = None,
+) -> Path:
+    """Helper to create a test session file."""
+    timestamp = start_time.strftime("%Y%m%d_%H%M%S")
+    filename = f"session_{timestamp}_{session_id[:8]}.json"
+    filepath = save_dir / filename
+
+    data = {
+        "metadata": {
+            "session_id": session_id,
+            "start_time": start_time.isoformat(),
+            "end_time": start_time.isoformat(),
+            "git_branch": git_branch,
+            "environment": {"working_directory": working_directory},
+            "total_messages": message_count,
+        },
+        "messages": [],
+    }
+
+    filepath.write_text(json.dumps(data), encoding="utf-8")
+    return filepath
+
+
+def test_list_sessions_returns_empty_when_no_sessions(config_dir: Path) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    result = InteractionLogger.list_sessions(config)
+
+    assert result == []
+
+
+def test_list_sessions_returns_empty_when_dir_not_exists(config_dir: Path) -> None:
+    config = SessionLoggingConfig(save_dir=str(config_dir / "nonexistent"))
+    result = InteractionLogger.list_sessions(config)
+
+    assert result == []
+
+
+def test_list_sessions_returns_sessions_sorted_by_time(config_dir: Path) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create sessions with different times
+    older_time = datetime(2024, 12, 15, 10, 0, 0)
+    newer_time = datetime(2024, 12, 17, 14, 30, 0)
+
+    older_file = create_session_file(
+        session_dir, "older123-uuid-here", older_time, "/home/user/project1", 10, "main"
+    )
+    newer_file = create_session_file(
+        session_dir,
+        "newer456-uuid-here",
+        newer_time,
+        "/home/user/project2",
+        25,
+        "feature",
+    )
+
+    # Set file modification times to match creation order
+    import os
+    import time
+
+    os.utime(older_file, (time.time() - 1000, time.time() - 1000))
+    os.utime(newer_file, (time.time(), time.time()))
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    result = InteractionLogger.list_sessions(config)
+
+    assert len(result) == 2
+    # Most recent first
+    assert result[0].session_id == "newer456"
+    assert result[1].session_id == "older123"
+
+
+def test_list_sessions_returns_correct_metadata(config_dir: Path) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    test_time = datetime(2024, 12, 17, 14, 30, 0)
+    create_session_file(
+        session_dir,
+        "abc12345-full-uuid",
+        test_time,
+        "/home/user/myproject",
+        42,
+        "develop",
+    )
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    result = InteractionLogger.list_sessions(config)
+
+    assert len(result) == 1
+    entry = result[0]
+    assert isinstance(entry, SessionListEntry)
+    assert entry.session_id == "abc12345"
+    assert entry.start_time == test_time
+    assert entry.working_directory == "/home/user/myproject"
+    assert entry.message_count == 42
+    assert entry.git_branch == "develop"
+
+
+def test_list_sessions_respects_limit(config_dir: Path) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create 5 sessions
+    for i in range(5):
+        test_time = datetime(2024, 12, 17, 10 + i, 0, 0)
+        create_session_file(
+            session_dir, f"session{i:02d}-uuid", test_time, f"/path/{i}", i * 10
+        )
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    result = InteractionLogger.list_sessions(config, limit=3)
+
+    assert len(result) == 3
+
+
+def test_list_sessions_skips_corrupted_files(config_dir: Path) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create a valid session
+    test_time = datetime(2024, 12, 17, 14, 0, 0)
+    create_session_file(
+        session_dir, "valid123-uuid", test_time, "/home/user/project", 5
+    )
+
+    # Create a corrupted session file
+    corrupted = session_dir / "session_20241217_120000_corrupt1.json"
+    corrupted.write_text("not valid json {{{", encoding="utf-8")
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    result = InteractionLogger.list_sessions(config)
+
+    # Should only return the valid session
+    assert len(result) == 1
+    assert result[0].session_id == "valid123"
+
+
+def test_list_sessions_handles_missing_optional_fields(config_dir: Path) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create a session with minimal metadata
+    filepath = session_dir / "session_20241217_140000_minimal1.json"
+    data = {
+        "metadata": {
+            "session_id": "minimal1-uuid",
+            "start_time": "2024-12-17T14:00:00",
+            "total_messages": 3,
+            # No git_branch, no environment
+        },
+        "messages": [],
+    }
+    filepath.write_text(json.dumps(data), encoding="utf-8")
+
+    config = SessionLoggingConfig(save_dir=str(session_dir))
+    result = InteractionLogger.list_sessions(config)
+
+    assert len(result) == 1
+    assert result[0].session_id == "minimal1"
+    assert result[0].git_branch is None
+    assert result[0].working_directory is None
+
+
+def test_list_sessions_uses_custom_prefix(config_dir: Path) -> None:
+    session_dir = config_dir / "logs" / "session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create session with default prefix
+    test_time = datetime(2024, 12, 17, 14, 0, 0)
+    create_session_file(session_dir, "default1-uuid", test_time, "/path", 5)
+
+    # Create session with custom prefix
+    custom_file = session_dir / "custom_20241217_150000_custom12.json"
+    custom_data = {
+        "metadata": {
+            "session_id": "custom12-uuid",
+            "start_time": "2024-12-17T15:00:00",
+            "total_messages": 10,
+        },
+        "messages": [],
+    }
+    custom_file.write_text(json.dumps(custom_data), encoding="utf-8")
+
+    # Search with custom prefix should only find custom files
+    config = SessionLoggingConfig(save_dir=str(session_dir), session_prefix="custom")
+    result = InteractionLogger.list_sessions(config)
+
+    assert len(result) == 1
+    assert result[0].session_id == "custom12"

--- a/vibe/cli/entrypoint.py
+++ b/vibe/cli/entrypoint.py
@@ -5,6 +5,7 @@ import sys
 
 from rich import print as rprint
 
+from vibe.cli.session_selector import select_session
 from vibe.cli.textual_ui.app import run_textual_ui
 from vibe.core.config import (
     MissingAPIKeyError,
@@ -93,8 +94,12 @@ def parse_arguments() -> argparse.Namespace:
     )
     continuation_group.add_argument(
         "--resume",
+        nargs="?",
+        const=True,
+        default=None,
         metavar="SESSION_ID",
-        help="Resume a specific session by its ID (supports partial matching)",
+        help="Resume a session. Without ID: show list to select from. "
+        "With ID: resume that specific session (supports partial matching)",
     )
     return parser.parse_args()
 
@@ -183,7 +188,13 @@ def main() -> None:  # noqa: PLR0912, PLR0915
                         f"{config.session_logging.save_dir}[/]"
                     )
                     sys.exit(1)
+            elif args.resume is True:
+                # --resume without argument: show interactive selection
+                session_to_load = select_session(config.session_logging)
+                if not session_to_load:
+                    sys.exit(0)
             else:
+                # --resume SESSION_ID: find by ID
                 session_to_load = InteractionLogger.find_session_by_id(
                     args.resume, config.session_logging
                 )

--- a/vibe/cli/session_selector/__init__.py
+++ b/vibe/cli/session_selector/__init__.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from textual.app import App
+
+from vibe.cli.session_selector.screen import SessionSelectorScreen
+
+if TYPE_CHECKING:
+    from vibe.core.config import SessionLoggingConfig
+
+
+class SessionSelectorApp(App[Path | None]):
+    """Standalone app for selecting a session to resume."""
+
+    CSS_PATH = "session_selector.tcss"
+
+    def __init__(self, config: SessionLoggingConfig, limit: int = 20) -> None:
+        super().__init__()
+        self._config = config
+        self._limit = limit
+
+    def on_mount(self) -> None:
+        screen = SessionSelectorScreen(self._config, self._limit)
+        self.install_screen(screen, "selector")
+        self.push_screen("selector")
+
+
+def select_session(config: SessionLoggingConfig, limit: int = 20) -> Path | None:
+    """Run the session selector and return the selected session path."""
+    app = SessionSelectorApp(config, limit)
+    return app.run()

--- a/vibe/cli/session_selector/screen.py
+++ b/vibe/cli/session_selector/screen.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+from textual import events
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Container, VerticalScroll
+from textual.screen import Screen
+from textual.widgets import Static
+
+from vibe.core.interaction_logger import InteractionLogger, SessionListEntry
+
+if TYPE_CHECKING:
+    from vibe.core.config import SessionLoggingConfig
+
+
+class SessionSelectorScreen(Screen[Path | None]):
+    """Screen for selecting a session to resume."""
+
+    can_focus = True
+    can_focus_children = False
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("up", "move_up", "Up", show=False),
+        Binding("down", "move_down", "Down", show=False),
+        Binding("enter", "select", "Select", show=False),
+        Binding("escape", "cancel", "Cancel", show=False),
+        Binding("ctrl+c", "cancel", "Cancel", show=False),
+    ]
+
+    def __init__(self, config: SessionLoggingConfig, limit: int = 20) -> None:
+        super().__init__()
+        self._config = config
+        self._limit = limit
+        self._sessions: list[SessionListEntry] = []
+        self._selected_index = 0
+        self._session_widgets: list[Static] = []
+
+    def compose(self) -> ComposeResult:
+        with Container(id="selector-outer"):
+            yield Static("Select a session to resume", id="selector-title")
+            with VerticalScroll(id="session-list"):
+                pass
+            yield Static(
+                "↑↓ navigate  Enter select  ESC cancel", id="selector-help"
+            )
+
+    def on_mount(self) -> None:
+        self._sessions = InteractionLogger.list_sessions(self._config, self._limit)
+        if not self._sessions:
+            self.app.exit(None)
+            return
+        self._build_session_widgets()
+        self._update_display()
+        self.focus()
+
+    def _build_session_widgets(self) -> None:
+        session_list = self.query_one("#session-list", VerticalScroll)
+        for _ in self._sessions:
+            widget = Static("", classes="session-item")
+            self._session_widgets.append(widget)
+            session_list.mount(widget)
+
+    def _shorten_path(self, path: str | None, max_length: int = 35) -> str:
+        if not path:
+            return "-"
+        try:
+            p = Path(path)
+            home = Path.home()
+            if p.is_relative_to(home):
+                path = "~/" + str(p.relative_to(home))
+        except (ValueError, RuntimeError):
+            pass
+
+        if len(path) > max_length:
+            return "..." + path[-(max_length - 3) :]
+        return path
+
+    def _format_session(self, session: SessionListEntry, selected: bool) -> str:
+        cursor = "> " if selected else "  "
+        date_str = session.start_time.strftime("%Y-%m-%d %H:%M")
+        workdir = self._shorten_path(session.working_directory)
+        branch = f" [{session.git_branch}]" if session.git_branch else ""
+        msgs = f"({session.message_count} msgs)"
+        return f"{cursor}{session.session_id}  {date_str}  {workdir}{branch}  {msgs}"
+
+    def _update_display(self) -> None:
+        for i, (session, widget) in enumerate(
+            zip(self._sessions, self._session_widgets, strict=True)
+        ):
+            is_selected = i == self._selected_index
+            text = self._format_session(session, is_selected)
+            widget.update(text)
+
+            widget.remove_class("selected", "unselected")
+            widget.add_class("selected" if is_selected else "unselected")
+
+        if self._session_widgets:
+            self._session_widgets[self._selected_index].scroll_visible()
+
+    def _navigate(self, direction: int) -> None:
+        self._selected_index = (self._selected_index + direction) % len(self._sessions)
+        self._update_display()
+
+    def action_move_up(self) -> None:
+        self._navigate(-1)
+
+    def action_move_down(self) -> None:
+        self._navigate(1)
+
+    def action_select(self) -> None:
+        if self._sessions:
+            self.app.exit(self._sessions[self._selected_index].filepath)
+
+    def action_cancel(self) -> None:
+        self.app.exit(None)
+
+    def on_blur(self, event: events.Blur) -> None:
+        self.call_after_refresh(self.focus)

--- a/vibe/cli/session_selector/session_selector.tcss
+++ b/vibe/cli/session_selector/session_selector.tcss
@@ -1,0 +1,48 @@
+/* =============================================================================
+   Session Selector Styles
+   ============================================================================= */
+
+Screen {
+    layout: vertical;
+}
+
+#selector-outer {
+    width: 100%;
+    height: 100%;
+    padding: 1 2;
+}
+
+#selector-title {
+    width: 100%;
+    text-align: center;
+    text-style: bold;
+    padding: 1;
+}
+
+#session-list {
+    width: 100%;
+    height: 1fr;
+    border: round #555555;
+    padding: 1;
+}
+
+.session-item {
+    width: 100%;
+    height: auto;
+}
+
+.session-item.selected {
+    color: $primary;
+    text-style: bold;
+}
+
+.session-item.unselected {
+    color: $text-muted;
+}
+
+#selector-help {
+    width: 100%;
+    text-align: center;
+    color: $text-muted;
+    padding: 1;
+}


### PR DESCRIPTION
Adds the ability to run `vibe --resume` without specifying a session ID. This opens an interactive selector showing recent sessions.

Built this for my own workflow - sharing in case it's useful.

### Changes
- `InteractionLogger.list_sessions()` - returns recent sessions sorted by modification time
- `SessionSelectorApp` - Textual-based selector with keyboard navigation (↑↓ Enter Esc)
- `--resume` argument now accepts optional ID (`nargs="?"`)

### Usage
```bash
vibe --resume          # opens interactive selector
vibe --resume abc123   # resumes specific session (unchanged)
```

### Note
If #125 lands first, `list_sessions()` could be consolidated with `get_all_sessions()`.