### PR TITLE
Fix SessionLogger O(N^2) performance bug

### DIFF
--- a/tests/session/test_session_logger.py
+++ b/tests/session/test_session_logger.py
@@ -349,6 +349,19 @@ class TestSessionLoggerSaveInteraction:
             assert metadata["total_messages"] == 4
             assert metadata["stats"]["steps"] == updated_stats.steps
 
+        # Verify messages file content to ensure no duplicates
+        messages_file = logger.session_dir / "messages.jsonl"
+        with open(messages_file) as f:
+            lines = f.readlines()
+            # Initial (User, Assistant) + New (User, Assistant) = 4 lines
+            assert len(lines) == 4
+
+            messages_data = [json.loads(line) for line in lines]
+            assert messages_data[0]["content"] == "Hello"
+            assert messages_data[1]["content"] == "Hi there!"
+            assert messages_data[2]["content"] == "How are you?"
+            assert messages_data[3]["content"] == "I'm fine, thanks!"
+
     @pytest.mark.asyncio
     async def test_save_interaction_no_user_messages(
         self,

--- a/vibe/core/session/session_logger.py
+++ b/vibe/core/session/session_logger.py
@@ -233,7 +233,11 @@ class SessionLogger:
 
         try:
             # Append new messages
-            new_messages = messages[old_total_messages:]
+            start_index = old_total_messages
+            if messages and messages[0].role == Role.system:
+                start_index += 1
+
+            new_messages = messages[start_index:]
 
             messages_data = [
                 m.model_dump(exclude_none=True)


### PR DESCRIPTION
A bug in session_logger results in the complete message history being appended instead of just the new messages.
Because of this bug, what should be O(N) becomes O(N^2), resulting in increased resource usage and performance degradation over time.