### PR TITLE
feat: Automatically strip trailing whitespace from file writes

### DIFF
--- a/tests/test_write_file_trailing_whitespace.py
+++ b/tests/test_write_file_trailing_whitespace.py
@@ -1,0 +1,84 @@
+"""Test that write_file tool strips trailing whitespace."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from vibe.core.tools.builtins.write_file import (
+    WriteFile, 
+    WriteFileArgs, 
+    WriteFileConfig, 
+    WriteFileState
+)
+
+
+@pytest.fixture
+def write_file_tool(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> WriteFile:
+    """Create a WriteFile tool instance with default config and state."""
+    # Change working directory to tmp_path to allow writing files there
+    monkeypatch.chdir(tmp_path)
+    config = WriteFileConfig()
+    state = WriteFileState()
+    return WriteFile(config=config, state=state)
+
+
+class TestWriteFileTrailingWhitespace:
+    @pytest.mark.asyncio
+    async def test_strips_trailing_whitespace(self, tmp_path: Path, write_file_tool: WriteFile) -> None:
+        """Test that write_file automatically strips trailing whitespace."""
+        test_file = tmp_path / "test.txt"
+        
+        # Content with trailing whitespace
+        content_with_whitespace = "line1  \nline2  \nline3"
+        args = WriteFileArgs(path=str(test_file), content=content_with_whitespace, overwrite=True)
+        
+        result = await write_file_tool.run(args).__anext__()
+        
+        # Read the written file
+        written_content = test_file.read_text()
+        
+        # Verify trailing whitespace was stripped
+        assert written_content == "line1\nline2\nline3"
+        assert "  \n" not in written_content
+        assert "  " not in written_content  # No trailing spaces at end of lines
+        
+    @pytest.mark.asyncio
+    async def test_preserves_line_structure(self, tmp_path: Path, write_file_tool: WriteFile) -> None:
+        """Test that write_file preserves line structure while stripping trailing whitespace."""
+        test_file = tmp_path / "test.txt"
+        
+        # Content with mixed whitespace and empty lines
+        content = "header  \n  \ncontent  \n  \nfooter"
+        args = WriteFileArgs(path=str(test_file), content=content, overwrite=True)
+        
+        result = await write_file_tool.run(args).__anext__()
+        
+        # Read the written file
+        written_content = test_file.read_text()
+        
+        # Verify structure is preserved but trailing whitespace stripped
+        lines = written_content.split('\n')
+        assert lines == ['header', '', 'content', '', 'footer']
+        assert all(line == line.rstrip() for line in lines)  # No line has trailing whitespace
+        
+    @pytest.mark.asyncio
+    async def test_strips_whitespace_method(self, write_file_tool: WriteFile) -> None:
+        """Test the _strip_trailing_whitespace method directly."""
+        # Test various whitespace patterns
+        test_cases = [
+            ("hello  \nworld  ", "hello\nworld"),
+            ("line1  \n  \nline2  ", "line1\n\nline2"),
+            ("no_whitespace", "no_whitespace"),
+            ("  leading_and_trailing  ", "  leading_and_trailing"),  # Only trailing stripped
+            ("", ""),
+            ("\n", "\n"),  # Single newline preserved
+        ]
+        
+        for input_text, expected in test_cases:
+            result = write_file_tool._strip_trailing_whitespace(input_text)
+            assert result == expected, f"Failed for input: {input_text!r}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vibe/acp/tools/builtins/write_file.py
+++ b/vibe/acp/tools/builtins/write_file.py
@@ -42,8 +42,11 @@ class WriteFile(CoreWriteFileTool, BaseAcpTool[AcpWriteFileState]):
         await self._send_in_progress_session_update()
 
         try:
+            # Strip trailing whitespace from each line while preserving line structure
+            content_to_write = self._strip_trailing_whitespace(args.content)
+            
             await client.write_text_file(
-                session_id=session_id, path=str(file_path), content=args.content
+                session_id=session_id, path=str(file_path), content=content_to_write
             )
         except Exception as e:
             raise ToolError(f"Error writing {file_path}: {e}") from e

--- a/vibe/core/tools/builtins/write_file.py
+++ b/vibe/core/tools/builtins/write_file.py
@@ -152,9 +152,19 @@ class WriteFile(
 
     async def _write_file(self, args: WriteFileArgs, file_path: Path) -> None:
         try:
+            # Strip trailing whitespace from each line while preserving line structure
+            content_to_write = self._strip_trailing_whitespace(args.content)
+            
             async with await anyio.Path(file_path).open(
                 mode="w", encoding="utf-8"
             ) as f:
-                await f.write(args.content)
+                await f.write(content_to_write)
         except Exception as e:
             raise ToolError(f"Error writing {file_path}: {e}") from e
+
+    @staticmethod
+    def _strip_trailing_whitespace(content: str) -> str:
+        """Strip trailing whitespace from each line while preserving line structure."""
+        lines = content.split('\n')
+        stripped_lines = [line.rstrip() for line in lines]
+        return '\n'.join(stripped_lines)


### PR DESCRIPTION
This enhancement ensures that all file writing operations automatically remove
 trailing whitespace from each line, improving code hygiene and consistency.

Changes:
- Modified write_file tool to strip trailing whitespace before writing files
- Updated ACP write_file tool for consistency
- Added comprehensive tests to verify the functionality
- Preserves line structure and indentation while only removing trailing spaces

This provides end-to-end trailing whitespace management across all file
 modification pathways in the codebase.