### PR TITLE
Remove 'Beautiful Themes' from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ pip install mistral-vibe
 - **Advanced CLI Experience**: Built with modern libraries for a smooth and efficient workflow.
   - Autocompletion for slash commands (`/`) and file paths (`@`).
   - Persistent command history.
-  - Beautiful Themes.
 - **Highly Configurable**: Customize models, providers, tool permissions, and UI preferences through a simple `config.toml` file.
 - **Safety First**: Features tool execution approval.
 - **Multiple Built-in Agents**: Choose from different agent profiles tailored for specific workflows.


### PR DESCRIPTION
Removed the mention of 'Beautiful Themes' from the README. 
Themes are gone with 2.1.0