### PR TITLE
feat: Add rate limit resilience with Retry-After header support

### DIFF
--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,326 @@
+"""Tests for retry functionality with rate limiting support."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from vibe.core.utils import (
+    _get_retry_after_delay,
+    _is_retryable_http_error,
+    async_retry,
+    async_generator_retry,
+)
+
+
+class TestRetryAfterParsing:
+    """Tests for _get_retry_after_delay function."""
+
+    def test_no_retry_after_header(self) -> None:
+        """Should return None when no Retry-After header."""
+        response = MagicMock(spec=httpx.Response)
+        response.headers = {}
+        error = httpx.HTTPStatusError(
+            "Rate limited", request=MagicMock(), response=response
+        )
+        assert _get_retry_after_delay(error) is None
+
+    def test_retry_after_seconds(self) -> None:
+        """Should parse integer seconds from Retry-After header."""
+        response = MagicMock(spec=httpx.Response)
+        response.headers = {"retry-after": "30"}
+        error = httpx.HTTPStatusError(
+            "Rate limited", request=MagicMock(), response=response
+        )
+        assert _get_retry_after_delay(error) == 30.0
+
+    def test_retry_after_float_seconds(self) -> None:
+        """Should parse float seconds from Retry-After header."""
+        response = MagicMock(spec=httpx.Response)
+        response.headers = {"retry-after": "1.5"}
+        error = httpx.HTTPStatusError(
+            "Rate limited", request=MagicMock(), response=response
+        )
+        assert _get_retry_after_delay(error) == 1.5
+
+    def test_retry_after_http_date(self) -> None:
+        """Should parse HTTP-date from Retry-After header."""
+        future_time = datetime.now(timezone.utc) + timedelta(seconds=60)
+        http_date = future_time.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+        response = MagicMock(spec=httpx.Response)
+        response.headers = {"retry-after": http_date}
+        error = httpx.HTTPStatusError(
+            "Rate limited", request=MagicMock(), response=response
+        )
+
+        delay = _get_retry_after_delay(error)
+        assert delay is not None
+        assert 55 <= delay <= 65  # Allow some tolerance
+
+    def test_retry_after_invalid_value(self) -> None:
+        """Should return None for invalid Retry-After value."""
+        response = MagicMock(spec=httpx.Response)
+        response.headers = {"retry-after": "invalid"}
+        error = httpx.HTTPStatusError(
+            "Rate limited", request=MagicMock(), response=response
+        )
+        assert _get_retry_after_delay(error) is None
+
+    def test_non_http_error(self) -> None:
+        """Should return None for non-HTTP errors."""
+        error = ValueError("Not an HTTP error")
+        assert _get_retry_after_delay(error) is None
+
+
+class TestIsRetryableHttpError:
+    """Tests for _is_retryable_http_error function."""
+
+    @pytest.mark.parametrize(
+        "status_code,expected",
+        [
+            (408, True),  # Request Timeout
+            (409, True),  # Conflict
+            (425, True),  # Too Early
+            (429, True),  # Too Many Requests
+            (500, True),  # Internal Server Error
+            (502, True),  # Bad Gateway
+            (503, True),  # Service Unavailable
+            (504, True),  # Gateway Timeout
+            (400, False),  # Bad Request
+            (401, False),  # Unauthorized
+            (403, False),  # Forbidden
+            (404, False),  # Not Found
+            (200, False),  # OK
+        ],
+    )
+    def test_status_codes(self, status_code: int, expected: bool) -> None:
+        """Should correctly identify retryable status codes."""
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = status_code
+        error = httpx.HTTPStatusError(
+            f"Error {status_code}", request=MagicMock(), response=response
+        )
+        assert _is_retryable_http_error(error) == expected
+
+    def test_non_http_error(self) -> None:
+        """Should return False for non-HTTP errors."""
+        assert _is_retryable_http_error(ValueError("Not HTTP")) is False
+
+
+class TestAsyncRetry:
+    """Tests for async_retry decorator."""
+
+    @pytest.mark.asyncio
+    async def test_success_no_retry(self) -> None:
+        """Should return result on success without retry."""
+        call_count = 0
+
+        @async_retry(tries=3)
+        async def successful_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "success"
+
+        result = await successful_func()
+        assert result == "success"
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_on_429(self) -> None:
+        """Should retry on 429 status code."""
+        call_count = 0
+
+        @async_retry(tries=3, delay_seconds=0.01)
+        async def flaky_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                response = MagicMock(spec=httpx.Response)
+                response.status_code = 429
+                response.headers = {}
+                raise httpx.HTTPStatusError(
+                    "Rate limited", request=MagicMock(), response=response
+                )
+            return "success"
+
+        result = await flaky_func()
+        assert result == "success"
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_max_retries_exceeded(self) -> None:
+        """Should raise after max retries exceeded."""
+        call_count = 0
+
+        @async_retry(tries=2, delay_seconds=0.01)
+        async def always_fails() -> str:
+            nonlocal call_count
+            call_count += 1
+            response = MagicMock(spec=httpx.Response)
+            response.status_code = 429
+            response.headers = {}
+            raise httpx.HTTPStatusError(
+                "Rate limited", request=MagicMock(), response=response
+            )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await always_fails()
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_error_not_retried(self) -> None:
+        """Should not retry non-retryable errors."""
+        call_count = 0
+
+        @async_retry(tries=3, delay_seconds=0.01)
+        async def bad_request() -> str:
+            nonlocal call_count
+            call_count += 1
+            response = MagicMock(spec=httpx.Response)
+            response.status_code = 400  # Not retryable
+            response.headers = {}
+            raise httpx.HTTPStatusError(
+                "Bad request", request=MagicMock(), response=response
+            )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await bad_request()
+        assert call_count == 1  # No retries
+
+    @pytest.mark.asyncio
+    async def test_respects_max_delay(self) -> None:
+        """Should cap delay at max_delay."""
+        sleep_calls: list[float] = []
+
+        async def mock_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        call_count = 0
+
+        @async_retry(
+            tries=3,
+            delay_seconds=100.0,  # Very high initial delay
+            backoff_factor=2.0,
+            max_delay=0.5,  # But capped at 0.5s
+        )
+        async def timed_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                response = MagicMock(spec=httpx.Response)
+                response.status_code = 429
+                response.headers = {}
+                raise httpx.HTTPStatusError(
+                    "Rate limited", request=MagicMock(), response=response
+                )
+            return "success"
+
+        with patch("vibe.core.utils.asyncio.sleep", mock_sleep):
+            result = await timed_func()
+
+        assert result == "success"
+        assert call_count == 3
+        # Check that delays were capped at max_delay
+        for delay in sleep_calls:
+            assert delay <= 0.5
+
+    @pytest.mark.asyncio
+    async def test_respects_retry_after_header(self) -> None:
+        """Should use Retry-After header value when present."""
+        sleep_calls: list[float] = []
+
+        async def mock_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        call_count = 0
+
+        @async_retry(tries=3, delay_seconds=0.1, max_delay=60.0)
+        async def rate_limited_func() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                response = MagicMock(spec=httpx.Response)
+                response.status_code = 429
+                response.headers = {"retry-after": "5"}
+                raise httpx.HTTPStatusError(
+                    "Rate limited", request=MagicMock(), response=response
+                )
+            return "success"
+
+        with patch("vibe.core.utils.asyncio.sleep", mock_sleep):
+            result = await rate_limited_func()
+
+        assert result == "success"
+        # The delay should be based on Retry-After (5s) plus small jitter
+        assert len(sleep_calls) == 1
+        assert 5.0 <= sleep_calls[0] <= 5.5
+
+
+class TestAsyncGeneratorRetry:
+    """Tests for async_generator_retry decorator."""
+
+    @pytest.mark.asyncio
+    async def test_success_no_retry(self) -> None:
+        """Should yield all items on success without retry."""
+        call_count = 0
+
+        @async_generator_retry(tries=3)
+        async def gen_func():
+            nonlocal call_count
+            call_count += 1
+            for i in range(3):
+                yield i
+
+        results = [item async for item in gen_func()]
+        assert results == [0, 1, 2]
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_on_error(self) -> None:
+        """Should retry generator on retryable error."""
+        call_count = 0
+
+        @async_generator_retry(tries=3, delay_seconds=0.01)
+        async def flaky_gen():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                response = MagicMock(spec=httpx.Response)
+                response.status_code = 429
+                response.headers = {}
+                raise httpx.HTTPStatusError(
+                    "Rate limited", request=MagicMock(), response=response
+                )
+            for i in range(3):
+                yield i
+
+        results = [item async for item in flaky_gen()]
+        assert results == [0, 1, 2]
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_max_retries_exceeded(self) -> None:
+        """Should raise after max retries exceeded."""
+        call_count = 0
+
+        @async_generator_retry(tries=2, delay_seconds=0.01)
+        async def always_fails():
+            nonlocal call_count
+            call_count += 1
+            response = MagicMock(spec=httpx.Response)
+            response.status_code = 429
+            response.headers = {}
+            raise httpx.HTTPStatusError(
+                "Rate limited", request=MagicMock(), response=response
+            )
+            yield  # Never reached
+
+        with pytest.raises(httpx.HTTPStatusError):
+            async for _ in always_fails():
+                pass
+        assert call_count == 2

--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -371,7 +371,7 @@ class GenericBackend:
         data: dict[str, Any]
         headers: dict[str, str]
 
-    @async_retry(tries=3)
+    @async_retry(tries=5, delay_seconds=1.0, backoff_factor=2.0, max_delay=60.0)
     async def _make_request(
         self, url: str, data: bytes, headers: dict[str, str]
     ) -> HTTPResponse:
@@ -383,7 +383,7 @@ class GenericBackend:
         response_body = response.json()
         return self.HTTPResponse(response_body, response_headers)
 
-    @async_generator_retry(tries=3)
+    @async_generator_retry(tries=5, delay_seconds=1.0, backoff_factor=2.0, max_delay=60.0)
     async def _make_streaming_request(
         self, url: str, data: bytes, headers: dict[str, str]
     ) -> AsyncGenerator[dict[str, Any]]:

--- a/vibe/core/utils.py
+++ b/vibe/core/utils.py
@@ -7,6 +7,7 @@ from enum import Enum, auto
 import functools
 import logging
 from pathlib import Path
+import random
 import re
 import sys
 from typing import Any
@@ -160,16 +161,55 @@ def _is_retryable_http_error(e: Exception) -> bool:
     return False
 
 
+def _get_retry_after_delay(e: Exception) -> float | None:
+    """Extract delay from Retry-After header if present.
+
+    The Retry-After header can be either:
+    - An integer representing seconds to wait
+    - An HTTP-date representing when to retry
+
+    Returns the delay in seconds, or None if not present/parseable.
+    """
+    if not isinstance(e, httpx.HTTPStatusError):
+        return None
+
+    retry_after = e.response.headers.get("retry-after")
+    if not retry_after:
+        return None
+
+    try:
+        return float(retry_after)
+    except ValueError:
+        pass
+
+    from email.utils import parsedate_to_datetime
+    from datetime import datetime, timezone
+
+    try:
+        retry_date = parsedate_to_datetime(retry_after)
+        now = datetime.now(timezone.utc)
+        delay = (retry_date - now).total_seconds()
+        return max(0.0, delay)
+    except (ValueError, TypeError):
+        return None
+
+
 def async_retry[T, **P](
     tries: int = 3,
     delay_seconds: float = 0.5,
     backoff_factor: float = 2.0,
+    max_delay: float = 60.0,
+    respect_retry_after: bool = True,
     is_retryable: Callable[[Exception], bool] = _is_retryable_http_error,
 ) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
-    """Args:
+    """Retry decorator with exponential backoff and Retry-After header support.
+
+    Args:
         tries: Number of retry attempts
         delay_seconds: Initial delay between retries in seconds
         backoff_factor: Multiplier for delay on each retry
+        max_delay: Maximum delay in seconds between retries
+        respect_retry_after: Whether to respect the Retry-After header from server
         is_retryable: Function to determine if an exception should trigger a retry
                      (defaults to checking for retryable HTTP errors from both urllib and httpx)
 
@@ -187,9 +227,26 @@ def async_retry[T, **P](
                 except Exception as e:
                     last_exc = e
                     if attempt < tries - 1 and is_retryable(e):
-                        current_delay = (delay_seconds * (backoff_factor**attempt)) + (
-                            0.05 * attempt
-                        )
+                        base_delay = delay_seconds * (backoff_factor**attempt)
+                        jitter = random.uniform(0, 0.1 * base_delay)
+
+                        if respect_retry_after:
+                            retry_after = _get_retry_after_delay(e)
+                            if retry_after is not None:
+                                current_delay = min(retry_after + jitter, max_delay)
+                                logger.info(
+                                    f"Rate limited. Retry-After header suggests {retry_after:.1f}s. "
+                                    f"Waiting {current_delay:.1f}s (attempt {attempt + 1}/{tries})"
+                                )
+                            else:
+                                current_delay = min(base_delay + jitter, max_delay)
+                                logger.info(
+                                    f"Request failed, retrying in {current_delay:.1f}s "
+                                    f"(attempt {attempt + 1}/{tries})"
+                                )
+                        else:
+                            current_delay = min(base_delay + jitter, max_delay)
+
                         await asyncio.sleep(current_delay)
                         continue
                     raise e
@@ -206,14 +263,18 @@ def async_generator_retry[T, **P](
     tries: int = 3,
     delay_seconds: float = 0.5,
     backoff_factor: float = 2.0,
+    max_delay: float = 60.0,
+    respect_retry_after: bool = True,
     is_retryable: Callable[[Exception], bool] = _is_retryable_http_error,
 ) -> Callable[[Callable[P, AsyncGenerator[T]]], Callable[P, AsyncGenerator[T]]]:
-    """Retry decorator for async generators.
+    """Retry decorator for async generators with exponential backoff and Retry-After support.
 
     Args:
         tries: Number of retry attempts
         delay_seconds: Initial delay between retries in seconds
         backoff_factor: Multiplier for delay on each retry
+        max_delay: Maximum delay in seconds between retries
+        respect_retry_after: Whether to respect the Retry-After header from server
         is_retryable: Function to determine if an exception should trigger a retry
                      (defaults to checking for retryable HTTP errors from both urllib and httpx)
 
@@ -235,9 +296,26 @@ def async_generator_retry[T, **P](
                 except Exception as e:
                     last_exc = e
                     if attempt < tries - 1 and is_retryable(e):
-                        current_delay = (delay_seconds * (backoff_factor**attempt)) + (
-                            0.05 * attempt
-                        )
+                        base_delay = delay_seconds * (backoff_factor**attempt)
+                        jitter = random.uniform(0, 0.1 * base_delay)
+
+                        if respect_retry_after:
+                            retry_after = _get_retry_after_delay(e)
+                            if retry_after is not None:
+                                current_delay = min(retry_after + jitter, max_delay)
+                                logger.info(
+                                    f"Rate limited. Retry-After header suggests {retry_after:.1f}s. "
+                                    f"Waiting {current_delay:.1f}s (attempt {attempt + 1}/{tries})"
+                                )
+                            else:
+                                current_delay = min(base_delay + jitter, max_delay)
+                                logger.info(
+                                    f"Request failed, retrying in {current_delay:.1f}s "
+                                    f"(attempt {attempt + 1}/{tries})"
+                                )
+                        else:
+                            current_delay = min(base_delay + jitter, max_delay)
+
                         await asyncio.sleep(current_delay)
                         continue
                     raise e


### PR DESCRIPTION
## Summary

This PR improves the retry mechanism for rate-limited API requests, addressing issue #264.

### Changes

- **Retry-After header support**: The retry decorators now parse and respect the `Retry-After` header from server responses, supporting both seconds and HTTP-date formats
- **Improved defaults**: Increased retry attempts from 3 to 5 with better backoff settings (1s initial delay, 2x backoff, 60s max)
- **Random jitter**: Added randomized jitter to prevent thundering herd problems when multiple clients retry simultaneously
- **Observability**: Added logging for retry attempts so users can see when rate limiting occurs
- **Comprehensive tests**: Added test suite covering all retry scenarios

### Retry Behavior

When a retryable error occurs (429, 500, 502, 503, 504, etc.):
1. If server sends `Retry-After` header, waits that duration (plus small jitter)
2. Otherwise, uses exponential backoff: 1s → 2s → 4s → 8s → 16s (capped at 60s)
3. Each delay includes random jitter (0-10% of base delay) to distribute retries

### Test Plan

- [x] Unit tests for `_get_retry_after_delay` function (seconds, HTTP-date, invalid values)
- [x] Unit tests for `_is_retryable_http_error` function (all status codes)
- [x] Integration tests for `async_retry` decorator (success, retry on 429, max retries, non-retryable errors)
- [x] Integration tests for `async_generator_retry` decorator
- [x] Tests for max_delay cap and Retry-After header handling

Closes #264