### PR TITLE
fix: do not crash when config file is not writeable

### DIFF
--- a/vibe/acp/acp_agent_loop.py
+++ b/vibe/acp/acp_agent_loop.py
@@ -511,6 +511,7 @@ class VibeAcpAgentLoop(AcpAgent):
         VibeConfig.save_updates({"active_model": model_id})
 
         new_config = VibeConfig.load(
+            active_model=model_id,
             tool_paths=session.agent_loop.config.tool_paths,
             disabled_tools=["ask_user_question"],
         )

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -452,7 +452,7 @@ class VibeApp(App):  # noqa: PLR0904
     ) -> None:
         if message.changes:
             VibeConfig.save_updates(message.changes)
-            await self._reload_config()
+            await self._reload_config(**message.changes)
         else:
             await self._mount_and_scroll(
                 UserCommandMessage("Configuration closed (no changes saved).")
@@ -996,11 +996,11 @@ class VibeApp(App):  # noqa: PLR0904
 
         await self._mount_and_scroll(UserCommandMessage("Resume cancelled."))
 
-    async def _reload_config(self) -> None:
+    async def _reload_config(self, **overrides: Any) -> None:
         try:
             self._reset_ui_state()
             await self._load_more.hide()
-            base_config = VibeConfig.load()
+            base_config = VibeConfig.load(**overrides)
 
             await self.agent_loop.reload_with_initial_messages(base_config=base_config)
 

--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -20,6 +20,7 @@ from pydantic_settings import (
 )
 import tomli_w
 
+from vibe.core.logger import logger
 from vibe.core.paths.config_paths import CONFIG_DIR, CONFIG_FILE, PROMPTS_DIR
 from vibe.core.paths.global_paths import (
     GLOBAL_ENV_FILE,
@@ -568,6 +569,12 @@ class VibeConfig(BaseSettings):
     @classmethod
     def save_updates(cls, updates: dict[str, Any]) -> None:
         CONFIG_DIR.path.mkdir(parents=True, exist_ok=True)
+        # try:
+        #     CONFIG_DIR.path.mkdir(parents=True, exist_ok=True)
+        # except OSError as exc:
+        #     logger.warning(
+        #         "Could not create config directory %s: %s", CONFIG_DIR.path, exc
+        #     )
         current_config = TomlFileSettingsSource(cls).toml_data
 
         def deep_merge(target: dict, source: dict) -> None:
@@ -597,8 +604,11 @@ class VibeConfig(BaseSettings):
 
     @classmethod
     def dump_config(cls, config: dict[str, Any]) -> None:
-        with CONFIG_FILE.path.open("wb") as f:
-            tomli_w.dump(config, f)
+        try:
+            with CONFIG_FILE.path.open("wb") as f:
+                tomli_w.dump(config, f)
+        except OSError as exc:
+            logger.warning("Could not write config file %s: %s", CONFIG_FILE.path, exc)
 
     @classmethod
     def _migrate(cls) -> None:


### PR DESCRIPTION
When doing any config change directly from vibe (e.g. changing the `active_model`), it will try to update the config file accordingly (`~/.vibe/config.toml`).
If the config file is not writeable, the program hard crashes with:
```
PermissionError: [Errno 13] Permission denied: '/Users/gaetan/.vibe/config.toml'
```

This PR adds a graceful handling of such situations by simply logging the incident, but do not halt execution.
