### PR TITLE
feat: Simple sandboxing via Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Ignore hidden files and directories
+.*
+*.pyc
+*.pyo
+*.pyd
+__pycache__/
+*.egg-info/
+*.egg
+*.log
+*.pid
+*.sock
+*.swp
+*.swo
+.DS_Store
+.env
+.venv/
+venv/
+.env
+.git/
+.gitignore
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:alpine3.22
 
 # install bash support for tooling
-RUN apk update && apk add bash curl shadow gosu sed
+RUN apk update && apk add bash curl shadow gosu sed git
 
 # Create vibeuser with a default UID/GID that can be overridden at runtime
 ARG VIBE_UID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ghcr.io/astral-sh/uv:alpine3.22
+
+# install bash support for tooling
+RUN apk update && apk add bash curl shadow gosu sed
+
+# Create vibeuser with a default UID/GID that can be overridden at runtime
+ARG VIBE_UID=1000
+ARG VIBE_GID=1000
+RUN addgroup -g ${VIBE_GID} vibeuser && \
+    adduser -u ${VIBE_UID} -G vibeuser -D vibeuser
+
+RUN mkdir -p /app && chown vibeuser:vibeuser /app
+RUN mkdir -p /logs && chown vibeuser:vibeuser /logs
+RUN mkdir -p /vibe && chown vibeuser:vibeuser /vibe
+RUN mkdir -p /work && chown vibeuser:vibeuser /work
+
+# copy source code (excluding hidden files and directories)
+USER vibeuser
+WORKDIR /app
+COPY --chown=vibeuser:vibeuser . /app/
+
+# build vibe and install it in development mode as vibeuser
+RUN uv sync --python 3.12
+ENV VIBE_HOME="/vibe"
+
+# Set the entrypoint (entrypoint bootstraps vibe with correct permissions)
+USER root
+WORKDIR /work
+ENTRYPOINT ["/app/scripts/entrypoint.sh"]
+CMD ["/app/.venv/bin/vibe"]

--- a/README.md
+++ b/README.md
@@ -308,6 +308,27 @@ This affects where Vibe looks for:
 
 Mistral Vibe can be used in text editors and IDEs that support [Agent Client Protocol](https://agentclientprotocol.com/overview/clients). See the [ACP Setup documentation](docs/acp-setup.md) for setup instructions for various editors and IDEs.
 
+## Sandboxing
+
+Especially when freely giving permissions through `--auto-approve`, it is good
+practice to use _sandboxing_, i.e. execute the agent from within a container. Docker,
+for example, offers [Sandboxes](https://docs.docker.com/ai/sandboxes/) (without `vibe` support)
+but there are also [community-lead projects](https://github.com/agent-infra/sandbox).
+
+For now, we can build a custom Docker image for sandboxing (instructions for Linux):
+```bash
+./scripts/build_sandbox.sh
+```
+
+Then, after installing `mistral-vibe` as above, the flag `--sandbox` for `vibe`
+executes `vibe` in the custom Docker sandbox.
+
+Please note that there are several restrictions on the use:
+- ` The `~/.vibe` directory is copied to the container at `/vibe`, hence sessions
+are not stored and no settings can be changed.
+- Only `bash` and `uv` are installed for tool use. More tools need to be installed
+either at runtime or installed via `apk` within the `Dockerfile`.
+
 ## Resources
 
 - [CHANGELOG](CHANGELOG.md) - See what's new in each version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "watchfiles>=1.1.1",
     "pyperclip>=1.11.0",
     "textual-speedups>=0.2.1",
+    "docker>=7.1.0",
 ]
 
 [project.urls]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Project Management Scripts
 
-This directory contains scripts that support project versioning and deployment workflows.
+This directory contains scripts that support project versioning, deployment workflows, and Docker sandbox management.
 
 ## Versioning
 
@@ -17,4 +17,22 @@ uv run scripts/bump_version.py minor
 uv run scripts/bump_version.py micro
 # or
 uv run scripts/bump_version.py patch
+```
+
+## Docker Sandbox
+
+The `build_sandbox.sh` script builds the Docker image with the following features:
+
+- Creates a non-root user `vibeuser` (UID 1000 by default)
+- Installs all dependencies as the non-root user
+- Supports custom UID/GID for better host-container user mapping
+
+### Usage
+
+```bash
+# Build with default UID/GID (1000:1000)
+./build_sandbox.sh
+
+# Build with custom UID/GID (recommended for proper file permissions)
+./build_sandbox.sh $(id -u) $(id -g)
 ```

--- a/scripts/build_sandbox.sh
+++ b/scripts/build_sandbox.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Build the Docker image with optional UID/GID arguments
+# Usage: ./build_sandbox.sh [VIBE_UID] [VIBE_GID]
+
+docker build \
+  --build-arg VIBE_UID=${1:-1000} \
+  --build-arg VIBE_GID=${2:-1000} \
+  -t mistral-vibe \
+  -f Dockerfile \
+  .

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+# update vibeuser's IDs to host suer's ID
+current_uid=$(id -u vibeuser)
+current_gid=$(id -g vibeuser)
+
+if [ "$current_uid" -ne "$PUID" ]; then
+    echo "Updating vibeuser UID from $current_uid to $PUID"
+    usermod -o -u "$PUID" vibeuser
+fi
+
+if [ "$current_gid" -ne "$PGID" ]; then
+    echo "Updating vibeuser GID from $current_gid to $PGID"
+    groupmod -o -g "$PGID" vibeuser
+fi
+
+chown -R vibeuser:vibeuser /app
+
+# import .vibe directory and adapt log session
+cp -R /vibe_in/* /vibe/
+chown -R vibeuser:vibeuser /vibe/
+
+CONFIG_FILE="/vibe/config.toml"
+if [ -f "$CONFIG_FILE" ]; then
+    NEW_PATH="/logs/"
+    sed -i "s|^save_dir = .*|save_dir = \"$NEW_PATH\"|" "$CONFIG_FILE"
+fi
+
+# execute docker CMD as vibeuser
+exec gosu vibeuser "$@"

--- a/tests/core/test_sandbox.py
+++ b/tests/core/test_sandbox.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import docker
+import pytest
+
+from vibe.core.sandbox.sandbox import IMAGE_NAME, run_sandbox
+
+def _is_running_in_docker() -> bool:
+    try:
+        with open("/proc/1/cgroup", "rt", encoding="utf-8") as f:
+            return "docker" in f.read()
+    except FileNotFoundError:
+        # Not running on Linux or /proc not available
+        return False
+
+
+def _docker_available() -> bool:
+    # Skip if we're already running in a Docker container
+    if _is_running_in_docker():
+        return False
+
+    try:
+        client = docker.from_env()
+        client.ping()
+        return True
+    except (docker.errors.DockerException, OSError):
+        return False
+
+
+def _image_available() -> bool:
+    if not _docker_available():
+        return False
+
+    try:
+        client = docker.from_env()
+        client.images.get(IMAGE_NAME)
+        return True
+    except docker.errors.ImageNotFound:
+        return False
+    except docker.errors.DockerException:
+        return False
+
+
+class TestSandbox:
+    def test_run_sandbox_requires_docker(self, tmp_path: Path) -> None:
+        """Test that run_sandbox fails gracefully when Docker is not available."""
+        with patch("docker.from_env") as mock_docker:
+            mock_docker.side_effect = docker.errors.DockerException("Docker not available")
+
+            with pytest.raises(SystemExit) as exc_info:
+                run_sandbox(str(tmp_path), "")
+
+            assert exc_info.value.code == 1
+
+    def test_run_sandbox_requires_image(self, tmp_path: Path) -> None:
+        """Test that run_sandbox fails gracefully when the required image is not available."""
+        with patch("docker.from_env") as mock_docker:
+            mock_client = mock_docker.return_value
+            mock_client.images.get.side_effect = docker.errors.ImageNotFound("Image not found")
+
+            with pytest.raises(SystemExit) as exc_info:
+                run_sandbox(str(tmp_path), "")
+
+            assert exc_info.value.code == 1
+
+    @pytest.mark.skipif(
+        not _docker_available(),
+        reason="Docker is not installed or not running"
+    )
+    @pytest.mark.skipif(
+        not _image_available(),
+        reason=f"Docker image '{IMAGE_NAME}' is not available"
+    )
+    def test_run_sandbox_launches_container(self, tmp_path: Path) -> None:
+        """Test that run_sandbox successfully launches a Docker container."""
+        # Create a test file in the temporary directory
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("Hello from sandbox test!", encoding="utf-8")
+
+        # Test with a simple command that should exit quickly
+        # We'll use a timeout to prevent hanging
+        import threading
+
+        # Store exceptions
+        exception_ref = []
+
+        def run_with_timeout():
+            try:
+                # This should launch the container and exit quickly with --help
+                run_sandbox(str(tmp_path), "--help")
+            except SystemExit as e:
+                # Expected - the container will exit with code 0
+                exception_ref.append(e)
+            except Exception as e:
+                exception_ref.append(e)
+
+        # Start the sandbox in a separate thread
+        thread = threading.Thread(target=run_with_timeout)
+        thread.start()
+
+        # Wait for the container to start and exit (should be quick with --help)
+        thread.join(timeout=30)
+
+        # Check if we got the expected SystemExit with code 0
+        if exception_ref:
+            if isinstance(exception_ref[0], SystemExit):
+                assert exception_ref[0].code == 0
+            else:
+                raise exception_ref[0]
+        else:
+            # If no exception, the thread should have completed
+            if thread.is_alive():
+                pytest.fail("Sandbox container did not exit within expected time")

--- a/tests/core/test_sandbox.py
+++ b/tests/core/test_sandbox.py
@@ -8,9 +8,10 @@ import pytest
 
 from vibe.core.sandbox.sandbox import IMAGE_NAME, run_sandbox
 
+
 def _is_running_in_docker() -> bool:
     try:
-        with open("/proc/1/cgroup", "rt", encoding="utf-8") as f:
+        with open("/proc/1/cgroup", encoding="utf-8") as f:
             return "docker" in f.read()
     except FileNotFoundError:
         # Not running on Linux or /proc not available

--- a/uv.lock
+++ b/uv.lock
@@ -282,6 +282,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.22.3"
 source = { registry = "https://pypi.org/simple" }
@@ -666,6 +680,7 @@ source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "aiofiles" },
+    { name = "docker" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "mistralai" },
@@ -705,6 +720,7 @@ dev = [
 requires-dist = [
     { name = "agent-client-protocol", specifier = "==0.6.3" },
     { name = "aiofiles", specifier = ">=24.1.0" },
+    { name = "docker", specifier = ">=7.1.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", specifier = ">=1.14.0" },
     { name = "mistralai", specifier = "==1.9.11" },

--- a/vibe/cli/entrypoint.py
+++ b/vibe/cli/entrypoint.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 import sys
+import os
 
 from rich import print as rprint
 
@@ -86,6 +87,7 @@ def parse_arguments() -> argparse.Namespace:
         help="Load agent configuration from ~/.vibe/agents/NAME.toml",
     )
     parser.add_argument("--setup", action="store_true", help="Setup API key and exit")
+    parser.add_argument("--sandbox", action="store_true", help="Launch vibe in docker container as a sandbox.")
 
     continuation_group = parser.add_mutually_exclusive_group()
     continuation_group.add_argument(
@@ -100,6 +102,7 @@ def parse_arguments() -> argparse.Namespace:
         metavar="SESSION_ID",
         help="Resume a specific session by its ID (supports partial matching)",
     )
+
     return parser.parse_args()
 
 
@@ -129,6 +132,16 @@ def check_and_resolve_trusted_folder() -> None:
 
 def main() -> None:
     args = parse_arguments()
+
+    if args.sandbox:
+        # launch sanboxing container and pass arguments and current working dir
+        raw_arg_str = " ".join(sys.argv[1:]).replace("--sandbox", "")
+        cwd_path = os.curdir
+
+        from vibe.core.sandbox.sandbox import run_sandbox
+        run_sandbox(cwd_path, raw_arg_str)
+
+        return
 
     is_interactive = args.prompt is None
     if is_interactive:

--- a/vibe/cli/entrypoint.py
+++ b/vibe/cli/entrypoint.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 import sys
-import os
 
 from rich import print as rprint
 

--- a/vibe/core/sandbox/sandbox.py
+++ b/vibe/core/sandbox/sandbox.py
@@ -8,7 +8,6 @@ import uuid
 
 import docker
 from docker.errors import DockerException, ImageNotFound
-
 from rich import print as rprint
 
 from vibe.core.paths.global_paths import _get_vibe_home

--- a/vibe/core/sandbox/sandbox.py
+++ b/vibe/core/sandbox/sandbox.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import uuid
+
+import docker
+from docker.errors import DockerException, ImageNotFound
+
+from rich import print as rprint
+
+from vibe.core.paths.global_paths import _get_vibe_home
+from vibe.core.utils import logger
+
+IMAGE_NAME = "mistral-vibe"
+
+
+def run_sandbox(cwd: str, arg_str: str) -> None:
+    """Launch vibe in a Docker container sandbox.
+
+    Args:
+        cwd: Current working directory to mount into the container.
+        arg_str: Additional arguments to append to the container command.
+
+    Raises:
+        SystemExit: If Docker is not available or container launch fails.
+    """
+    # Convert cwd to absolute path for Docker volume mount
+    cwd = str(Path(cwd).resolve())
+
+    try:
+        client = docker.from_env()
+    except DockerException as e:
+        rprint("[red]Error: Docker is not available or not running.[/]")
+        raise SystemExit(1) from e
+    except Exception as e:
+        rprint("[red]Error: Failed to initialize Docker client.[/]")
+        raise SystemExit(1) from e
+
+    container_name = f"mistral-vibe-{uuid.uuid4()}"
+
+    # Check for required environment and config
+    api_key = os.environ.get("MISTRAL_API_KEY")
+    vibe_dir = _get_vibe_home()
+
+    if not api_key and not vibe_dir.exists():
+        rprint("[red]Error: Mistral-vibe is not initialized.[/]")
+        rprint("[yellow]Please run mistral-vibe on the host first to set up your API key and configuration.[/]")
+        raise SystemExit(1) from None
+
+    # Build volume mount arguments
+    volume_args = [f"-v{cwd}:/work"]
+    if vibe_dir.exists():
+        volume_args.append(f"-v{vibe_dir}:/vibe_in:ro")
+        logger.info(f"Mounting {vibe_dir} to /vibe_in")
+
+    # Build environment arguments
+    env_args = []
+    if api_key:
+        env_args.append(f"-eMISTRAL_API_KEY={api_key}")
+        logger.info("Passing MISTRAL_API_KEY to container")
+
+    try:
+        try:
+            image = client.images.get(IMAGE_NAME)
+        except ImageNotFound:
+            rprint(f"[yellow]Image '{IMAGE_NAME}' not found. Build it with scripts/container.sh[/]")
+            raise SystemExit(1) from None
+
+        cmd = image.attrs["Config"]["Cmd"]
+        if cmd is None:
+            cmd = []
+        if not isinstance(cmd, list):
+            cmd = [cmd]
+
+        # Append arg_str to the command
+        full_cmd = cmd + arg_str.split()
+
+        # Build docker CLI command for interactive execution
+        docker_cmd = [
+            "docker",
+            "run",
+            "--rm",
+            f"--name={container_name}",
+            "--network=host",
+            "-i",
+        ]
+
+        # Enables interactive sessions
+        if sys.stdin.isatty():
+            docker_cmd.append("-t")
+
+        # Run container as current user to ensure proper file permissions
+        # This ensures files created in bind mounts are owned by the host user
+        uid = os.getuid()
+        gid = os.getgid()
+        docker_cmd.extend([f"-ePUID={uid}", f"-ePGID={gid}"])
+
+        docker_cmd.extend([
+            *volume_args,
+            *env_args,
+            IMAGE_NAME,
+            *full_cmd,  # Pass additional arguments after the image name
+        ])
+
+        # Subprocess enables Ctrl+C-handling and stdin/stdout handling
+        result = subprocess.run(docker_cmd)
+        raise SystemExit(result.returncode)
+
+    except SystemExit:
+        raise
+    except Exception as e:
+        rprint(f"[red]Error: An unexpected error occurred while running the sandbox: {e}.[/]")
+        raise SystemExit(1) from e


### PR DESCRIPTION
This PR adds initial support for sandboxing.

## Motivation
As agents become more autonomous (in `vibe:` `--auto-approve`), we need to make sure that users don't loose data due to model malfunctions. One popular concept for that is sandboxing as e.g. implemented in [Docker](https://docs.docker.com/ai/sandboxes/) which unfortunately still lacks support for `vibe`.
Claude Code has a [very simple](https://code.claude.com/docs/en/sandboxing) implementation which I think shows the right way: Users only use sandboxing it it's relatively painless.

For now, the support is very simple: A new container is launched at every call with the current dir and the `VIBE_HOME` mounted into a minimal container with only `bash, git, uv` available.

## Changes

- `vibe/core/sandbox/sandbox.py`: Coantains the handler for starting the sandbox.
- `Dockerfile`: Docker build instructions for the sandbox' image.

## Usage

Users first need (at this point, in the future there should probably be a downloadable image!) build the sandbox image via `./script/build_sandbox.sh`. After that, any call to `vibe` that contains `--sandbox` is automatically wrapped into a new docker container.
We mount the current working directory as writeable and a copy of `~/.vibe`.

## Testing

Added a test in `tests/core/test_sandbox.py` checking if the container launches as expected; skipped if Docker or the image is not available.