### PR TITLE
 Enable History Navigation and Reload

### DIFF
--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -21,6 +21,11 @@ class CommandRegistry:
                 description="Show help message",
                 handler="_show_help",
             ),
+            "restore-session": Command(
+                aliases=frozenset(["/restore-session"]),
+                description="Restore a session from history",
+                handler="_restore_session",
+            ),
             "config": Command(
                 aliases=frozenset(["/config", "/theme", "/model"]),
                 description="Edit config settings",

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 from enum import StrEnum, auto
+import json
+from pathlib import Path
 import subprocess
 import time
 from typing import Any, ClassVar, assert_never
@@ -28,6 +30,7 @@ from vibe.cli.textual_ui.widgets.chat_input import ChatInputContainer
 from vibe.cli.textual_ui.widgets.compact import CompactMessage
 from vibe.cli.textual_ui.widgets.config_app import ConfigApp
 from vibe.cli.textual_ui.widgets.context_progress import ContextProgress, TokenState
+from vibe.cli.textual_ui.widgets.history_app import HistoryApp, HistoryDefinition
 from vibe.cli.textual_ui.widgets.loading import LoadingWidget
 from vibe.cli.textual_ui.widgets.messages import (
     AssistantMessage,
@@ -71,6 +74,7 @@ from vibe.core.utils import (
 class BottomApp(StrEnum):
     Approval = auto()
     Config = auto()
+    History = auto()
     Input = auto()
 
 
@@ -318,6 +322,17 @@ class VibeApp(App):  # noqa: PLR0904
                 UserCommandMessage("Configuration closed (no changes saved).")
             )
 
+        await self._switch_to_input_app()
+
+    async def on_history_app_history_closed(
+        self, message: HistoryApp.HistoryClosed
+    ) -> None:
+        if message.changes:
+            await self._mount_and_scroll(UserCommandMessage("History closed."))
+        else:
+            await self._mount_and_scroll(
+                UserCommandMessage("History closed (no changes saved).")
+            )
         await self._switch_to_input_app()
 
     def _set_tool_permission_always(
@@ -674,6 +689,66 @@ class VibeApp(App):  # noqa: PLR0904
         help_text = self.commands.get_help_text()
         await self._mount_and_scroll(UserCommandMessage(help_text))
 
+    async def _restore_session(self) -> None:
+        """Switch to the History app in the bottom panel."""
+        if self._current_bottom_app == BottomApp.History:
+            return
+        await self._get_and_switch_to_history_app()
+
+    async def _get_and_switch_to_history_app(self) -> None:
+        """Load saved sessions and show the history app."""
+        await self._mount_and_scroll(UserCommandMessage("History opened..."))
+
+        sessions: list[HistoryDefinition] = []
+        try:
+            save_dir = Path(self.config.session_logging.save_dir)
+            prefix = self.config.session_logging.session_prefix or "session"
+            pattern = f"{prefix}_*.json"
+            if save_dir.exists():
+                files = sorted(
+                    save_dir.glob(pattern),
+                    key=lambda p: p.stat().st_mtime,
+                    reverse=True,
+                )
+                for p in files:
+                    try:
+                        content = p.read_text(encoding="utf-8")
+                        data = json.loads(content)
+                        meta = data.get("metadata", {}) or {}
+                        sid = meta.get("session_id") or p.stem.split("_")[-1]
+                        title = meta.get("session_title") or ""
+                        sessions.append({
+                            "session_id": str(sid)[:8],
+                            "session_title": str(title),
+                        })
+                    except Exception:
+                        continue
+        except Exception as e:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    f"Failed to read session logs: {e}", collapsed=self._tools_collapsed
+                )
+            )
+
+        try:
+            from vibe.core.paths.config_paths import HISTORY_FILE
+
+            HISTORY_FILE.path.parent.mkdir(parents=True, exist_ok=True)
+            with HISTORY_FILE.path.open("w", encoding="utf-8") as f:
+                for session in sessions:
+                    sid = session["session_id"]
+                    title = session["session_title"]
+                    line = f"{sid} {title}\n" if title else f"{sid}\n"
+                    f.write(line)
+        except Exception as e:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    f"Failed to write history file: {e}",
+                    collapsed=self._tools_collapsed,
+                )
+            )
+        await self._switch_to_history_app(sessions)
+
     async def _show_status(self) -> None:
         if self.agent is None:
             await self._mount_and_scroll(
@@ -920,6 +995,29 @@ class VibeApp(App):  # noqa: PLR0904
                 ErrorMessage(result.message, collapsed=self._tools_collapsed)
             )
 
+    async def _switch_to_history_app(self, sessions: list[HistoryDefinition]) -> None:
+        if self._current_bottom_app == BottomApp.History:
+            return
+
+        bottom_container = self.query_one("#bottom-app-container")
+        try:
+            chat_input_container = self.query_one(ChatInputContainer)
+            await chat_input_container.remove()
+        except Exception:
+            pass
+
+        if self._mode_indicator:
+            self._mode_indicator.display = False
+
+        history_app = HistoryApp(
+            self.config,
+            history=sessions,
+            has_terminal_theme=self._terminal_theme is not None,
+        )
+        await bottom_container.mount(history_app)
+        self._current_bottom_app = BottomApp.History
+        self.call_after_refresh(history_app.focus)
+
     async def _switch_to_config_app(self) -> None:
         if self._current_bottom_app == BottomApp.Config:
             return
@@ -980,6 +1078,12 @@ class VibeApp(App):  # noqa: PLR0904
             pass
 
         try:
+            history_app = self.query_one("#history-app")
+            await history_app.remove()
+        except Exception:
+            pass
+
+        try:
             approval_app = self.query_one("#approval-app")
             await approval_app.remove()
         except Exception:
@@ -1031,6 +1135,15 @@ class VibeApp(App):  # noqa: PLR0904
             try:
                 config_app = self.query_one(ConfigApp)
                 config_app.action_close()
+            except Exception:
+                pass
+            self._last_escape_time = None
+            return
+
+        if self._current_bottom_app == BottomApp.History:
+            try:
+                history_app = self.query_one(HistoryApp)
+                history_app.action_close()
             except Exception:
                 pass
             self._last_escape_time = None

--- a/vibe/cli/textual_ui/app.tcss
+++ b/vibe/cli/textual_ui/app.tcss
@@ -720,6 +720,20 @@ WelcomeBanner {
     height: auto;
 }
 
+#history-app {
+    width: 100%;
+    height: auto;
+    background: $background;
+    border: round $foreground-muted;
+    padding: 0 1;
+    margin: 0 0 1 0;
+}
+
+#history-content {
+    width: 100%;
+    height: auto;
+}
+
 .settings-title {
     height: auto;
     text-style: bold;

--- a/vibe/cli/textual_ui/widgets/history_app.py
+++ b/vibe/cli/textual_ui/widgets/history_app.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, TypedDict
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Container, Vertical
+from textual.message import Message
+from textual.widgets import Static
+
+from vibe.cli.textual_ui.terminal_theme import TERMINAL_THEME_NAME
+from vibe.cli.textual_ui.widgets.config_app import _ALL_THEMES
+
+if TYPE_CHECKING:
+    from vibe.core.config import VibeConfig
+
+
+class HistoryDefinition(TypedDict):
+    id: str
+    name: str
+
+
+# HistoryApp needs the same focus behavior and bindings as the config UI
+
+
+class HistoryApp(Container):
+    history: list[HistoryDefinition] = []
+    themes: list[str] = []
+    can_focus = True
+    can_focus_children = False
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("up", "move_up", "Up", show=False),
+        Binding("down", "move_down", "Down", show=False),
+        Binding("space", "toggle_setting", "Toggle", show=False),
+        Binding("enter", "cycle", "Next", show=False),
+    ]
+
+    class HistoryClosed(Message):
+        def __init__(self, changes: dict[str, str]) -> None:
+            super().__init__()
+            self.changes = changes
+
+    def __init__(self, config: VibeConfig, *, has_terminal_theme: bool = False) -> None:
+        super().__init__(id="history-app")
+        self.config = config
+        self.selected_index = 0
+        self.changes: dict[str, str] = {}
+
+        themes = (
+            _ALL_THEMES
+            if has_terminal_theme
+            else [t for t in _ALL_THEMES if t != TERMINAL_THEME_NAME]
+        )
+
+        self.history: list[HistoryDefinition] = [
+            {
+                "id": "2a23d8be",
+                "name": "Enhancing Code Quality with Python 3.12+ Best Practices",
+            },
+            {
+                "id": "4033b89d",
+                "name": "Refactoring a Python Codebase for Modern Best Practices",
+            },
+            {
+                "id": "9c12a5be",
+                "name": "Refactoring a Python Codebase for Modern Best Practices",
+            },
+            {"id": "7ebb2e34", "name": "Title Generation for Conversations"},
+            {
+                "id": "d8e75be7",
+                "name": "Enhancing a Codebase with Modern Python Best Practices",
+            },
+            {"id": "36abdbdd", "name": "Codebase Analysis and Task Management"},
+            {"id": "d22b4daf", "name": "Title Generation for Conversations"},
+            {"id": "7520556e", "name": "Title Generation for Conversations"},
+            {"id": "c7b29265", "name": "Understanding JavaScript Basics"},
+        ]
+
+        self.title_widget: Static | None = None
+        self.history_widgets: list[Static] = []
+        self.help_widget: Static | None = None
+
+    def on_mount(self) -> None:
+        self._update_display()
+        self.focus()
+
+    def _update_display(self) -> None:
+        for i, (history, widget) in enumerate(
+            zip(self.history, self.history_widgets, strict=True)
+        ):
+            is_selected = i == self.selected_index
+            cursor = "› " if is_selected else "  "
+
+            value: str = history["name"]
+            label: str = history["id"]
+            text = f"{cursor}{label} : {value}"
+
+            widget.update(text)
+
+            widget.remove_class("settings-cursor-selected")
+            widget.remove_class("settings-value-cycle-selected")
+            widget.remove_class("settings-value-cycle-unselected")
+
+            if is_selected:
+                widget.add_class("settings-value-cycle-selected")
+            else:
+                widget.add_class("settings-value-cycle-unselected")
+
+    def action_move_up(self) -> None:
+        self.selected_index = (self.selected_index - 1) % len(self.history)
+        self._update_display()
+
+    def action_move_down(self) -> None:
+        self.selected_index = (self.selected_index + 1) % len(self.history)
+        self._update_display()
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="config-content"):
+            self.title_widget = Static("Sessions", classes="settings-title")
+            yield self.title_widget
+
+            yield Static("")
+
+            for _ in self.history:
+                widget = Static("", classes="settings-option")
+                self.history_widgets.append(widget)
+                yield widget
+
+            yield Static("")
+
+            self.help_widget = Static(
+                "↑↓ navigate  Space/Enter toggle  ESC exit", classes="settings-help"
+            )
+            yield self.help_widget

--- a/vibe/cli/textual_ui/widgets/history_app.py
+++ b/vibe/cli/textual_ui/widgets/history_app.py
@@ -40,6 +40,11 @@ class HistoryApp(Container):
             super().__init__()
             self.changes = changes
 
+    class SessionSelected(Message):
+        def __init__(self, session: HistoryDefinition) -> None:
+            super().__init__()
+            self.session = session
+
     def __init__(
         self,
         config: VibeConfig,
@@ -97,6 +102,22 @@ class HistoryApp(Container):
         self.selected_index = (self.selected_index + 1) % len(self.history)
         self._update_display()
 
+    def _emit_selection(self) -> None:
+        if not self.history:
+            return
+
+        try:
+            session = self.history[self.selected_index]
+            self.post_message(self.SessionSelected(session))
+        except Exception:
+            pass
+
+    def action_toggle_setting(self) -> None:
+        self._emit_selection()
+
+    def action_cycle(self) -> None:
+        self._emit_selection()
+
     def action_close(self) -> None:
         self.post_message(self.HistoryClosed(changes=self.changes.copy()))
 
@@ -118,6 +139,6 @@ class HistoryApp(Container):
             yield Static("")
 
             self.help_widget = Static(
-                "↑↓ navigate  Space/Enter toggle  ESC exit", classes="settings-help"
+                "↑↓ navigate  Enter/Open  ESC exit", classes="settings-help"
             )
             yield self.help_widget

--- a/vibe/cli/textual_ui/widgets/history_app.py
+++ b/vibe/cli/textual_ui/widgets/history_app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar, TypedDict
 
+from textual import events
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical
@@ -16,11 +17,8 @@ if TYPE_CHECKING:
 
 
 class HistoryDefinition(TypedDict):
-    id: str
-    name: str
-
-
-# HistoryApp needs the same focus behavior and bindings as the config UI
+    session_id: str
+    session_title: str
 
 
 class HistoryApp(Container):
@@ -34,6 +32,7 @@ class HistoryApp(Container):
         Binding("down", "move_down", "Down", show=False),
         Binding("space", "toggle_setting", "Toggle", show=False),
         Binding("enter", "cycle", "Next", show=False),
+        Binding("escape", "close", "Esc", show=False),
     ]
 
     class HistoryClosed(Message):
@@ -41,41 +40,24 @@ class HistoryApp(Container):
             super().__init__()
             self.changes = changes
 
-    def __init__(self, config: VibeConfig, *, has_terminal_theme: bool = False) -> None:
+    def __init__(
+        self,
+        config: VibeConfig,
+        history: list[HistoryDefinition] | None = None,
+        *,
+        has_terminal_theme: bool = False,
+    ) -> None:
         super().__init__(id="history-app")
         self.config = config
         self.selected_index = 0
         self.changes: dict[str, str] = {}
+        self.history = history or []
 
         themes = (
             _ALL_THEMES
             if has_terminal_theme
             else [t for t in _ALL_THEMES if t != TERMINAL_THEME_NAME]
         )
-
-        self.history: list[HistoryDefinition] = [
-            {
-                "id": "2a23d8be",
-                "name": "Enhancing Code Quality with Python 3.12+ Best Practices",
-            },
-            {
-                "id": "4033b89d",
-                "name": "Refactoring a Python Codebase for Modern Best Practices",
-            },
-            {
-                "id": "9c12a5be",
-                "name": "Refactoring a Python Codebase for Modern Best Practices",
-            },
-            {"id": "7ebb2e34", "name": "Title Generation for Conversations"},
-            {
-                "id": "d8e75be7",
-                "name": "Enhancing a Codebase with Modern Python Best Practices",
-            },
-            {"id": "36abdbdd", "name": "Codebase Analysis and Task Management"},
-            {"id": "d22b4daf", "name": "Title Generation for Conversations"},
-            {"id": "7520556e", "name": "Title Generation for Conversations"},
-            {"id": "c7b29265", "name": "Understanding JavaScript Basics"},
-        ]
 
         self.title_widget: Static | None = None
         self.history_widgets: list[Static] = []
@@ -92,9 +74,9 @@ class HistoryApp(Container):
             is_selected = i == self.selected_index
             cursor = "› " if is_selected else "  "
 
-            value: str = history["name"]
-            label: str = history["id"]
-            text = f"{cursor}{label} : {value}"
+            title: str = history["session_title"]
+            session_id: str = history["session_id"]
+            text = f"{cursor}{session_id} : {title}"
 
             widget.update(text)
 
@@ -114,6 +96,12 @@ class HistoryApp(Container):
     def action_move_down(self) -> None:
         self.selected_index = (self.selected_index + 1) % len(self.history)
         self._update_display()
+
+    def action_close(self) -> None:
+        self.post_message(self.HistoryClosed(changes=self.changes.copy()))
+
+    def on_blur(self, event: events.Blur) -> None:
+        self.call_after_refresh(self.focus)
 
     def compose(self) -> ComposeResult:
         with Vertical(id="config-content"):

--- a/vibe/core/prompts/__init__.py
+++ b/vibe/core/prompts/__init__.py
@@ -26,6 +26,7 @@ class UtilityPrompt(Prompt):
     COMPACT = auto()
     DANGEROUS_DIRECTORY = auto()
     PROJECT_CONTEXT = auto()
+    TITLE = auto()
 
 
 __all__ = ["SystemPrompt", "UtilityPrompt"]

--- a/vibe/core/prompts/title.md
+++ b/vibe/core/prompts/title.md
@@ -1,0 +1,10 @@
+Create a concise, clear, and descriptive **title** for this conversation.
+
+The title should:
+
+- Accurately reflect the main topic and intent of the discussion
+- Be short (ideally under 10 words)
+- Avoid generic phrases like “Help” or “Question”
+- Capture both the technical and practical focus if applicable
+
+Respond with ONLY the title, no explanations or additional text.

--- a/vibe/core/types.py
+++ b/vibe/core/types.py
@@ -106,6 +106,7 @@ class SessionMetadata(BaseModel):
     environment: dict[str, str | None]
     auto_approve: bool = False
     username: str
+    session_title: str | None
 
 
 StrToolChoice = Literal["auto", "none", "any", "required"]


### PR DESCRIPTION
Currently, while chats are being saved in the CLI, there is no way to restore a specific session. Additionally, showing only the session ID provides no context to the user.

This change introduces a `/restore-session` command to address this limitation:

- Added a title for each saved session to provide context.
- Added a command to list all saved sessions with their titles.
- Users can select a specific session from the list and press Enter to restore it.
- Restored chats can be continued seamlessly, improving workflow and accessibility to past interactions.

This change allows users to navigate, identify, and restore specific previous sessions easily.

**Screenshot:**
<img width="1935" height="975" alt="image" src="https://github.com/user-attachments/assets/abe2edf1-3a3b-41fa-ac4f-ced0d6ba1396" />


**Video:** 

https://github.com/user-attachments/assets/f13a5f29-be90-498a-9a32-6ff6d7b78bf9



### Related Issue
Fixes: #226 
