### PR TITLE
Prevent asyncio task from being garbage-collected

### DIFF
--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -1158,7 +1158,7 @@ class VibeApp(App):  # noqa: PLR0904
         if self._update_notifier is None or not self.config.enable_update_checks:
             return
 
-        asyncio.create_task(self._check_update(), name="version-update-check")
+        self._update_task = asyncio.create_task(self._check_update(), name="version-update-check")
 
     async def _check_update(self) -> None:
         try:


### PR DESCRIPTION
This PR keeps a reference to the task, otherwise it might just disappear (see [here](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task)).