### PR TITLE
Fix token counting bug in streaming inference

### DIFF
--- a/vibe/core/agent_loop.py
+++ b/vibe/core/agent_loop.py
@@ -691,7 +691,6 @@ class AgentLoop:
         tool_choice = self.format_handler.get_tool_choice()
         try:
             start_time = time.perf_counter()
-            usage = LLMUsage()
             chunk_agg = LLMChunk(message=LLMMessage(role=Role.assistant))
             async for chunk in self.backend.complete_streaming(
                 model=active_model,
@@ -710,7 +709,6 @@ class AgentLoop:
                 )
                 processed_chunk = LLMChunk(message=processed_message, usage=chunk.usage)
                 chunk_agg += processed_chunk
-                usage += chunk.usage or LLMUsage()
                 yield processed_chunk
             end_time = time.perf_counter()
 
@@ -718,7 +716,7 @@ class AgentLoop:
                 raise AgentLoopLLMResponseError(
                     "Usage data missing in final chunk of streamed completion"
                 )
-            self._update_stats(usage=usage, time_seconds=end_time - start_time)
+            self._update_stats(usage=chunk_agg.usage, time_seconds=end_time - start_time)
 
             self.messages.append(chunk_agg.message)
 

--- a/vibe/core/types.py
+++ b/vibe/core/types.py
@@ -288,10 +288,9 @@ class LLMChunk(BaseModel):
     usage: LLMUsage | None = None
 
     def __add__(self, other: LLMChunk) -> LLMChunk:
-        if self.usage is None and other.usage is None:
-            new_usage = None
-        else:
-            new_usage = (self.usage or LLMUsage()) + (other.usage or LLMUsage())
+        # For usage, take the latest (other) since SSE chunks have cumulative totals
+        # Don't accumulate - just use the most recent usage data
+        new_usage = other.usage if other.usage is not None else self.usage
         return LLMChunk(message=self.message + other.message, usage=new_usage)
 
 


### PR DESCRIPTION
## Bug Description

During streaming inference with slow models, Vibe was dramatically overcounting tokens, triggering unnecessary compaction. For example:
- Actual context: ~7,640 tokens
- Vibe counted: 354,033 tokens
- Result: "Compaction complete: 354,033 → 7,640 tokens (-98%)"

## Root Cause

Vibe was accumulating token usage from **every SSE streaming chunk** instead of using only the final chunk's totals.

During streaming, each SSE chunk contains cumulative usage data:
```json
{"usage": {"prompt_tokens": 100, "completion_tokens": 1}}
{"usage": {"prompt_tokens": 100, "completion_tokens": 2}}
{"usage": {"prompt_tokens": 100, "completion_tokens": 3}}
...
{"usage": {"prompt_tokens": 100, "completion_tokens": 50}}
```

The `LLMChunk.__add__` method was adding these cumulative values together, causing massive overcounting after 1000+ chunks.

## Changes

### `vibe/core/types.py`
Modified `LLMChunk.__add__` to use the latest (other) usage data instead of accumulating across chunks.

### `vibe/core/agent_loop.py`
- Removed separate `usage` variable in `_chat_streaming`
- Changed `_update_stats` to use `chunk_agg.usage` (final chunk's usage)

## Test plan

After applying this fix:
1. Run Vibe with a slow model that produces many streaming chunks
2. Verify that token counts are accurate (no massive overcounting)
3. Verify compaction only triggers when actually needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)