### PR TITLE
Add AzureOpenAIAdapter and include extra pytests

### DIFF
--- a/tests/backend/test_azure_adapter.py
+++ b/tests/backend/test_azure_adapter.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vibe.core.config import ProviderConfig
+from vibe.core.llm.backend.azure import AzureOpenAIAdapter
+from vibe.core.types import AvailableFunction, AvailableTool, LLMMessage, Role
+
+
+@pytest.fixture
+def adapter():
+    return AzureOpenAIAdapter()
+
+
+@pytest.fixture
+def provider():
+    return ProviderConfig(
+        name="azure",
+        api_base="https://api.azure.com",
+        api_key_env_var="AZURE_API_KEY",
+        api_style="azure",
+        api_version="2024-02-01",  # Mock API version
+    )
+
+
+class TestAdapterBuildPayload:
+    def test_basic_payload(self, adapter):
+        messages = [{"role": "user", "content": "Hello"}]
+        payload = adapter.build_payload(
+            model_name="gpt-4",
+            converted_messages=messages,
+            temperature=0.5,
+            tools=None,
+            max_tokens=1024,
+            tool_choice=None,
+        )
+        assert payload["model"] == "gpt-4"
+        assert payload["messages"] == messages
+        assert payload["temperature"] == 0.5
+        assert payload["max_tokens"] == 1024
+
+    def test_with_tools(self, adapter):
+        tools = [
+            AvailableTool(
+                function=AvailableFunction(
+                    name="test_tool",
+                    description="A test tool",
+                    parameters={"type": "object", "properties": {}},
+                )
+            )
+        ]
+        messages = [{"role": "user", "content": "Hello"}]
+        payload = adapter.build_payload(
+            model_name="gpt-4",
+            converted_messages=messages,
+            temperature=0.5,
+            tools=tools,
+            max_tokens=1024,
+            tool_choice=None,
+        )
+        assert "tools" in payload
+        assert len(payload["tools"]) == 1
+        assert payload["tools"][0]["function"]["name"] == "test_tool"
+
+    def test_with_tool_choice(self, adapter):
+        tools = [
+            AvailableTool(
+                function=AvailableFunction(
+                    name="test_tool",
+                    description="A test tool",
+                    parameters={"type": "object", "properties": {}},
+                )
+            )
+        ]
+        messages = [{"role": "user", "content": "Hello"}]
+        payload = adapter.build_payload(
+            model_name="gpt-4",
+            converted_messages=messages,
+            temperature=0.5,
+            tools=tools,
+            max_tokens=1024,
+            tool_choice="auto",
+        )
+        assert payload["tool_choice"] == "auto"
+
+    def test_without_max_tokens(self, adapter):
+        messages = [{"role": "user", "content": "Hello"}]
+        payload = adapter.build_payload(
+            model_name="gpt-4",
+            converted_messages=messages,
+            temperature=0.5,
+            tools=None,
+            max_tokens=None,
+            tool_choice=None,
+        )
+        assert "max_tokens" not in payload
+
+
+class TestAdapterBuildHeaders:
+    def test_basic_headers(self, adapter):
+        headers = adapter.build_headers()
+        assert headers["Content-Type"] == "application/json"
+        assert "Authorization" not in headers
+
+    def test_with_api_key(self, adapter):
+        headers = adapter.build_headers(api_key="test-key-123")
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Authorization"] == "Bearer test-key-123"
+
+
+class TestAdapterReasoningConversion:
+    def test_reasoning_to_api_default(self, adapter):
+        msg_dict = {
+            "role": "assistant",
+            "content": "Hello",
+            "reasoning_content": "thinking...",
+        }
+        result = adapter._reasoning_to_api(msg_dict, "reasoning_content")
+        assert result == msg_dict  # Should remain unchanged when field names match
+
+    def test_reasoning_to_api_custom_field(self, adapter):
+        msg_dict = {
+            "role": "assistant",
+            "content": "Hello",
+            "reasoning_content": "thinking...",
+        }
+        result = adapter._reasoning_to_api(msg_dict, "custom_reasoning")
+        assert "reasoning_content" not in result
+        assert result["custom_reasoning"] == "thinking..."
+
+    def test_reasoning_from_api_default(self, adapter):
+        msg_dict = {
+            "role": "assistant",
+            "content": "Hello",
+            "reasoning_content": "thinking...",
+        }
+        result = adapter._reasoning_from_api(msg_dict, "reasoning_content")
+        assert result == msg_dict  # Should remain unchanged when field names match
+
+    def test_reasoning_from_api_custom_field(self, adapter):
+        msg_dict = {
+            "role": "assistant",
+            "content": "Hello",
+            "custom_reasoning": "thinking...",
+        }
+        result = adapter._reasoning_from_api(msg_dict, "custom_reasoning")
+        assert "custom_reasoning" not in result
+        assert result["reasoning_content"] == "thinking..."
+
+
+class TestAdapterPrepareRequest:
+    def test_basic_request(self, adapter, provider):
+        messages = [LLMMessage(role=Role.user, content="Hello")]
+        req = adapter.prepare_request(
+            model_name="gpt-4",
+            messages=messages,
+            temperature=0.5,
+            tools=None,
+            max_tokens=1024,
+            tool_choice=None,
+            enable_streaming=False,
+            provider=provider,
+        )
+
+        payload = json.loads(req.body)
+        assert payload["model"] == "gpt-4"
+        assert payload["max_tokens"] == 1024
+        assert payload["temperature"] == 0.5
+        assert (
+            req.endpoint == "/deployments/gpt-4/chat/completions?api-version=2024-02-01"
+        )
+        assert req.headers["Content-Type"] == "application/json"
+
+    def test_streaming_request(self, adapter, provider):
+        messages = [LLMMessage(role=Role.user, content="Hello")]
+        req = adapter.prepare_request(
+            model_name="gpt-4",
+            messages=messages,
+            temperature=0.5,
+            tools=None,
+            max_tokens=1024,
+            tool_choice=None,
+            enable_streaming=True,
+            provider=provider,
+        )
+
+        payload = json.loads(req.body)
+        assert payload["stream"] is True
+        assert "stream_options" in payload
+        assert payload["stream_options"]["include_usage"] is True
+
+    def test_with_api_key(self, adapter, provider):
+        messages = [LLMMessage(role=Role.user, content="Hello")]
+        req = adapter.prepare_request(
+            model_name="gpt-4",
+            messages=messages,
+            temperature=0.5,
+            tools=None,
+            max_tokens=1024,
+            tool_choice=None,
+            enable_streaming=False,
+            provider=provider,
+            api_key="test-key-123",
+        )
+        assert req.headers["Authorization"] == "Bearer test-key-123"
+
+    def test_with_tools(self, adapter, provider):
+        messages = [LLMMessage(role=Role.user, content="Hello")]
+        tools = [
+            AvailableTool(
+                function=AvailableFunction(
+                    name="test_tool",
+                    description="A test tool",
+                    parameters={"type": "object", "properties": {}},
+                )
+            )
+        ]
+        req = adapter.prepare_request(
+            model_name="gpt-4",
+            messages=messages,
+            temperature=0.5,
+            tools=tools,
+            max_tokens=1024,
+            tool_choice=None,
+            enable_streaming=False,
+            provider=provider,
+        )
+        payload = json.loads(req.body)
+        assert len(payload["tools"]) == 1
+        assert payload["tools"][0]["function"]["name"] == "test_tool"
+
+    def test_with_reasoning_field(self, adapter, provider):
+        # Test with custom reasoning field name
+        provider.reasoning_field_name = "custom_reasoning"
+        messages = [
+            LLMMessage(role=Role.user, content="Hello"),
+            LLMMessage(
+                role=Role.assistant, content="Answer", reasoning_content="thinking..."
+            ),
+        ]
+        req = adapter.prepare_request(
+            model_name="gpt-4",
+            messages=messages,
+            temperature=0.5,
+            tools=None,
+            max_tokens=1024,
+            tool_choice=None,
+            enable_streaming=False,
+            provider=provider,
+        )
+        payload = json.loads(req.body)
+        # The reasoning content should be converted to the custom field name
+        assert payload["messages"][1]["custom_reasoning"] == "thinking..."
+        assert "reasoning_content" not in payload["messages"][1]
+
+
+class TestAdapterParseMessage:
+    def test_parse_message_with_choices(self, adapter):
+        data = {
+            "choices": [{"message": {"role": "assistant", "content": "Hello there!"}}]
+        }
+        message = adapter._parse_message(data, "reasoning_content")
+        assert message is not None
+        assert message.role == Role.assistant
+        assert message.content == "Hello there!"
+
+    def test_parse_message_with_delta(self, adapter):
+        data = {"choices": [{"delta": {"role": "assistant", "content": "Hello"}}]}
+        message = adapter._parse_message(data, "reasoning_content")
+        assert message is not None
+        assert message.role == Role.assistant
+        assert message.content == "Hello"
+
+    def test_parse_message_direct_message(self, adapter):
+        data = {"message": {"role": "assistant", "content": "Direct message"}}
+        message = adapter._parse_message(data, "reasoning_content")
+        assert message is not None
+        assert message.role == Role.assistant
+        assert message.content == "Direct message"
+
+    def test_parse_message_direct_delta(self, adapter):
+        data = {"delta": {"role": "assistant", "content": "Delta content"}}
+        message = adapter._parse_message(data, "reasoning_content")
+        assert message is not None
+        assert message.role == Role.assistant
+        assert message.content == "Delta content"
+
+    def test_parse_message_none(self, adapter):
+        data = {"some_other_field": "value"}
+        message = adapter._parse_message(data, "reasoning_content")
+        assert message is None
+
+    def test_parse_message_with_reasoning_field(self, adapter):
+        data = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Answer",
+                        "custom_reasoning": "thinking...",
+                    }
+                }
+            ]
+        }
+        message = adapter._parse_message(data, "custom_reasoning")
+        assert message is not None
+        assert message.reasoning_content == "thinking..."
+        assert "custom_reasoning" not in message.model_dump()
+
+
+class TestAdapterParseResponse:
+    def test_non_streaming_response(self, adapter, provider):
+        data = {
+            "choices": [{"message": {"role": "assistant", "content": "Hello!"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        chunk = adapter.parse_response(data, provider)
+        assert chunk.message.content == "Hello!"
+        assert chunk.usage.prompt_tokens == 10
+        assert chunk.usage.completion_tokens == 5
+
+    def test_streaming_response(self, adapter, provider):
+        data = {"choices": [{"delta": {"role": "assistant", "content": "Hi"}}]}
+        chunk = adapter.parse_response(data, provider)
+        assert chunk.message.content == "Hi"
+        assert chunk.usage.prompt_tokens == 0
+        assert chunk.usage.completion_tokens == 0
+
+    def test_response_with_reasoning(self, adapter, provider):
+        provider.reasoning_field_name = "custom_reasoning"
+        data = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Answer",
+                        "custom_reasoning": "thinking...",
+                    }
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        chunk = adapter.parse_response(data, provider)
+        assert chunk.message.content == "Answer"
+        assert chunk.message.reasoning_content == "thinking..."
+        assert chunk.usage.prompt_tokens == 10
+
+    def test_empty_response_returns_default_message(self, adapter, provider):
+        data = {"some_other_field": "value"}
+        chunk = adapter.parse_response(data, provider)
+        assert chunk.message.role == Role.assistant
+        assert chunk.message.content == ""
+        assert chunk.usage.prompt_tokens == 0
+        assert chunk.usage.completion_tokens == 0

--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -150,6 +150,7 @@ class ProviderConfig(BaseModel):
     reasoning_field_name: str = "reasoning_content"
     project_id: str = ""
     region: str = ""
+    api_version: str = ""
 
 
 class _MCPBase(BaseModel):

--- a/vibe/core/llm/backend/azure.py
+++ b/vibe/core/llm/backend/azure.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from vibe.core.llm.backend.base import APIAdapter, PreparedRequest
+from vibe.core.llm.message_utils import merge_consecutive_user_messages
+from vibe.core.types import (
+    AvailableTool,
+    LLMChunk,
+    LLMMessage,
+    LLMUsage,
+    Role,
+    StrToolChoice,
+)
+
+if TYPE_CHECKING:
+    from vibe.core.config import ProviderConfig
+
+
+class AzureOpenAIAdapter(APIAdapter):
+    endpoint: ClassVar[str] = "/chat/completions"
+
+    def build_payload(
+        self,
+        model_name: str,
+        converted_messages: list[dict[str, Any]],
+        temperature: float,
+        tools: list[AvailableTool] | None,
+        max_tokens: int | None,
+        tool_choice: StrToolChoice | AvailableTool | None,
+    ) -> dict[str, Any]:
+        payload = {
+            "model": model_name,
+            "messages": converted_messages,
+            "temperature": temperature,
+        }
+
+        if tools:
+            payload["tools"] = [tool.model_dump(exclude_none=True) for tool in tools]
+        if tool_choice:
+            payload["tool_choice"] = (
+                tool_choice
+                if isinstance(tool_choice, str)
+                else tool_choice.model_dump()
+            )
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+
+        return payload
+
+    def build_headers(self, api_key: str | None = None) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        return headers
+
+    def _reasoning_to_api(
+        self, msg_dict: dict[str, Any], field_name: str
+    ) -> dict[str, Any]:
+        if field_name != "reasoning_content" and "reasoning_content" in msg_dict:
+            msg_dict[field_name] = msg_dict.pop("reasoning_content")
+        return msg_dict
+
+    def _reasoning_from_api(
+        self, msg_dict: dict[str, Any], field_name: str
+    ) -> dict[str, Any]:
+        if field_name != "reasoning_content" and field_name in msg_dict:
+            msg_dict["reasoning_content"] = msg_dict.pop(field_name)
+        return msg_dict
+
+    def prepare_request(  # noqa: PLR0913
+        self,
+        *,
+        model_name: str,
+        messages: list[LLMMessage],
+        temperature: float,
+        tools: list[AvailableTool] | None,
+        max_tokens: int | None,
+        tool_choice: StrToolChoice | AvailableTool | None,
+        enable_streaming: bool,
+        provider: ProviderConfig,
+        api_key: str | None = None,
+        thinking: str = "off",
+    ) -> PreparedRequest:
+        merged_messages = merge_consecutive_user_messages(messages)
+        field_name = provider.reasoning_field_name
+        converted_messages = [
+            self._reasoning_to_api(
+                msg.model_dump(exclude_none=True, exclude={"message_id"}), field_name
+            )
+            for msg in merged_messages
+        ]
+
+        payload = self.build_payload(
+            model_name, converted_messages, temperature, tools, max_tokens, tool_choice
+        )
+
+        if enable_streaming:
+            payload["stream"] = True
+            stream_options = {"include_usage": True}
+            if provider.name == "mistral":
+                stream_options["stream_tool_calls"] = True
+            payload["stream_options"] = stream_options
+
+        headers = self.build_headers(api_key)
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        url = f"/deployments/{model_name}{self.endpoint}?api-version={provider.api_version}"
+
+        return PreparedRequest(url, headers, body)
+
+    def _parse_message(
+        self, data: dict[str, Any], field_name: str
+    ) -> LLMMessage | None:
+        if data.get("choices"):
+            choice = data["choices"][0]
+            if "message" in choice:
+                msg_dict = self._reasoning_from_api(choice["message"], field_name)
+                return LLMMessage.model_validate(msg_dict)
+            if "delta" in choice:
+                msg_dict = self._reasoning_from_api(choice["delta"], field_name)
+                return LLMMessage.model_validate(msg_dict)
+            raise ValueError("Invalid response data: missing message or delta")
+
+        if "message" in data:
+            msg_dict = self._reasoning_from_api(data["message"], field_name)
+            return LLMMessage.model_validate(msg_dict)
+        if "delta" in data:
+            msg_dict = self._reasoning_from_api(data["delta"], field_name)
+            return LLMMessage.model_validate(msg_dict)
+
+        return None
+
+    def parse_response(
+        self, data: dict[str, Any], provider: ProviderConfig
+    ) -> LLMChunk:
+        message = self._parse_message(data, provider.reasoning_field_name)
+        if message is None:
+            message = LLMMessage(role=Role.assistant, content="")
+
+        usage_data = data.get("usage") or {}
+        usage = LLMUsage(
+            prompt_tokens=usage_data.get("prompt_tokens", 0),
+            completion_tokens=usage_data.get("completion_tokens", 0),
+        )
+
+        return LLMChunk(message=message, usage=usage)

--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 import httpx
 
 from vibe.core.llm.backend.anthropic import AnthropicAdapter
+from vibe.core.llm.backend.azure import AzureOpenAIAdapter
 from vibe.core.llm.backend.base import APIAdapter, PreparedRequest
 from vibe.core.llm.backend.vertex import VertexAnthropicAdapter
 from vibe.core.llm.exceptions import BackendErrorBuilder
@@ -91,6 +92,7 @@ class OpenAIAdapter(APIAdapter):
         provider: ProviderConfig,
         api_key: str | None = None,
         thinking: str = "off",
+        api_version: str = "",
     ) -> PreparedRequest:
         merged_messages = merge_consecutive_user_messages(messages)
         field_name = provider.reasoning_field_name
@@ -158,6 +160,7 @@ class OpenAIAdapter(APIAdapter):
 ADAPTERS: dict[str, APIAdapter] = {
     "openai": OpenAIAdapter(),
     "anthropic": AnthropicAdapter(),
+    "azure": AzureOpenAIAdapter(),
     "vertex-anthropic": VertexAnthropicAdapter(),
 }
 


### PR DESCRIPTION
Added the `AzureOpenAIAdapter` in `vibe/core/llm/backend/azure.py`. This adapter makes use of the newly introduced `api_version` parameter in `ProviderConfig`.
New pytests for this adapter were also created, following the structure of `tests/backend/test_anthropic_adapter.py`.