### PR TITLE
feat: add compact_model config for dedicated compaction model

### DIFF
--- a/tests/test_compact_model.py
+++ b/tests/test_compact_model.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.mock.utils import mock_llm_chunk
+from tests.stubs.fake_backend import FakeBackend
+from vibe.core.agent import Agent
+from vibe.core.config import (
+    ModelConfig,
+    SessionLoggingConfig,
+    VibeConfig,
+)
+
+
+class TestGetCompactModel:
+    def test_returns_active_model_when_compact_model_empty(self) -> None:
+        cfg = VibeConfig(
+            compact_model="",
+            active_model="devstral-2",
+            models=[
+                ModelConfig(
+                    name="devstral-latest", provider="mistral", alias="devstral-2"
+                ),
+            ],
+        )
+        result = cfg.get_compact_model()
+        assert result.alias == "devstral-2"
+
+    def test_returns_active_model_when_compact_model_not_set(self) -> None:
+        cfg = VibeConfig(
+            active_model="devstral-2",
+            models=[
+                ModelConfig(
+                    name="devstral-latest", provider="mistral", alias="devstral-2"
+                ),
+            ],
+        )
+        result = cfg.get_compact_model()
+        assert result.alias == "devstral-2"
+
+    def test_returns_compact_model_when_set(self) -> None:
+        cfg = VibeConfig(
+            compact_model="devstral-small",
+            models=[
+                ModelConfig(
+                    name="devstral-small-latest",
+                    provider="mistral",
+                    alias="devstral-small",
+                ),
+                ModelConfig(
+                    name="devstral-latest", provider="mistral", alias="devstral-2"
+                ),
+            ],
+        )
+        result = cfg.get_compact_model()
+        assert result.alias == "devstral-small"
+        assert result.name == "devstral-small-latest"
+
+    def test_falls_back_to_active_model_when_compact_model_not_found(self) -> None:
+        cfg = VibeConfig(
+            compact_model="nonexistent-model",
+            active_model="devstral-2",
+            models=[
+                ModelConfig(
+                    name="devstral-latest", provider="mistral", alias="devstral-2"
+                ),
+            ],
+        )
+        result = cfg.get_compact_model()
+        assert result.alias == "devstral-2"
+
+
+class TestSelectCompactBackend:
+    def test_returns_main_backend_when_compact_model_empty(self) -> None:
+        backend = FakeBackend([mock_llm_chunk(content="test")])
+        cfg = VibeConfig(session_logging=SessionLoggingConfig(enabled=False))
+        agent = Agent(cfg, backend=backend)
+        assert agent._compact_backend is agent.backend
+
+    def test_creates_separate_backend_when_compact_model_set(self) -> None:
+        backend = FakeBackend([mock_llm_chunk(content="test")])
+        cfg = VibeConfig(
+            session_logging=SessionLoggingConfig(enabled=False),
+            compact_model="devstral-small",
+            models=[
+                ModelConfig(
+                    name="devstral-small-latest",
+                    provider="mistral",
+                    alias="devstral-small",
+                ),
+            ],
+        )
+        agent = Agent(cfg, backend=backend)
+        assert agent._compact_backend is not agent.backend
+
+
+class TestCompactUsesCompactModel:
+    @pytest.mark.asyncio
+    async def test_compact_uses_injected_backend(self) -> None:
+        main_backend = FakeBackend([mock_llm_chunk(content="main")])
+        compact_backend = FakeBackend([mock_llm_chunk(content="<summary>")])
+        cfg = VibeConfig(session_logging=SessionLoggingConfig(enabled=False))
+        agent = Agent(cfg, backend=main_backend)
+        agent._compact_backend = compact_backend
+
+        agent.messages.append(
+            agent.messages[0].model_copy(update={"content": "user message"})
+        )
+
+        summary = await agent.compact()
+
+        assert len(compact_backend.requests_messages) == 1
+        assert len(main_backend.requests_messages) == 0
+
+    @pytest.mark.asyncio
+    async def test_compact_uses_compact_backend_when_configured(self) -> None:
+        main_backend = FakeBackend([mock_llm_chunk(content="main")])
+        compact_backend = FakeBackend([mock_llm_chunk(content="<compact_summary>")])
+
+        cfg = VibeConfig(
+            session_logging=SessionLoggingConfig(enabled=False),
+            compact_model="devstral-small",
+            active_model="devstral-2",
+            models=[
+                ModelConfig(
+                    name="devstral-small-latest",
+                    provider="mistral",
+                    alias="devstral-small",
+                ),
+                ModelConfig(
+                    name="devstral-latest", provider="mistral", alias="devstral-2"
+                ),
+            ],
+        )
+
+        agent = Agent(cfg, backend=main_backend)
+        agent._compact_backend = compact_backend
+
+        agent.messages.append(
+            agent.messages[0].model_copy(update={"content": "user message"})
+        )
+
+        summary = await agent.compact()
+
+        assert len(compact_backend.requests_messages) == 1
+        assert len(main_backend.requests_messages) == 0
+        assert "<compact_summary>" in summary
+
+
+class TestCompactFailure:
+    @pytest.mark.asyncio
+    async def test_compact_raises_when_compact_backend_fails(self) -> None:
+        main_backend = FakeBackend(
+            [], exception_to_raise=ConnectionError("server down")
+        )
+
+        cfg = VibeConfig(session_logging=SessionLoggingConfig(enabled=False))
+        agent = Agent(cfg, backend=main_backend)
+
+        agent.messages.append(
+            agent.messages[0].model_copy(update={"content": "user message"})
+        )
+
+        with pytest.raises(RuntimeError, match="server down"):
+            await agent.compact()
+
+    @pytest.mark.asyncio
+    async def test_compact_restores_messages_on_failure(self) -> None:
+        """When compact fails, messages should be restored to original state."""
+        compact_backend = FakeBackend(
+            [], exception_to_raise=ConnectionError("compact server down")
+        )
+
+        cfg = VibeConfig(
+            session_logging=SessionLoggingConfig(enabled=False),
+            compact_model="devstral-small",
+            models=[
+                ModelConfig(
+                    name="devstral-small-latest",
+                    provider="mistral",
+                    alias="devstral-small",
+                ),
+            ],
+        )
+
+        agent = Agent(cfg, backend=FakeBackend([mock_llm_chunk(content="main")]))
+        agent._compact_backend = compact_backend
+
+        # Add a user message to simulate conversation
+        agent.messages.append(
+            agent.messages[0].model_copy(update={"content": "user message"})
+        )
+        original_message_count = len(agent.messages)
+
+        with pytest.raises(RuntimeError, match="compact server down"):
+            await agent.compact()
+
+        # Messages should be restored to original state
+        assert len(agent.messages) == original_message_count

--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -273,6 +273,7 @@ DEFAULT_MODELS = [
 
 class VibeConfig(BaseSettings):
     active_model: str = "devstral-2"
+    compact_model: str = ""
     vim_keybindings: bool = False
     disable_welcome_banner_animation: bool = False
     displayed_workdir: str = ""
@@ -353,6 +354,13 @@ class VibeConfig(BaseSettings):
         raise ValueError(
             f"Active model '{self.active_model}' not found in configuration."
         )
+
+    def get_compact_model(self) -> ModelConfig:
+        if self.compact_model:
+            for model in self.models:
+                if model.alias == self.compact_model:
+                    return model
+        return self.get_active_model()
 
     def get_provider_for_model(self, model: ModelConfig) -> ProviderConfig:
         for provider in self.providers:


### PR DESCRIPTION
This PR adds support for configuring a separate model for conversation compaction.

### Motivation

When using vibe, compaction can be slow with large models. This allows using a smaller/faster model specifically for summarization, speeding up `/compact` and auto-compact operations. Also useful for saving API tokens when using cloud providers.

### Changes

- Add `compact_model` config option to specify a dedicated model for compaction
- Create separate backend for compact operations when configured
- Restore messages on compact failure to prevent corrupted conversation state

### Usage

```toml
# ~/.vibe/config.toml
compact_model = "ministral-3b"
```

When `compact_model` is set, `/compact` and auto-compact will use the specified model. If not set, behavior is unchanged (uses active model).

### Testing

Added 10 tests covering config resolution, backend selection, and failure recovery.