### PR TITLE
Add Easter egg message to loading.py, for sure

### DIFF
--- a/vibe/cli/textual_ui/widgets/loading.py
+++ b/vibe/cli/textual_ui/widgets/loading.py
@@ -31,6 +31,7 @@ class LoadingWidget(SpinnerMixin, Static):
         "Vibing",
         "Sending good vibes",
         "Petting le chat",
+        "\"Sometimes is too slow, for sure\""
     ]
 
     EASTER_EGGS_HALLOWEEN: ClassVar[list[str]] = [


### PR DESCRIPTION
* Adding "Sometimes is too slow, for sure" reference to Macron's speech in Davos.

* Quotes ".." are kept for reference accuracy.

* Reasons: 
- it became a big enough meme to have its space in these easter eggs.
- it is relative to time and waiting: perfect for loading.