### PR TITLE
Fix session_id missing in programmatic streaming output

### DIFF
--- a/tests/test_cli_programmatic_preload.py
+++ b/tests/test_cli_programmatic_preload.py
@@ -13,6 +13,10 @@ from vibe.core.types import LLMMessage, OutputFormat, Role
 class SpyStreamingFormatter:
     def __init__(self) -> None:
         self.emitted: list[tuple[Role, str | None]] = []
+        self.session_id: str | None = None
+
+    def set_session_id(self, session_id: str) -> None:
+        self.session_id = session_id
 
     def on_message_added(self, message: LLMMessage) -> None:
         self.emitted.append((message.role, message.content))

--- a/vibe/core/agent.py
+++ b/vibe/core/agent.py
@@ -97,6 +97,7 @@ class Agent:
         max_price: float | None = None,
         backend: BackendLike | None = None,
         enable_streaming: bool = False,
+        session_id: str | None = None,
     ) -> None:
         """Initialize the agent with configuration and mode."""
         self.config = config
@@ -117,6 +118,8 @@ class Agent:
         self.enable_streaming = enable_streaming
         self._setup_middleware()
 
+        self.session_id = session_id or str(uuid4())
+
         system_prompt = get_universal_system_prompt(
             self.tool_manager, config, self.skill_manager
         )
@@ -135,8 +138,6 @@ class Agent:
             pass
 
         self.approval_callback: ApprovalCallback | None = None
-
-        self.session_id = str(uuid4())
 
         self.interaction_logger = InteractionLogger(
             config.session_logging,

--- a/vibe/core/output_formatters.py
+++ b/vibe/core/output_formatters.py
@@ -13,6 +13,10 @@ class OutputFormatter(ABC):
         self.stream = stream
         self._messages: list[LLMMessage] = []
         self._final_response: str | None = None
+        self.session_id: str | None = None
+
+    def set_session_id(self, session_id: str) -> None:
+        self.session_id = session_id
 
     @abstractmethod
     def on_message_added(self, message: LLMMessage) -> None:
@@ -61,7 +65,10 @@ class JsonOutputFormatter(OutputFormatter):
 
 class StreamingJsonOutputFormatter(OutputFormatter):
     def on_message_added(self, message: LLMMessage) -> None:
-        json.dump(message.model_dump(mode="json"), self.stream)
+        data = message.model_dump(mode="json")
+        if self.session_id:
+            data["session_id"] = self.session_id
+        json.dump(data, self.stream)
         self.stream.write("\n")
         self.stream.flush()
 

--- a/vibe/core/programmatic.py
+++ b/vibe/core/programmatic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from uuid import uuid4
 
 from vibe.core.agent import Agent
 from vibe.core.config import VibeConfig
@@ -33,7 +34,9 @@ def run_programmatic(
     Returns:
         The final assistant response text, or None if no response
     """
+    session_id = str(uuid4())
     formatter = create_formatter(output_format)
+    formatter.set_session_id(session_id)
 
     agent = Agent(
         config,
@@ -42,6 +45,7 @@ def run_programmatic(
         max_turns=max_turns,
         max_price=max_price,
         enable_streaming=False,
+        session_id=session_id,
     )
     logger.info("USER: %s", prompt)
 


### PR DESCRIPTION
Ensures the session_id is included in every chunk of the programmatic streaming output (JSON), starting from the first message.

- Generates ID early in run_programmatic.
- Updates StreamingJsonOutputFormatter to include the field.
- Verified manually and with updated unit tests.

Fixes issue #208 