### PR TITLE
Bash Tool: Explicitly use bash instead of sh

### DIFF
--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -63,6 +63,20 @@ async def test_truncates_output_to_max_bytes(bash):
 
 
 @pytest.mark.asyncio
+async def test_bash_source_command(bash, tmp_path):
+    # Create a temporary script to source
+    script_path = tmp_path / "test_script.sh"
+    script_path.write_text("export TEST_VAR='hello from source'")
+
+    # Test that source command works (bash-specific feature)
+    result = await bash.run(BashArgs(command=f"source {script_path} && echo $TEST_VAR"))
+
+    assert result.returncode == 0
+    assert "hello from source" in result.stdout
+    assert result.stderr == ""
+
+
+@pytest.mark.asyncio
 async def test_decodes_non_utf8_bytes(bash):
     result = await bash.run(BashArgs(command="printf '\\xff\\xfe'"))
 

--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -244,6 +244,7 @@ class Bash(BaseTool[BashArgs, BashResult, BashToolConfig, BaseToolState]):
                 stdin=asyncio.subprocess.DEVNULL,
                 cwd=self.config.effective_workdir,
                 env=_get_base_env(),
+                executable="/bin/bash" if not is_windows() else None,
                 **kwargs,
             )
 


### PR DESCRIPTION
- Updated the bash tool to explicitly use `/bin/bash` as the executable instead of relying on Python's default /bin/sh
- Added test for bash-specific `source` command functionality

Seeing that the tool is called bash, uses bash-specific functionality.

For instance, it will perform `source .venv/bin/activate`, yet `source` [is bash-only][bash], and not supported by `sh` and replacement programs such as `dash`.

Sadly, [vibe's bash tool call runs][vibe] `asyncio.create_subprocess_shell()` which [uses][asyncio] `subprocess.Popen()` which [runs][popen] /bin/sh, not bash.

This change fixes issue #186.

[bash]: https://man7.org/linux/man-pages/man1/bash.1.html#SHELL_BUILTIN_COMMANDS
[vibe]: https://github.com/mistralai/mistral-vibe/blob/402e898f391f65c447cfe061a5fee47a0b50cce7/vibe/core/tools/builtins/bash.py#L240-L248
[asyncio]: https://github.com/python/cpython/blob/4ea3c1a04747978361b497798428423cbb6a7146/Lib/asyncio/unix_events.py#L844-L846
[popen]: https://github.com/python/cpython/blob/4ea3c1a04747978361b497798428423cbb6a7146/Lib/subprocess.py#L1845-L1851

- All existing tests pass (7 bash tool tests + 30 related tests)
- Added new test `test_bash_source_command` to verify bash-specific functionality
- Code follows project standards (linting and formatting pass)