### PR TITLE
fix(deps): allow cryptography 46.0.4 by relaxing upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "agent-client-protocol==0.8.0",
     "anyio>=4.12.0",
-    "cryptography>=44.0.0,<=46.0.3",
+    "cryptography>=44.0.0,<47.0.0",
     "gitpython>=3.1.46",
     "giturlparse>=0.14.0",
     "google-auth>=2.0.0",


### PR DESCRIPTION
## Summary
- relax `cryptography` dependency from `<=46.0.3` to `<47.0.0`
- allow patch releases like `46.0.4` that currently fail runtime dependency checks
- keep a major-version cap to avoid unexpected breaking changes

## Why
Issue #413 reports builds failing because the current upper bound excludes `cryptography==46.0.4`. Patch releases are expected to remain compatible, so the pin was too strict.

Fixes #413