### PR TITLE
Fix(docs): link to main README in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Mistral Vibe Documentation
 
-Welcome to the Mistral Vibe documentation! For basic setup, see the [main README](https://github.com/mistral-vibe/mistral-vibe#readme).
+Welcome to the Mistral Vibe documentation! For basic setup, see the [main README](https://github.com/mistralai/mistral-vibe#readme).
 
 ## Available Documentation
 


### PR DESCRIPTION
Broken link in `/docs` pointing to a wrong URL instead of the main README.md section.

Before:

https://github.com/mistral-vibe/mistral-vibe#readme

After (fix):

https://github.com/mistralai/mistral-vibe#readme