### PR TITLE
fix: avoid reloading MCP tools when switching agent modes

### DIFF
--- a/tests/test_agent_stats.py
+++ b/tests/test_agent_stats.py
@@ -684,18 +684,22 @@ class TestStatsEdgeCases:
         backend = FakeBackend([])
         original_config = make_config(active_model="devstral-latest")
         agent = build_test_agent_loop(config=original_config, backend=backend)
+        original_tool_manager = agent.tool_manager
 
         await agent.reload_with_initial_messages(base_config=None)
 
         assert agent.config.active_model == "devstral-latest"
+        assert agent.tool_manager is original_tool_manager
 
     @pytest.mark.asyncio
     async def test_reload_with_new_config_updates_it(self) -> None:
         backend = FakeBackend([])
         original_config = make_config(active_model="devstral-latest")
         agent = build_test_agent_loop(config=original_config, backend=backend)
+        original_tool_manager = agent.tool_manager
 
         new_config = make_config(active_model="devstral-small")
         await agent.reload_with_initial_messages(base_config=new_config)
 
         assert agent.config.active_model == "devstral-small"
+        assert agent.tool_manager is not original_tool_manager

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -377,6 +377,19 @@ class TestAgentSwitchAgent:
         assert agent.config is original_config
         assert agent.agent_profile.name == BuiltinAgentName.DEFAULT
 
+    @pytest.mark.asyncio
+    async def test_switch_agent_reuses_tool_manager_instance(
+        self, base_config: VibeConfig, backend: FakeBackend
+    ) -> None:
+        agent = build_test_agent_loop(
+            config=base_config, agent_name=BuiltinAgentName.DEFAULT, backend=backend
+        )
+        original_tool_manager = agent.tool_manager
+
+        await agent.switch_agent(BuiltinAgentName.PLAN)
+
+        assert agent.tool_manager is original_tool_manager
+
 
 class TestAcceptEditsAgent:
     def test_accept_edits_config_sets_write_file_always(self) -> None:

--- a/vibe/core/agent_loop.py
+++ b/vibe/core/agent_loop.py
@@ -988,8 +988,10 @@ class AgentLoop:
         if max_price is not None:
             self._max_price = max_price
 
-        self.tool_manager = ToolManager(lambda: self.config)
-        self.skill_manager = SkillManager(lambda: self.config)
+        should_rebuild_managers = base_config is not None
+        if should_rebuild_managers:
+            self.tool_manager = ToolManager(lambda: self.config)
+            self.skill_manager = SkillManager(lambda: self.config)
 
         new_system_prompt = get_universal_system_prompt(
             self.tool_manager, self.config, self.skill_manager, self.agent_manager


### PR DESCRIPTION
### Summary
- Fixes repeated MCP discovery/re-execution when switching between built-in modes (e.g. `default`, `plan`, `auto-approve`, `accept-edits`).
- Keeps MCP/tool initialization stable across mode switches by reusing the existing `ToolManager`/`SkillManager` when no base config reload is requested.
- Preserves current behavior for explicit config reloads: when `base_config` changes, managers are rebuilt so config-driven updates still apply.
 ### Problem
Switching agent modes currently reconstructs tool infrastructure, which re-runs MCP server discovery commands.  
This adds avoidable latency and makes mode transitions noisy and frustrating, even though MCP setup should be startup-scoped for a running app/session.
 ### Solution
- Updated `AgentLoop.reload_with_initial_messages()` to conditionally rebuild managers only when `base_config` is provided.
- Mode switches (`switch_agent`) now regenerate prompts/config view without reinitializing MCP integrations.
- Explicit reload paths (e.g. config/model reload) still rebuild managers to pick up new configuration safely.
 ### Tests
Added regression coverage to verify lifecycle behavior:
- mode switch reuses the same `ToolManager` instance
- reload without `base_config` preserves the existing `ToolManager`
- reload with a new `base_config` creates a new `ToolManager`
###  Why this is safe
- This change only alters manager rebuild conditions, not MCP tool call execution logic.
- Existing config reload semantics remain intact.
- New tests lock in expected behavior for both reuse and rebuild paths.
 User impact
- Faster mode switching
- No repeated config defined mcp command execution on every mode change