### PR TITLE
Let users opt into which tools are available in Plan Mode

### DIFF
--- a/tests/core/test_plan_agent_integration.py
+++ b/tests/core/test_plan_agent_integration.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import build_test_vibe_config
+from vibe.core.agents.manager import AgentManager
+from vibe.core.agents.models import BUILTIN_AGENTS
+
+
+class TestPlanAgentIntegration:
+    def test_plan_agent_integration_with_tools(self):
+        """Integration test that verifies the complete plan agent tool configuration flow."""
+        # Test with custom tools
+        config = build_test_vibe_config(plan_agent_tools=["grep", "read_file", "web_search"])
+        manager = AgentManager(lambda: config)
+        
+        # Start with default agent
+        default_config = manager.config
+        assert default_config.enabled_tools == []  # Default agent has no specific tools enabled
+        
+        # Switch to plan agent
+        manager.switch_profile("plan")
+        plan_config = manager.config
+        
+        # Verify plan agent uses the custom tools
+        assert plan_config.enabled_tools == ["grep", "read_file", "web_search"]
+        assert plan_config.auto_approve is True
+        
+        # Verify the plan agent profile is correct
+        plan_agent = BUILTIN_AGENTS["plan"]
+        assert plan_agent.name == "plan"
+        assert plan_agent.safety == "safe"
+        
+    def test_plan_agent_default_behavior(self):
+        """Test that plan agent works with default tools when none are specified."""
+        # Test with default configuration
+        config = build_test_vibe_config()
+        manager = AgentManager(lambda: config)
+        
+        # Switch to plan agent
+        manager.switch_profile("plan")
+        plan_config = manager.config
+        
+        # Verify default tools are used
+        expected_default = ["grep", "read_file", "todo", "ask_user_question", "task"]
+        assert plan_config.enabled_tools == expected_default
+        assert plan_config.auto_approve is True
+
+    def test_plan_agent_tool_config_isolation(self):
+        """Test that plan agent tool configuration doesn't affect other agents."""
+        config = build_test_vibe_config(plan_agent_tools=["grep", "read_file"])
+        manager = AgentManager(lambda: config)
+        
+        # Check default agent (should not be affected)
+        default_config = manager.config
+        assert default_config.enabled_tools == []
+        
+        # Switch to plan agent
+        manager.switch_profile("plan")
+        plan_config = manager.config
+        assert plan_config.enabled_tools == ["grep", "read_file"]
+        
+        # Switch back to default agent
+        manager.switch_profile("default")
+        back_to_default = manager.config
+        assert back_to_default.enabled_tools == []  # Should be back to default

--- a/tests/core/test_plan_agent_tools.py
+++ b/tests/core/test_plan_agent_tools.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+from tests.conftest import build_test_vibe_config
+from vibe.core.agents.manager import AgentManager
+from vibe.core.agents.models import BUILTIN_AGENTS, PLAN
+
+
+class TestPlanAgentTools:
+    def test_config_plan_agent_tools_default(self):
+        """Test that config has default plan agent tools."""
+        config = build_test_vibe_config()
+        expected_tools = ["grep", "read_file", "todo", "ask_user_question", "task"]
+        assert hasattr(config, 'plan_agent_tools'), "Config should have plan_agent_tools attribute"
+        assert config.plan_agent_tools == expected_tools
+
+    def test_config_plan_agent_tools_custom(self):
+        """Test that config can load custom plan agent tools."""
+        config = build_test_vibe_config(plan_agent_tools=["grep", "read_file", "web_search"])
+        assert config.plan_agent_tools == ["grep", "read_file", "web_search"]
+
+    def test_plan_agent_uses_config_tools(self):
+        """Test that PLAN agent uses tools from config."""
+        config = build_test_vibe_config(plan_agent_tools=["grep", "read_file", "web_search"])
+        plan_agent = BUILTIN_AGENTS["plan"]
+
+        # Apply agent overrides to config
+        agent_config = plan_agent.apply_to_config(config)
+
+        assert agent_config.enabled_tools == ["grep", "read_file", "web_search"]
+        assert agent_config.auto_approve is True
+
+    def test_agent_manager_respects_plan_tools(self):
+        """Test that AgentManager correctly applies plan agent tool configuration."""
+        config = build_test_vibe_config(plan_agent_tools=["grep", "read_file"])
+        manager = AgentManager(lambda: config)
+
+        # Switch to plan agent
+        manager.switch_profile("plan")
+        active_config = manager.config
+
+        assert active_config.enabled_tools == ["grep", "read_file"]
+        assert active_config.auto_approve is True

--- a/vibe/core/agents/models.py
+++ b/vibe/core/agents/models.py
@@ -53,7 +53,14 @@ class AgentProfile:
     def apply_to_config(self, base: VibeConfig) -> VibeConfig:
         from vibe.core.config import VibeConfig as VC
 
-        merged = _deep_merge(base.model_dump(), self.overrides)
+        # Start with base config overrides
+        processed_overrides = self.overrides.copy()
+        
+        # Special handling for plan agent tools
+        if self.name == "plan" and hasattr(base, 'plan_agent_tools'):
+            processed_overrides["enabled_tools"] = base.plan_agent_tools
+        
+        merged = _deep_merge(base.model_dump(), processed_overrides)
         return VC.model_validate(merged)
 
     @classmethod
@@ -84,7 +91,7 @@ PLAN = AgentProfile(
     "Plan",
     "Read-only agent for exploration and planning",
     AgentSafety.SAFE,
-    overrides={"auto_approve": True, "enabled_tools": PLAN_AGENT_TOOLS},
+    overrides={"auto_approve": True},
 )
 CHAT = AgentProfile(
     BuiltinAgentName.CHAT,

--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -419,6 +419,13 @@ class VibeConfig(BaseSettings):
             " is set. Supports glob patterns and regex with 're:' prefix."
         ),
     )
+    plan_agent_tools: list[str] = Field(
+        default_factory=lambda: ["grep", "read_file", "todo", "ask_user_question", "task"],
+        description=(
+            "List of tools available to the plan agent. "
+            "These tools are used when the plan agent is active."
+        ),
+    )
 
     model_config = SettingsConfigDict(
         env_prefix="VIBE_", case_sensitive=False, extra="ignore"


### PR DESCRIPTION
This pull request introduces support for configuring the tools available to the "plan" agent via a new `plan_agent_tools` field in the `VibeConfig` configuration. The plan agent's enabled tools are now determined dynamically from this config value, and several tests have been added to verify the integration and correct isolation of this feature.

Configuration and agent behavior improvements:

* Added a new `plan_agent_tools` field to `VibeConfig`, allowing users to specify which tools the plan agent should use. It defaults to `["grep", "read_file", "todo", "ask_user_question", "task"]` as those are the existing tools available in Plan mode.
* Updated the `AgentProfile.apply_to_config` method so that, for the plan agent, the `enabled_tools` field is set from `plan_agent_tools` in the config instead of a hard-coded value.
* Removed the hard-coded `enabled_tools` override from the plan agent's profile definition, so tool selection is now fully config-driven.

Testing enhancements:

* Added `test_plan_agent_tools.py` to verify that the config and agent profile correctly handle default and custom tool lists for the plan agent.
* Added integration tests in `test_plan_agent_integration.py` to ensure the plan agent uses the correct tools, respects config isolation, and behaves as expected when switching profiles.

---

I'm in the process of migrating from Claude Code, and I'm currently finding plan mode with `vibe` to be difficult to use as it's too restrictive. I don't know what users want to see as I'm new to this ecosystem. For example, for my use case I want `vibe` to be able to search the internet for the latest information on SDKs, libraries, methodologies, etc. I tested this locally and it worked for me.

<img width="3588" height="1156" alt="image" src="https://github.com/user-attachments/assets/32920c1c-da54-41b9-a5f0-6778e56d6287" />
