### PR TITLE
fix(terminal-setup): use XDG_CONFIG_HOME for wezterm config path

### DIFF
--- a/vibe/cli/terminal_setup.py
+++ b/vibe/cli/terminal_setup.py
@@ -258,8 +258,26 @@ def _setup_iterm2() -> SetupResult:
         )
 
 
+def _get_wezterm_config_path() -> Path:
+    """Get wezterm config path following XDG specification."""
+    # Check XDG_CONFIG_HOME first
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config_home:
+        config_path = Path(xdg_config_home) / "wezterm" / "wezterm.lua"
+        if config_path.exists():
+            return config_path
+
+    # Fall back to ~/.config/wezterm/wezterm.lua
+    config_path = Path.home() / ".config" / "wezterm" / "wezterm.lua"
+    if config_path.exists():
+        return config_path
+
+    # Fall back to traditional location
+    return Path.home() / ".wezterm.lua"
+
+
 def _setup_wezterm() -> SetupResult:
-    wezterm_config = Path.home() / ".wezterm.lua"
+    wezterm_config = _get_wezterm_config_path()
 
     key_binding = """{
     key = "Enter",


### PR DESCRIPTION
First we wanna check if check if user followed XDG specification for wezterm configuration. If so, we use that path for editing the wezterm config. If not, we fall back to the traditional ~/.wezterm.lua.

Note: Other CLI agents, edit the terminal configurations and not all the time the escape sequence is the same. This can cause a false positive detection of "terminal setup already configured". Maybe we should improve the checking for specific escape sequences. Maybe we can return to the user a more descriptive message about the file edit/check when running `/terminal-setup` command.