### PR TITLE
fix(paths): adopt XDG config home default for VIBE_HOME

### DIFF
--- a/tests/core/test_config_resolution.py
+++ b/tests/core/test_config_resolution.py
@@ -51,3 +51,29 @@ class TestResolveConfigFile:
         assert VIBE_HOME.path != tmp_path
         monkeypatch.setenv("VIBE_HOME", str(tmp_path))
         assert VIBE_HOME.path == tmp_path
+
+    def test_prefers_legacy_vibe_home_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        legacy_home = tmp_path / ".vibe"
+        legacy_home.mkdir()
+
+        monkeypatch.setattr(
+            "vibe.core.paths.global_paths._DEFAULT_VIBE_HOME", legacy_home
+        )
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+        assert VIBE_HOME.path == legacy_home.resolve()
+
+    def test_uses_xdg_config_home_when_legacy_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        legacy_home = tmp_path / ".vibe-missing"
+        xdg_home = tmp_path / "xdg"
+
+        monkeypatch.setattr(
+            "vibe.core.paths.global_paths._DEFAULT_VIBE_HOME", legacy_home
+        )
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
+
+        assert VIBE_HOME.path == (xdg_home / "vibe").resolve()

--- a/vibe/core/paths/global_paths.py
+++ b/vibe/core/paths/global_paths.py
@@ -19,10 +19,21 @@ class GlobalPath:
 _DEFAULT_VIBE_HOME = Path.home() / ".vibe"
 
 
+def _get_xdg_vibe_home() -> Path:
+    if xdg_config_home := os.getenv("XDG_CONFIG_HOME"):
+        return Path(xdg_config_home).expanduser().resolve() / "vibe"
+    return (Path.home() / ".config" / "vibe").resolve()
+
+
 def _get_vibe_home() -> Path:
     if vibe_home := os.getenv("VIBE_HOME"):
         return Path(vibe_home).expanduser().resolve()
-    return _DEFAULT_VIBE_HOME
+
+    legacy_home = _DEFAULT_VIBE_HOME.expanduser().resolve()
+    if legacy_home.exists():
+        return legacy_home
+
+    return _get_xdg_vibe_home()
 
 
 VIBE_HOME = GlobalPath(_get_vibe_home)


### PR DESCRIPTION
## Summary
- make default global config location follow XDG (`$XDG_CONFIG_HOME/vibe` or `~/.config/vibe`)
- keep backward compatibility by preferring legacy `~/.vibe` when it already exists
- preserve explicit override behavior for `VIBE_HOME`
- add tests for legacy-preferred and XDG-default resolution

## Why
Issue #409 requests moving away from `$HOME` pollution and adopting XDG conventions. This change updates defaults for new setups while avoiding breakage for existing users already using `~/.vibe`.

## Validation
- `uv run ruff check vibe/core/paths/global_paths.py tests/core/test_config_resolution.py`
- `uv run pytest tests/core/test_config_resolution.py`

Fixes #409