### PR TITLE
Add /quit alias for exit command

### DIFF
--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -47,7 +47,7 @@ class CommandRegistry:
                 handler="_compact_history",
             ),
             "exit": Command(
-                aliases=frozenset(["/exit"]),
+                aliases=frozenset(["/exit", "/quit"]),
                 description="Exit the application",
                 handler="_exit_app",
                 exits=True,


### PR DESCRIPTION
## Summary
- Adds `/quit` as an alias for the `exit` command in the CLI