### PR TITLE
🐛 Fix path autocompletion root resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Path autocompletion now anchors to the configured workdir (or git root) instead of assuming `.`
+
 ## [1.3.3] - 2025-12-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ pip install mistral-vibe
 Simply run `vibe` to enter the interactive chat loop.
 
 - **Multi-line Input**: Press `Ctrl+J` or `Shift+Enter` for select terminals to insert a newline.
-- **File Paths**: Reference files in your prompt using the `@` symbol for smart autocompletion (e.g., `> Read the file @src/agent.py`).
+- **File Paths**: Reference files in your prompt using the `@` symbol for smart autocompletion (e.g., `> Read the file @src/agent.py`). Autocompletion is anchored to the configured workdir when set, otherwise to the Git repository root if available (falls back to the current directory).
 - **Shell Commands**: Prefix any command with `!` to execute it directly in your shell, bypassing the agent (e.g., `> !ls -l`).
 
 You can start Vibe with a prompt with the following command:

--- a/tests/autocompletion/test_path_completer_fuzzy.py
+++ b/tests/autocompletion/test_path_completer_fuzzy.py
@@ -34,6 +34,27 @@ def test_fuzzy_matches_subsequence_characters(file_tree: Path) -> None:
     assert "@src/" in results
 
 
+def test_root_resolver_overrides_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "src").mkdir()
+    (root / "root.txt").write_text("", encoding="utf-8")
+
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    (sandbox / "cwd.txt").write_text("", encoding="utf-8")
+    monkeypatch.chdir(sandbox)
+
+    completer = PathCompleter(root_resolver=lambda: root)
+    results = completer.get_completions("@", cursor_pos=1)
+
+    assert "@root.txt" in results
+    assert "@src/" in results
+    assert "@cwd.txt" not in results
+
+
 def test_fuzzy_matches_consecutive_characters_higher(file_tree: Path) -> None:
     results = PathCompleter().get_completions("@src/main", cursor_pos=9)
 

--- a/tests/autocompletion/test_path_completer_recursive.py
+++ b/tests/autocompletion/test_path_completer_recursive.py
@@ -28,6 +28,26 @@ def test_finds_files_recursively_by_filename(file_tree: Path) -> None:
     assert results[0] == "@vibe/acp/entrypoint.py"
 
 
+def test_defaults_to_git_root_when_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / "src").mkdir()
+    (repo / "src" / "main.py").write_text("", encoding="utf-8")
+    (repo / "README.md").write_text("", encoding="utf-8")
+    (repo / "subdir").mkdir()
+    (repo / "subdir" / "nested.txt").write_text("", encoding="utf-8")
+
+    monkeypatch.chdir(repo / "subdir")
+
+    results = PathCompleter().get_completions("@", cursor_pos=1)
+
+    assert "@README.md" in results
+    assert "@src/" in results
+    assert "@nested.txt" not in results
+
+
 def test_finds_files_recursively_by_partial_path(file_tree: Path) -> None:
     results = PathCompleter().get_completions("@acp/entry", cursor_pos=10)
 

--- a/vibe/cli/textual_ui/widgets/chat_input/container.py
+++ b/vibe/cli/textual_ui/widgets/chat_input/container.py
@@ -54,7 +54,9 @@ class ChatInputContainer(Vertical):
 
         self._completion_manager = MultiCompletionManager([
             SlashCommandController(CommandCompleter(command_entries), self),
-            PathCompletionController(PathCompleter(), self),
+            PathCompletionController(
+                PathCompleter(root_resolver=self._resolve_completion_root), self
+            ),
         ])
         self._completion_popup: CompletionPopup | None = None
         self._body: ChatInputBody | None = None
@@ -77,6 +79,12 @@ class ChatInputContainer(Vertical):
         if self._body.input_widget:
             self._body.input_widget.set_completion_manager(self._completion_manager)
             self._body.focus_input()
+
+    def _resolve_completion_root(self) -> Path | None:
+        try:
+            return self.app.config.workdir
+        except Exception:
+            return None
 
     @property
     def input_widget(self) -> ChatTextArea | None:


### PR DESCRIPTION
Hello 👋

I was digging through the TODOs and spotted this note in `completers.py`:  "*TODO (Vince): doing the assumption that '.' is the root directory... Reliable?*". So I followed up on it and made path autocompletion pick a better root. It now uses the configured workdir when set, otherwise it falls back to the git root (then to cwd).

## Changes

- Resolve completion root via configured workdir, otherwise use git root (fallback to cwd)
- UI path completion passes the configured workdir into the completer
- Added tests for workdir override, git-root defaulting, and UI completion
- Documented the autocompletion root behavior in the README
- Added CHANGELOG entry under `[Unreleased]`

Hope you like my change ! 😊
