### PR TITLE
fix: support FIFO files when loading .env

### DIFF
--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -34,7 +34,7 @@ def load_dotenv_values(
     env_path: Path = GLOBAL_ENV_FILE.path,
     environ: MutableMapping[str, str] = os.environ,
 ) -> None:
-    if not env_path.is_file():
+    if not (env_path.is_file() or env_path.is_fifo()):
         return
 
     env_vars = dotenv_values(env_path)


### PR DESCRIPTION
Check for both regular files and named pipes (FIFOs) when loading .env files. This allows 1Password's local-env file feature to work correctly.

Fixes #302