### PR TITLE
Fix telemetry configuration consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Google Vertex AI support
-- Telemetry: user interaction and tool usage events sent to datalake (configurable via `disable_telemetry`)
+- Telemetry: user interaction and tool usage events sent to datalake (configurable via `enable_telemetry`)
 - Skill discovery from `.agents/skills/` (Agent Skills standard) in addition to `.vibe/skills/`
 - ACP: `session/load` and `session/list` for loading and listing sessions
 - New model behavior prompts (CLI and explore)

--- a/tests/core/test_telemetry_send.py
+++ b/tests/core/test_telemetry_send.py
@@ -47,7 +47,7 @@ class TestTelemetryClient:
     def test_send_telemetry_event_does_nothing_when_api_key_is_none(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        config = build_test_vibe_config(disable_telemetry=False)
+        config = build_test_vibe_config(enable_telemetry=True)
         env_key = config.get_provider_for_model(
             config.get_active_model()
         ).api_key_env_var
@@ -65,7 +65,7 @@ class TestTelemetryClient:
     def test_send_telemetry_event_does_nothing_when_disabled(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        config = build_test_vibe_config(disable_telemetry=True)
+        config = build_test_vibe_config(enable_telemetry=False)
         env_key = config.get_provider_for_model(
             config.get_active_model()
         ).api_key_env_var
@@ -86,7 +86,7 @@ class TestTelemetryClient:
         monkeypatch.setattr(
             TelemetryClient, "send_telemetry_event", _original_send_telemetry_event
         )
-        config = build_test_vibe_config(disable_telemetry=False)
+        config = build_test_vibe_config(enable_telemetry=True)
         env_key = config.get_provider_for_model(
             config.get_active_model()
         ).api_key_env_var
@@ -113,7 +113,7 @@ class TestTelemetryClient:
     def test_send_tool_call_finished_payload_shape(
         self, telemetry_events: list[dict[str, Any]]
     ) -> None:
-        config = build_test_vibe_config(disable_telemetry=False)
+        config = build_test_vibe_config(enable_telemetry=True)
         client = TelemetryClient(config_getter=lambda: config)
         tool_call = _make_resolved_tool_call("todo", {})
         decision = ToolDecision(
@@ -142,7 +142,7 @@ class TestTelemetryClient:
     def test_send_tool_call_finished_nb_files_created_write_file_new(
         self, telemetry_events: list[dict[str, Any]]
     ) -> None:
-        config = build_test_vibe_config(disable_telemetry=False)
+        config = build_test_vibe_config(enable_telemetry=True)
         client = TelemetryClient(config_getter=lambda: config)
         tool_call = _make_resolved_tool_call("write_file", {"overwrite": False})
 
@@ -160,7 +160,7 @@ class TestTelemetryClient:
     def test_send_tool_call_finished_nb_files_modified_write_file_overwrite(
         self, telemetry_events: list[dict[str, Any]]
     ) -> None:
-        config = build_test_vibe_config(disable_telemetry=False)
+        config = build_test_vibe_config(enable_telemetry=True)
         client = TelemetryClient(config_getter=lambda: config)
         tool_call = _make_resolved_tool_call("write_file", {"overwrite": True})
 
@@ -178,7 +178,7 @@ class TestTelemetryClient:
     def test_send_tool_call_finished_decision_none(
         self, telemetry_events: list[dict[str, Any]]
     ) -> None:
-        config = build_test_vibe_config(disable_telemetry=False)
+        config = build_test_vibe_config(enable_telemetry=True)
         client = TelemetryClient(config_getter=lambda: config)
         tool_call = _make_resolved_tool_call("todo", {})
 
@@ -195,7 +195,7 @@ class TestTelemetryClient:
     def test_send_user_copied_text_payload(
         self, telemetry_events: list[dict[str, Any]]
     ) -> None:
-        config = build_test_vibe_config(disable_telemetry=False)
+        config = build_test_vibe_config(enable_telemetry=True)
         client = TelemetryClient(config_getter=lambda: config)
 
         client.send_user_copied_text("hello world")
@@ -207,7 +207,7 @@ class TestTelemetryClient:
     def test_send_user_cancelled_action_payload(
         self, telemetry_events: list[dict[str, Any]]
     ) -> None:
-        config = build_test_vibe_config(disable_telemetry=False)
+        config = build_test_vibe_config(enable_telemetry=True)
         client = TelemetryClient(config_getter=lambda: config)
 
         client.send_user_cancelled_action("interrupt_agent")
@@ -219,7 +219,7 @@ class TestTelemetryClient:
     def test_send_auto_compact_triggered_payload(
         self, telemetry_events: list[dict[str, Any]]
     ) -> None:
-        config = build_test_vibe_config(disable_telemetry=False)
+        config = build_test_vibe_config(enable_telemetry=True)
         client = TelemetryClient(config_getter=lambda: config)
 
         client.send_auto_compact_triggered()
@@ -230,7 +230,7 @@ class TestTelemetryClient:
     def test_send_slash_command_used_payload(
         self, telemetry_events: list[dict[str, Any]]
     ) -> None:
-        config = build_test_vibe_config(disable_telemetry=False)
+        config = build_test_vibe_config(enable_telemetry=True)
         client = TelemetryClient(config_getter=lambda: config)
 
         client.send_slash_command_used("help", "builtin")
@@ -246,7 +246,7 @@ class TestTelemetryClient:
     def test_send_new_session_payload(
         self, telemetry_events: list[dict[str, Any]]
     ) -> None:
-        config = build_test_vibe_config(disable_telemetry=False)
+        config = build_test_vibe_config(enable_telemetry=True)
         client = TelemetryClient(config_getter=lambda: config)
 
         client.send_new_session(

--- a/vibe/whats_new.md
+++ b/vibe/whats_new.md
@@ -2,4 +2,4 @@
 
 - **Agent Skills standard** — Vibe now discovers skills from `.agents/skills/` (agentskills.io) as well as `.vibe/skills/`.
 
-Optional: usage and tool events are sent to our datalake to improve the product if you have a valid Mistral API key; set `disable_telemetry = true` in config to opt out.
+Optional: usage and tool events are sent to our datalake to improve the product if you have a valid Mistral API key; set `enable_telemetry = false` in config to opt out.


### PR DESCRIPTION
I found that in the whats_new.md is written that telemetry could be disabled by setting `disable_telemetry = true` in the configuration file. The configuration object `VibeConfig` does not have this field but it has `enable_telemetry`. This PR fixes this.

- Correct documentation to use `enable_telemetry` instead of `disable_telemetry`
- Update tests to use `enable_telemetry` field which actually exists in VibeConfig
- Ensure consistency between documentation, tests, and implementation

The correct way to disable telemetry is now:
- Config: `enable_telemetry = false`
- Environment: `VIBE_ENABLE_TELEMETRY=false`

Generated by Mistral Vibe.