### PR TITLE
feat: add multimodal image input via @image.png syntax

### DIFF
--- a/tests/backend/test_mistral_image.py
+++ b/tests/backend/test_mistral_image.py
@@ -1,0 +1,148 @@
+"""Tests for MistralMapper and MistralBackend image handling."""
+
+from __future__ import annotations
+
+import mistralai
+
+from vibe.core.config import Backend, ModelConfig, ProviderConfig
+from vibe.core.llm.backend.mistral import MistralBackend, MistralMapper
+from vibe.core.types import ImageContentPart, LLMMessage, Role
+
+# ── MistralMapper.prepare_message ─────────────────────────────────────────────
+
+
+class TestMistralMapperImageMessages:
+    def test_plain_user_message_unchanged(self):
+        msg = LLMMessage(role=Role.user, content="hello")
+        result = MistralMapper().prepare_message(msg)
+        assert isinstance(result, mistralai.UserMessage)
+        assert result.content == "hello"
+
+    def test_user_message_with_text_and_image(self):
+        msg = LLMMessage(
+            role=Role.user,
+            content="what is this?",
+            image_parts=[
+                ImageContentPart(
+                    image_url="data:image/png;base64,abc", media_type="image/png"
+                )
+            ],
+        )
+        result = MistralMapper().prepare_message(msg)
+        assert isinstance(result, mistralai.UserMessage)
+        assert isinstance(result.content, list)
+        text_chunks = [c for c in result.content if isinstance(c, mistralai.TextChunk)]
+        image_chunks = [
+            c for c in result.content if isinstance(c, mistralai.ImageURLChunk)
+        ]
+        assert len(text_chunks) == 1
+        assert text_chunks[0].text == "what is this?"
+        assert len(image_chunks) == 1
+        assert image_chunks[0].image_url.url == "data:image/png;base64,abc"
+
+    def test_user_message_image_only_omits_text_chunk(self):
+        msg = LLMMessage(
+            role=Role.user,
+            content="",
+            image_parts=[ImageContentPart(image_url="data:image/png;base64,abc")],
+        )
+        result = MistralMapper().prepare_message(msg)
+        assert isinstance(result.content, list)
+        text_chunks = [c for c in result.content if isinstance(c, mistralai.TextChunk)]
+        assert text_chunks == []
+
+    def test_user_message_multiple_images(self):
+        msg = LLMMessage(
+            role=Role.user,
+            content="compare these",
+            image_parts=[
+                ImageContentPart(image_url="data:image/png;base64,aaa"),
+                ImageContentPart(image_url="data:image/jpeg;base64,bbb"),
+            ],
+        )
+        result = MistralMapper().prepare_message(msg)
+        image_chunks = [
+            c for c in result.content if isinstance(c, mistralai.ImageURLChunk)
+        ]
+        assert len(image_chunks) == 2
+        assert image_chunks[0].image_url.url == "data:image/png;base64,aaa"
+        assert image_chunks[1].image_url.url == "data:image/jpeg;base64,bbb"
+
+    def test_image_chunk_order_text_before_images(self):
+        msg = LLMMessage(
+            role=Role.user,
+            content="describe",
+            image_parts=[ImageContentPart(image_url="data:image/png;base64,xyz")],
+        )
+        result = MistralMapper().prepare_message(msg)
+        assert isinstance(result.content[0], mistralai.TextChunk)
+        assert isinstance(result.content[1], mistralai.ImageURLChunk)
+
+
+# ── MistralBackend._strip_image_parts_if_needed ───────────────────────────────
+
+
+def _make_provider() -> ProviderConfig:
+    return ProviderConfig(
+        name="mistral",
+        api_base="https://api.mistral.ai/v1",
+        api_key_env_var="MISTRAL_API_KEY",
+        backend=Backend.MISTRAL,
+    )
+
+
+def _vision_model() -> ModelConfig:
+    return ModelConfig(
+        name="pixtral-large-2411",
+        provider="mistral",
+        alias="pixtral-large",
+        supports_vision=True,
+    )
+
+
+def _non_vision_model() -> ModelConfig:
+    return ModelConfig(
+        name="mistral-vibe-cli-latest",
+        provider="mistral",
+        alias="devstral-2",
+        supports_vision=False,
+    )
+
+
+def _msg_with_image() -> LLMMessage:
+    return LLMMessage(
+        role=Role.user,
+        content="what is this?",
+        image_parts=[ImageContentPart(image_url="data:image/png;base64,abc")],
+    )
+
+
+class TestStripImageParts:
+    def test_vision_model_keeps_image_parts(self):
+        messages = [_msg_with_image()]
+        result = MistralBackend._strip_image_parts_if_needed(_vision_model(), messages)
+        assert result[0].image_parts is not None
+        assert len(result[0].image_parts) == 1
+
+    def test_non_vision_model_strips_image_parts(self):
+        messages = [_msg_with_image()]
+        result = MistralBackend._strip_image_parts_if_needed(
+            _non_vision_model(), messages
+        )
+        assert result[0].image_parts is None
+
+    def test_non_vision_model_does_not_mutate_original(self):
+        msg = _msg_with_image()
+        messages = [msg]
+        MistralBackend._strip_image_parts_if_needed(_non_vision_model(), messages)
+        assert msg.image_parts is not None
+
+    def test_messages_without_image_parts_unaffected(self):
+        msg = LLMMessage(role=Role.user, content="hello")
+        result = MistralBackend._strip_image_parts_if_needed(_non_vision_model(), [msg])
+        assert result[0].content == "hello"
+
+    def test_strips_only_image_parts_preserves_content(self):
+        msg = _msg_with_image()
+        result = MistralBackend._strip_image_parts_if_needed(_non_vision_model(), [msg])
+        assert result[0].content == "what is this?"

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -1,0 +1,145 @@
+"""Tests for _resolve_image_references in AgentLoop."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+import struct
+import zlib
+
+import pytest
+
+from vibe.core.agent_loop import AgentLoop
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def make_png(path: Path) -> None:
+    """Write a minimal valid 1×1 PNG to *path*."""
+
+    def chunk(name: bytes, data: bytes) -> bytes:
+        c = struct.pack(">I", len(data)) + name + data
+        return c + struct.pack(">I", zlib.crc32(c[4:]) & 0xFFFFFFFF)
+
+    png = b"\x89PNG\r\n\x1a\n"
+    png += chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0))
+    png += chunk(b"IDAT", zlib.compress(b"\x00\xff\xff\xff"))
+    png += chunk(b"IEND", b"")
+    path.write_bytes(png)
+
+
+# ── no images ─────────────────────────────────────────────────────────────────
+
+
+def test_plain_text_returns_unchanged():
+    text, parts = AgentLoop._resolve_image_references("hello world")
+    assert text == "hello world"
+    assert parts == []
+
+
+def test_at_ref_non_image_extension_is_ignored(tmp_path: Path):
+    f = tmp_path / "README.md"
+    f.write_text("# hello")
+    text, parts = AgentLoop._resolve_image_references(f"@{f} explain this")
+    assert parts == []
+    assert f"@{f}" in text
+
+
+def test_at_ref_nonexistent_image_raises(tmp_path: Path):
+    missing = tmp_path / "ghost.png"
+    with pytest.raises(FileNotFoundError, match="ghost.png"):
+        AgentLoop._resolve_image_references(f"@{missing} what is this?")
+
+
+# ── single image ──────────────────────────────────────────────────────────────
+
+
+def test_image_ref_at_start_of_message(tmp_path: Path):
+    img = tmp_path / "photo.png"
+    make_png(img)
+    text, parts = AgentLoop._resolve_image_references(f"@{img} what is this?")
+    assert len(parts) == 1
+    assert text == "what is this?"
+    assert parts[0].image_url.startswith("data:image/png;base64,")
+
+
+def test_image_ref_at_end_of_message(tmp_path: Path):
+    img = tmp_path / "photo.png"
+    make_png(img)
+    text, parts = AgentLoop._resolve_image_references(f"what is this? @{img}")
+    assert len(parts) == 1
+    assert text == "what is this?"
+
+
+def test_image_only_no_surrounding_text(tmp_path: Path):
+    img = tmp_path / "photo.png"
+    make_png(img)
+    text, parts = AgentLoop._resolve_image_references(f"@{img}")
+    assert len(parts) == 1
+    assert text == ""
+
+
+def test_jpeg_extension_detected(tmp_path: Path):
+    img = tmp_path / "photo.jpg"
+    make_png(img)
+    _, parts = AgentLoop._resolve_image_references(f"@{img} describe")
+    assert len(parts) == 1
+    assert "image/jpeg" in parts[0].image_url
+
+
+def test_webp_extension_detected(tmp_path: Path):
+    img = tmp_path / "photo.webp"
+    img.write_bytes(b"RIFF....WEBP")
+    _, parts = AgentLoop._resolve_image_references(f"@{img} describe")
+    assert len(parts) == 1
+
+
+def test_gif_extension_detected(tmp_path: Path):
+    img = tmp_path / "anim.gif"
+    img.write_bytes(b"GIF89a")
+    _, parts = AgentLoop._resolve_image_references(f"@{img} describe")
+    assert len(parts) == 1
+
+
+# ── multiple images ───────────────────────────────────────────────────────────
+
+
+def test_two_images_in_one_message(tmp_path: Path):
+    img1 = tmp_path / "a.png"
+    img2 = tmp_path / "b.png"
+    make_png(img1)
+    make_png(img2)
+    text, parts = AgentLoop._resolve_image_references(f"compare @{img1} and @{img2}")
+    assert len(parts) == 2
+    # each @ref is replaced with "" leaving a double space; strip only trims ends
+    assert "compare" in text and "and" in text
+
+
+def test_image_and_non_image_ref_in_same_message(tmp_path: Path):
+    img = tmp_path / "photo.png"
+    txt = tmp_path / "notes.txt"
+    make_png(img)
+    txt.write_text("some notes")
+    text, parts = AgentLoop._resolve_image_references(
+        f"@{img} explain with context @{txt}"
+    )
+    assert len(parts) == 1
+    assert str(txt) in text
+
+
+# ── base64 encoding ───────────────────────────────────────────────────────────
+
+
+def test_base64_round_trip(tmp_path: Path):
+    img = tmp_path / "photo.png"
+    make_png(img)
+    _, parts = AgentLoop._resolve_image_references(f"@{img}")
+    _prefix, b64 = parts[0].image_url.split(",", 1)
+    assert base64.standard_b64decode(b64) == img.read_bytes()
+
+
+def test_media_type_stored_on_part(tmp_path: Path):
+    img = tmp_path / "photo.png"
+    make_png(img)
+    _, parts = AgentLoop._resolve_image_references(f"@{img}")
+    assert parts[0].media_type == "image/png"

--- a/tests/test_vision_guard.py
+++ b/tests/test_vision_guard.py
@@ -1,0 +1,194 @@
+"""Tests for the vision capability guard in AgentLoop._conversation_loop."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import struct
+import zlib
+
+import pytest
+
+from tests.conftest import build_test_agent_loop, build_test_vibe_config
+from tests.mock.utils import mock_llm_chunk
+from tests.stubs.fake_backend import FakeBackend
+from vibe.core.config import Backend, ModelConfig, ProviderConfig
+from vibe.core.types import ImageContentPart, Role
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _sent_user_msg(backend: FakeBackend, call_idx: int = 0):
+    """Return the last user-role message from a backend call.
+
+    FakeBackend stores a reference to the live messages list, so by the time
+    the test reads it the assistant reply has already been appended.  We
+    therefore look for the last message with role=user explicitly.
+    """
+    msgs = backend.requests_messages[call_idx]
+    user_msgs = [m for m in msgs if m.role == Role.user]
+    return user_msgs[-1]
+
+
+def make_png(path: Path) -> None:
+    def chunk(name: bytes, data: bytes) -> bytes:
+        c = struct.pack(">I", len(data)) + name + data
+        return c + struct.pack(">I", zlib.crc32(c[4:]) & 0xFFFFFFFF)
+
+    png = b"\x89PNG\r\n\x1a\n"
+    png += chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0))
+    png += chunk(b"IDAT", zlib.compress(b"\x00\xff\xff\xff"))
+    png += chunk(b"IEND", b"")
+    path.write_bytes(png)
+
+
+def _vision_config(supports_vision: bool):
+    models = [
+        ModelConfig(
+            name="test-model",
+            provider="mistral",
+            alias="test-model",
+            supports_vision=supports_vision,
+        )
+    ]
+    providers = [
+        ProviderConfig(
+            name="mistral",
+            api_base="https://api.mistral.ai/v1",
+            api_key_env_var="MISTRAL_API_KEY",
+            backend=Backend.MISTRAL,
+        )
+    ]
+    return build_test_vibe_config(
+        active_model="test-model", models=models, providers=providers
+    )
+
+
+# ── plain text — guard is never triggered ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plain_text_message_passes_through():
+    backend = FakeBackend(mock_llm_chunk(content="Hello!"))
+    agent = build_test_agent_loop(config=_vision_config(False), backend=backend)
+    [e async for e in agent.act("Hello")]
+    assert len(backend.requests_messages) == 1
+    assert _sent_user_msg(backend).image_parts is None
+
+
+# ── vision-capable active model — no callback needed ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vision_capable_model_sends_images_without_callback(tmp_path: Path):
+    img = tmp_path / "photo.png"
+    make_png(img)
+
+    backend = FakeBackend(mock_llm_chunk(content="I see a photo."))
+    agent = build_test_agent_loop(config=_vision_config(True), backend=backend)
+
+    image_parts = [ImageContentPart(image_url="data:image/png;base64,abc")]
+    [_ async for _ in agent.act("describe this", image_parts=image_parts)]
+
+    sent = _sent_user_msg(backend)
+    assert sent.image_parts is not None
+    assert len(sent.image_parts) == 1
+
+
+# ── non-vision model, no callback (non-TUI mode) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_non_vision_model_no_callback_strips_images_silently(tmp_path: Path):
+    img = tmp_path / "photo.png"
+    make_png(img)
+
+    backend = FakeBackend(mock_llm_chunk(content="I see nothing."))
+    agent = build_test_agent_loop(config=_vision_config(False), backend=backend)
+
+    image_parts = [ImageContentPart(image_url="data:image/png;base64,abc")]
+    [_ async for _ in agent.act("describe this", image_parts=image_parts)]
+
+    assert _sent_user_msg(backend).image_parts is None
+
+
+# ── callback returns None — task is dropped ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vision_guard_drops_task_when_callback_returns_none(tmp_path: Path):
+    img = tmp_path / "photo.png"
+    make_png(img)
+
+    backend = FakeBackend(mock_llm_chunk(content="should not be called"))
+    agent = build_test_agent_loop(config=_vision_config(False), backend=backend)
+
+    async def cancel_callback():
+        return None
+
+    agent.set_vision_model_callback(cancel_callback)
+
+    image_parts = [ImageContentPart(image_url="data:image/png;base64,abc")]
+    [_ async for _ in agent.act("describe this", image_parts=image_parts)]
+
+    assert backend.requests_messages == []
+
+
+# ── callback returns a vision model — override model is used ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_vision_guard_uses_override_model_from_callback(tmp_path: Path):
+    img = tmp_path / "photo.png"
+    make_png(img)
+
+    backend = FakeBackend(mock_llm_chunk(content="I see the image."))
+    agent = build_test_agent_loop(config=_vision_config(False), backend=backend)
+
+    vision_model = ModelConfig(
+        name="pixtral-large-2411",
+        provider="mistral",
+        alias="pixtral-large",
+        supports_vision=True,
+    )
+
+    async def pick_vision_model():
+        return vision_model
+
+    agent.set_vision_model_callback(pick_vision_model)
+
+    image_parts = [ImageContentPart(image_url="data:image/png;base64,abc")]
+    [_ async for _ in agent.act("describe this", image_parts=image_parts)]
+
+    assert len(backend.requests_messages) == 1
+    assert _sent_user_msg(backend).image_parts is not None
+
+
+@pytest.mark.asyncio
+async def test_active_model_unchanged_after_vision_override():
+    backend = FakeBackend([
+        mock_llm_chunk(content="vision response"),
+        mock_llm_chunk(content="plain response"),
+    ])
+    agent = build_test_agent_loop(config=_vision_config(False), backend=backend)
+
+    vision_model = ModelConfig(
+        name="pixtral-large-2411",
+        provider="mistral",
+        alias="pixtral-large",
+        supports_vision=True,
+    )
+
+    async def pick_vision_model():
+        return vision_model
+
+    agent.set_vision_model_callback(pick_vision_model)
+
+    image_parts = [ImageContentPart(image_url="data:image/png;base64,abc")]
+    [_ async for _ in agent.act("describe this", image_parts=image_parts)]
+
+    # After the vision turn, _current_turn_model must be reset to None
+    assert agent._current_turn_model is None
+
+    # A plain follow-up uses the original (non-vision) active model
+    [_ async for _ in agent.act("follow-up plain message")]
+    assert len(backend.requests_messages) == 2

--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -26,6 +26,11 @@ class CommandRegistry:
                 description="Edit config settings",
                 handler="_show_config",
             ),
+            "vision-model": Command(
+                aliases=frozenset(["/vision-model"]),
+                description="Editthe active vision model",
+                handler="_show_vision_model_picker",
+            ),
             "reload": Command(
                 aliases=frozenset(["/reload"]),
                 description="Reload configuration from disk",

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -4,6 +4,7 @@ import asyncio
 from enum import StrEnum, auto
 import os
 from pathlib import Path
+import re
 import signal
 import subprocess
 import time
@@ -89,7 +90,13 @@ from vibe.cli.update_notifier.update import do_update
 from vibe.core.agent_loop import AgentLoop, TeleportError
 from vibe.core.agents import AgentProfile
 from vibe.core.autocompletion.path_prompt_adapter import render_path_prompt
-from vibe.core.config import VibeConfig
+from vibe.core.config import (
+    IMAGE_EXTENSIONS,
+    MISTRAL_VISION_MODELS,
+    VISION_MODEL_CATEGORIES,
+    ModelConfig,
+    VibeConfig,
+)
 from vibe.core.logger import logger
 from vibe.core.paths.config_paths import HISTORY_FILE
 from vibe.core.session.session_loader import SessionLoader
@@ -237,6 +244,7 @@ class VibeApp(App):  # noqa: PLR0904
         self._loading_widget: LoadingWidget | None = None
         self._pending_approval: asyncio.Future | None = None
         self._pending_question: asyncio.Future | None = None
+        self._pending_vision_choice: asyncio.Future | None = None
 
         self.event_handler: EventHandler | None = None
 
@@ -328,6 +336,7 @@ class VibeApp(App):  # noqa: PLR0904
 
         self.agent_loop.set_approval_callback(self._approval_callback)
         self.agent_loop.set_user_input_callback(self._user_input_callback)
+        self.agent_loop.set_vision_model_callback(self._vision_model_callback)
         self._refresh_profile_widgets()
 
         chat_input_container = self.query_one(ChatInputContainer)
@@ -428,6 +437,11 @@ class VibeApp(App):  # noqa: PLR0904
             await self._remove_loading_widget()
 
     async def on_question_app_answered(self, message: QuestionApp.Answered) -> None:
+        if self._pending_vision_choice and not self._pending_vision_choice.done():
+            self._pending_vision_choice.set_result(message)
+            # UI teardown is handled by _vision_model_callback between steps.
+            return
+
         if self._pending_question and not self._pending_question.done():
             result = AskUserQuestionResult(answers=message.answers, cancelled=False)
             self._pending_question.set_result(result)
@@ -435,6 +449,11 @@ class VibeApp(App):  # noqa: PLR0904
         await self._switch_to_input_app()
 
     async def on_question_app_cancelled(self, message: QuestionApp.Cancelled) -> None:
+        if self._pending_vision_choice and not self._pending_vision_choice.done():
+            self._pending_vision_choice.set_result(None)
+            # UI teardown is handled by _vision_model_callback.
+            return
+
         if self._pending_question and not self._pending_question.done():
             result = AskUserQuestionResult(answers=[], cancelled=True)
             self._pending_question.set_result(result)
@@ -590,8 +609,21 @@ class VibeApp(App):  # noqa: PLR0904
                 ErrorMessage(f"Command failed: {e}", collapsed=self._tools_collapsed)
             )
 
+    @staticmethod
+    def _image_filenames_from_prompt(prompt: str) -> list[str]:
+        """Return the bare filenames of any @image.ext refs in *prompt*.
+
+        Does NOT load files — only needed for display purposes.
+        """
+        return [
+            Path(m.group(1)).name
+            for m in re.finditer(r"@(\S+)", prompt)
+            if Path(m.group(1)).suffix.lower() in IMAGE_EXTENSIONS
+        ]
+
     async def _handle_user_message(self, message: str) -> None:
-        user_message = UserMessage(message)
+        image_filenames = self._image_filenames_from_prompt(message)
+        user_message = UserMessage(message, image_filenames=image_filenames)
 
         await self._mount_and_scroll(user_message)
 
@@ -693,6 +725,200 @@ class VibeApp(App):  # noqa: PLR0904
         self._pending_question = None
         return result
 
+    async def _ask_vision_question(
+        self, args: AskUserQuestionArgs
+    ) -> QuestionApp.Answered | None:
+        """Show a QuestionApp for vision model selection and return the result.
+
+        Handles the full lifecycle: create future → show app → await → teardown.
+        Returns None if the user cancelled.
+        """
+        self._pending_vision_choice = asyncio.Future()
+        with paused_timer(self._loading_widget):
+            await self._switch_to_question_app(args)
+            result = await self._pending_vision_choice
+        self._pending_vision_choice = None
+        await self._switch_to_input_app()
+        return result
+
+    async def _vision_model_callback(self) -> ModelConfig | None:
+        """Ask the user what to do when the active model does not support vision.
+
+        Flow:
+          1. Drop this task  -or-  Use a vision model for this message
+          2. (if no saved default) Pick category: Premier / Efficient
+          3. (if no saved default) Pick model within that category
+          4. (if no saved default) Save as default for future tasks?
+
+        If a default vision model is already saved, all steps are skipped.
+        The active model is never changed; the override is for this turn only.
+        """
+        saved_default = self.config.get_active_vision_model()
+        if saved_default is not None:
+            return saved_default
+
+        # Step 1: drop or use a vision model
+        result1 = await self._ask_vision_question(
+            AskUserQuestionArgs(
+                questions=[
+                    Question(
+                        question="The active model does not support vision. What would you like to do?",
+                        options=[
+                            Choice(
+                                label="Use a vision model for this message",
+                                description="Active model stays unchanged",
+                            ),
+                            Choice(label="Drop this task"),
+                        ],
+                        hide_other=True,
+                    )
+                ]
+            )
+        )
+        if result1 is None or result1.answers[0].answer == "Drop this task":
+            return None
+
+        chosen_model = await self._pick_vision_model_from_categories(
+            "Select a vision model (active model stays unchanged):"
+        )
+        if chosen_model is None:
+            return None
+
+        # Step 4: offer to save as default
+        result_save = await self._ask_vision_question(
+            AskUserQuestionArgs(
+                questions=[
+                    Question(
+                        question=f"Save {chosen_model.alias} as your default vision model?",
+                        options=[
+                            Choice(
+                                label="Yes, save as default",
+                                description="Skip model selection on future vision tasks",
+                            ),
+                            Choice(label="No, just use it this time"),
+                        ],
+                        hide_other=True,
+                    )
+                ]
+            )
+        )
+        if (
+            result_save is not None
+            and result_save.answers[0].answer == "Yes, save as default"
+        ):
+            VibeConfig.save_updates({"active_vision_model": chosen_model.alias})
+            self.agent_loop.config.active_vision_model = chosen_model.alias
+
+        return chosen_model
+
+    async def _pick_vision_model_from_categories(
+        self, question: str
+    ) -> ModelConfig | None:
+        """Two-step picker: category then specific model. Returns None if cancelled."""
+        result_cat = await self._ask_vision_question(
+            AskUserQuestionArgs(
+                questions=[
+                    Question(
+                        question=question,
+                        options=[
+                            Choice(
+                                label=cat,
+                                description=" · ".join(m.alias for m in models),
+                            )
+                            for cat, models in VISION_MODEL_CATEGORIES.items()
+                        ],
+                        hide_other=True,
+                    )
+                ]
+            )
+        )
+        if result_cat is None:
+            return None
+
+        category = result_cat.answers[0].answer
+        group = VISION_MODEL_CATEGORIES[category]
+
+        result_model = await self._ask_vision_question(
+            AskUserQuestionArgs(
+                questions=[
+                    Question(
+                        question=f"Select a {category.lower()} vision model:",
+                        options=[
+                            Choice(label=m.alias, description=m.name) for m in group
+                        ],
+                        hide_other=True,
+                    )
+                ]
+            )
+        )
+        if result_model is None:
+            return None
+
+        chosen_alias = result_model.answers[0].answer
+        return next((m for m in MISTRAL_VISION_MODELS if m.alias == chosen_alias), None)
+
+    async def _show_vision_model_picker(self) -> None:
+        """Schedule the vision model picker as a task so the event handler returns immediately."""
+        asyncio.create_task(self._run_vision_model_picker())
+
+    async def _run_vision_model_picker(self) -> None:
+        """Let the user change or clear the default vision model via /vision-model."""
+        current = self.config.active_vision_model
+        current_label = current if current else "none — always ask"
+
+        # Step 1: category or clear
+        result1 = await self._ask_vision_question(
+            AskUserQuestionArgs(
+                questions=[
+                    Question(
+                        question=f"Default vision model (current: {current_label}):",
+                        options=[
+                            Choice(
+                                label=cat,
+                                description=" · ".join(m.alias for m in models),
+                            )
+                            for cat, models in VISION_MODEL_CATEGORIES.items()
+                        ]
+                        + [
+                            Choice(
+                                label="none — always ask",
+                                description="Clear saved default, prompt on each vision task",
+                            )
+                        ],
+                        hide_other=True,
+                    )
+                ]
+            )
+        )
+        if result1 is None:
+            return
+
+        category = result1.answers[0].answer
+
+        if category == "none — always ask":
+            chosen_alias = ""
+        else:
+            model = await self._pick_vision_model_from_categories(
+                f"Select a {category.lower()} vision model:"
+            )
+            if model is None:
+                return
+            chosen_alias = model.alias
+
+        VibeConfig.save_updates({"active_vision_model": chosen_alias})
+        self.agent_loop.config.active_vision_model = chosen_alias
+
+        if chosen_alias:
+            await self._mount_and_scroll(
+                UserCommandMessage(f"Default vision model set to **{chosen_alias}**.")
+            )
+        else:
+            await self._mount_and_scroll(
+                UserCommandMessage(
+                    "Default vision model cleared. You will be prompted on each vision task."
+                )
+            )
+
     async def _handle_agent_loop_turn(self, prompt: str) -> None:
         self._agent_running = True
 
@@ -705,8 +931,17 @@ class VibeApp(App):  # noqa: PLR0904
         await loading_area.mount(loading)
 
         try:
-            rendered_prompt = render_path_prompt(prompt, base_dir=Path.cwd())
-            async for event in self.agent_loop.act(rendered_prompt):
+            # Extract image refs BEFORE render_path_prompt so they are not
+            # converted into plain-text URI blocks by the path renderer.
+            from vibe.core.agent_loop import AgentLoop as _AgentLoop
+
+            prompt_text, image_parts = _AgentLoop._resolve_image_references(prompt)
+            rendered_prompt = render_path_prompt(
+                prompt_text or prompt, base_dir=Path.cwd()
+            )
+            async for event in self.agent_loop.act(
+                rendered_prompt, image_parts=image_parts if image_parts else None
+            ):
                 if self.event_handler:
                     await self.event_handler.handle_event(
                         event,

--- a/vibe/cli/textual_ui/app.tcss
+++ b/vibe/cli/textual_ui/app.tcss
@@ -215,6 +215,14 @@ Markdown {
     color: $mistral_orange;
 }
 
+.user-message-image-label {
+    width: 1fr;
+    height: auto;
+    padding-left: 1;
+    border-left: heavy #666666;
+    color: #666666;
+}
+
 .assistant-message {
     layout: stream;
     margin-top: 1;

--- a/vibe/cli/textual_ui/widgets/messages.py
+++ b/vibe/cli/textual_ui/widgets/messages.py
@@ -35,15 +35,26 @@ class ExpandingBorder(NonSelectableStatic):
 
 
 class UserMessage(Static):
-    def __init__(self, content: str, pending: bool = False) -> None:
+    def __init__(
+        self,
+        content: str,
+        pending: bool = False,
+        image_filenames: list[str] | None = None,
+    ) -> None:
         super().__init__()
         self.add_class("user-message")
         self._content = content
         self._pending = pending
+        self._image_filenames: list[str] = image_filenames or []
 
     def compose(self) -> ComposeResult:
-        with Horizontal(classes="user-message-container"):
+        with Vertical(classes="user-message-container"):
             yield NoMarkupStatic(self._content, classes="user-message-content")
+            if self._image_filenames:
+                names = " ".join(f"[{n}]" for n in self._image_filenames)
+                yield NoMarkupStatic(
+                    f"Uploaded Images: {names}", classes="user-message-image-label"
+                )
             if self._pending:
                 self.add_class("pending")
 

--- a/vibe/cli/textual_ui/windowing/history.py
+++ b/vibe/cli/textual_ui/windowing/history.py
@@ -44,7 +44,12 @@ def build_history_widgets(
         match msg.role:
             case Role.user:
                 if msg.content:
-                    widget = UserMessage(msg.content)
+                    image_filenames = (
+                        [f"image {i + 1}" for i in range(len(msg.image_parts))]
+                        if msg.image_parts
+                        else None
+                    )
+                    widget = UserMessage(msg.content, image_filenames=image_filenames)
                     widgets.append(widget)
                     history_widget_indices[widget] = history_index
 

--- a/vibe/core/agent_loop.py
+++ b/vibe/core/agent_loop.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 from collections.abc import AsyncGenerator, Callable, Generator
 from enum import StrEnum, auto
 from http import HTTPStatus
 import json
+import mimetypes
 from pathlib import Path
+import re
 from threading import Thread
 import time
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -16,7 +19,13 @@ from pydantic import BaseModel
 from vibe.cli.terminal_setup import detect_terminal
 from vibe.core.agents.manager import AgentManager
 from vibe.core.agents.models import AgentProfile, BuiltinAgentName
-from vibe.core.config import Backend, ProviderConfig, VibeConfig
+from vibe.core.config import (
+    IMAGE_EXTENSIONS,
+    Backend,
+    ModelConfig,
+    ProviderConfig,
+    VibeConfig,
+)
 from vibe.core.llm.backend.factory import BACKEND_FACTORY
 from vibe.core.llm.exceptions import BackendError
 from vibe.core.llm.format import (
@@ -70,6 +79,7 @@ from vibe.core.types import (
     CompactEndEvent,
     CompactStartEvent,
     EntrypointMetadata,
+    ImageContentPart,
     LLMChunk,
     LLMMessage,
     LLMUsage,
@@ -84,6 +94,7 @@ from vibe.core.types import (
     ToolStreamEvent,
     UserInputCallback,
     UserMessageEvent,
+    VisionModelCallback,
 )
 from vibe.core.utils import (
     TOOL_ERROR_TAG,
@@ -192,6 +203,8 @@ class AgentLoop:
 
         self.approval_callback: ApprovalCallback | None = None
         self.user_input_callback: UserInputCallback | None = None
+        self.vision_model_callback: VisionModelCallback | None = None
+        self._current_turn_model: ModelConfig | None = None
 
         self.entrypoint_metadata = entrypoint_metadata
         self.session_id = str(uuid4())
@@ -274,9 +287,11 @@ class AgentLoop:
             self.agent_profile,
         )
 
-    async def act(self, msg: str) -> AsyncGenerator[BaseEvent]:
+    async def act(
+        self, msg: str, image_parts: list[ImageContentPart] | None = None
+    ) -> AsyncGenerator[BaseEvent]:
         self._clean_message_history()
-        async for event in self._conversation_loop(msg):
+        async for event in self._conversation_loop(msg, image_parts=image_parts):
             yield event
 
     @property
@@ -433,8 +448,72 @@ class AgentLoop:
             })
         return headers
 
-    async def _conversation_loop(self, user_msg: str) -> AsyncGenerator[BaseEvent]:
-        user_message = LLMMessage(role=Role.user, content=user_msg)
+    @staticmethod
+    def _resolve_image_references(user_msg: str) -> tuple[str, list[ImageContentPart]]:
+        """Extract @<file> refs that point to image files and encode them as base64.
+
+        Returns the remaining text (with image refs stripped) and a list of
+        ImageContentPart objects ready to attach to an LLMMessage.
+        """
+        image_parts: list[ImageContentPart] = []
+        refs_to_remove: list[str] = []
+
+        for m in re.finditer(r"@(\S+)", user_msg):
+            path_str = m.group(1)
+            p = Path(path_str).expanduser()
+            if not p.is_absolute():
+                p = Path.cwd() / p
+            if p.suffix.lower() in IMAGE_EXTENSIONS:
+                if not p.exists():
+                    raise FileNotFoundError(f"Image file not found: {p}")
+                raw = p.read_bytes()
+                b64 = base64.standard_b64encode(raw).decode()
+                mime, _ = mimetypes.guess_type(str(p))
+                mime = mime or "image/png"
+                image_parts.append(
+                    ImageContentPart(
+                        image_url=f"data:{mime};base64,{b64}", media_type=mime
+                    )
+                )
+                refs_to_remove.append(m.group(0))
+
+        text = user_msg
+        for ref in refs_to_remove:
+            text = text.replace(ref, "")
+        text = text.strip()
+
+        return text, image_parts
+
+    async def _conversation_loop(
+        self, user_msg: str, image_parts: list[ImageContentPart] | None = None
+    ) -> AsyncGenerator[BaseEvent]:
+        # In TUI mode image_parts are pre-extracted before render_path_prompt runs.
+        # In non-TUI mode (programmatic / ACP) we resolve them here from the raw text.
+        if image_parts is None:
+            user_msg, image_parts = self._resolve_image_references(user_msg)
+            if not image_parts:
+                image_parts = None
+
+        # Vision capability guard: if images are present and the active model
+        # does not support vision, ask the user what to do via the callback.
+        if image_parts:
+            active_model = self.config.get_active_model()
+            if not active_model.supports_vision:
+                if self.vision_model_callback is not None:
+                    override_model = await self.vision_model_callback()
+                    if override_model is None:
+                        # User chose to drop this task — exit silently.
+                        return
+                    self._current_turn_model = override_model
+                else:
+                    # Non-TUI mode: no callback registered, drop images silently.
+                    image_parts = []
+
+        user_message = LLMMessage(
+            role=Role.user,
+            content=user_msg,
+            image_parts=image_parts if image_parts else None,
+        )
         self.messages.append(user_message)
         self.stats.steps += 1
         self._current_user_message_id = user_message.message_id
@@ -471,6 +550,7 @@ class AgentLoop:
                     return
 
         finally:
+            self._current_turn_model = None
             await self._save_messages()
 
     async def _perform_llm_turn(self) -> AsyncGenerator[BaseEvent, None]:
@@ -707,7 +787,7 @@ class AgentLoop:
         )
 
     async def _chat(self, max_tokens: int | None = None) -> LLMChunk:
-        active_model = self.config.get_active_model()
+        active_model = self._current_turn_model or self.config.get_active_model()
         provider = self.config.get_provider_for_model(active_model)
 
         available_tools = self.format_handler.get_available_tools(self.tool_manager)
@@ -752,7 +832,7 @@ class AgentLoop:
     async def _chat_streaming(
         self, max_tokens: int | None = None
     ) -> AsyncGenerator[LLMChunk]:
-        active_model = self.config.get_active_model()
+        active_model = self._current_turn_model or self.config.get_active_model()
         provider = self.config.get_provider_for_model(active_model)
 
         available_tools = self.format_handler.get_available_tools(self.tool_manager)
@@ -938,6 +1018,9 @@ class AgentLoop:
 
     def set_user_input_callback(self, callback: UserInputCallback) -> None:
         self.user_input_callback = callback
+
+    def set_vision_model_callback(self, callback: VisionModelCallback) -> None:
+        self.vision_model_callback = callback
 
     async def clear_history(self) -> None:
         await self.session_logger.save_interaction(

--- a/vibe/core/config.py
+++ b/vibe/core/config.py
@@ -258,6 +258,7 @@ class ModelConfig(BaseModel):
     input_price: float = 0.0  # Price per million input tokens
     output_price: float = 0.0  # Price per million output tokens
     thinking: Literal["off", "low", "medium", "high"] = "off"
+    supports_vision: bool = False
 
     @model_validator(mode="before")
     @classmethod
@@ -309,9 +310,94 @@ DEFAULT_MODELS = [
     ),
 ]
 
+MISTRAL_VISION_MODELS: list[ModelConfig] = [
+    ModelConfig(
+        name="pixtral-large-2411",
+        provider="mistral",
+        alias="pixtral-large",
+        supports_vision=True,
+        input_price=2.0,
+        output_price=6.0,
+    ),
+    ModelConfig(
+        name="mistral-large-2512",
+        provider="mistral",
+        alias="mistral-large-3",
+        supports_vision=True,
+        input_price=2.0,
+        output_price=6.0,
+    ),
+    ModelConfig(
+        name="mistral-medium-2508",
+        provider="mistral",
+        alias="mistral-medium-3",
+        supports_vision=True,
+        input_price=0.4,
+        output_price=2.0,
+    ),
+    ModelConfig(
+        name="mistral-small-2506",
+        provider="mistral",
+        alias="mistral-small-3",
+        supports_vision=True,
+        input_price=0.1,
+        output_price=0.3,
+    ),
+    ModelConfig(
+        name="ministral-14b-2512",
+        provider="mistral",
+        alias="ministral-14b",
+        supports_vision=True,
+        input_price=0.15,
+        output_price=0.15,
+    ),
+    ModelConfig(
+        name="ministral-8b-2512",
+        provider="mistral",
+        alias="ministral-8b",
+        supports_vision=True,
+        input_price=0.1,
+        output_price=0.1,
+    ),
+    ModelConfig(
+        name="ministral-3b-2512",
+        provider="mistral",
+        alias="ministral-3b",
+        supports_vision=True,
+        input_price=0.04,
+        output_price=0.04,
+    ),
+]
+
+IMAGE_EXTENSIONS: frozenset[str] = frozenset({
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".bmp",
+    ".tiff",
+    ".tif",
+})
+
+VISION_MODEL_CATEGORIES: dict[str, list[ModelConfig]] = {
+    "Premier": [
+        m
+        for m in MISTRAL_VISION_MODELS
+        if m.alias
+        in {"pixtral-large", "mistral-large-3", "mistral-medium-3", "mistral-small-3"}
+    ],
+    "Efficient": [
+        m
+        for m in MISTRAL_VISION_MODELS
+        if m.alias in {"ministral-14b", "ministral-8b", "ministral-3b"}
+    ],
+}
+
 
 class VibeConfig(BaseSettings):
     active_model: str = "devstral-2"
+    active_vision_model: str = ""
     vim_keybindings: bool = False
     disable_welcome_banner_animation: bool = False
     autocopy_to_clipboard: bool = True
@@ -452,6 +538,15 @@ class VibeConfig(BaseSettings):
                 return model
         raise ValueError(
             f"Active model '{self.active_model}' not found in configuration."
+        )
+
+    def get_active_vision_model(self) -> ModelConfig | None:
+        """Return the saved default vision model, or None if none is set."""
+        if not self.active_vision_model:
+            return None
+        return next(
+            (m for m in MISTRAL_VISION_MODELS if m.alias == self.active_vision_model),
+            None,
         )
 
     def get_provider_for_model(self, model: ModelConfig) -> ProviderConfig:

--- a/vibe/core/llm/backend/mistral.py
+++ b/vibe/core/llm/backend/mistral.py
@@ -40,6 +40,19 @@ class MistralMapper:
             case Role.system:
                 return mistralai.SystemMessage(role="system", content=msg.content or "")
             case Role.user:
+                if msg.image_parts:
+                    chunks: list[mistralai.TextChunk | mistralai.ImageURLChunk] = []
+                    if msg.content:
+                        chunks.append(
+                            mistralai.TextChunk(type="text", text=msg.content)
+                        )
+                    for part in msg.image_parts:
+                        chunks.append(
+                            mistralai.ImageURLChunk(
+                                image_url=mistralai.ImageURL(url=part.image_url)
+                            )
+                        )
+                    return mistralai.UserMessage(role="user", content=chunks)
                 return mistralai.UserMessage(role="user", content=msg.content)
             case Role.assistant:
                 content: mistralai.AssistantMessageContent
@@ -222,6 +235,22 @@ class MistralBackend:
             self._client = self._create_mistral_client()
         return self._client
 
+    @staticmethod
+    def _strip_image_parts_if_needed(
+        model: ModelConfig, messages: Sequence[LLMMessage]
+    ) -> Sequence[LLMMessage]:
+        """Return messages with image_parts cleared for non-vision models.
+
+        Avoids sending ImageURLChunks to models that don't support vision,
+        which causes a 400 error from the Mistral API.
+        """
+        if model.supports_vision:
+            return messages
+        return [
+            msg.model_copy(update={"image_parts": None}) if msg.image_parts else msg
+            for msg in messages
+        ]
+
     async def complete(
         self,
         *,
@@ -235,6 +264,7 @@ class MistralBackend:
         metadata: dict[str, str] | None = None,
     ) -> LLMChunk:
         try:
+            messages = self._strip_image_parts_if_needed(model, messages)
             merged_messages = merge_consecutive_user_messages(messages)
             response = await self._get_client().chat.complete_async(
                 model=model.name,
@@ -311,6 +341,7 @@ class MistralBackend:
         metadata: dict[str, str] | None = None,
     ) -> AsyncGenerator[LLMChunk, None]:
         try:
+            messages = self._strip_image_parts_if_needed(model, messages)
             merged_messages = merge_consecutive_user_messages(messages)
             async for chunk in await self._get_client().chat.stream_async(
                 model=model.name,

--- a/vibe/core/types.py
+++ b/vibe/core/types.py
@@ -10,9 +10,11 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal, overload
 from uuid import uuid4
 
 if TYPE_CHECKING:
+    from vibe.core.config import ModelConfig
     from vibe.core.tools.base import BaseTool
 else:
     BaseTool = Any
+    ModelConfig = Any
 
 from pydantic import (
     BaseModel,
@@ -175,6 +177,13 @@ class ToolCall(BaseModel):
     type: Literal["function"] = "function"
 
 
+class ImageContentPart(BaseModel):
+    """A single image attached to a user message, encoded as a data URL."""
+
+    image_url: str  # "data:<mime>;base64,<b64>"
+    media_type: str = "image/png"
+
+
 def _content_before(v: Any) -> str:
     if isinstance(v, str):
         return v
@@ -215,6 +224,7 @@ class LLMMessage(BaseModel):
     name: str | None = None
     tool_call_id: str | None = None
     message_id: str | None = None
+    image_parts: list[ImageContentPart] | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -414,6 +424,8 @@ type SyncApprovalCallback = Callable[
 type ApprovalCallback = AsyncApprovalCallback | SyncApprovalCallback
 
 type UserInputCallback = Callable[[BaseModel], Awaitable[BaseModel]]
+
+type VisionModelCallback = Callable[[], Awaitable["ModelConfig | None"]]
 
 
 class MessageList(Sequence[LLMMessage]):


### PR DESCRIPTION
  ## Overview

  This PR adds multimodal image input support to Mistral Vibe, allowing users to reference
  local image files directly in their chat messages using the `@filename.png` syntax.
  The feature includes a full UX flow for vision model selection, a `/vision-model` command,
  and chat UI feedback.
  
  
  <img width="1376" height="953" alt="pr-image" src="https://github.com/user-attachments/assets/6677521e-c47e-486a-99b2-7aff8652b34c" />

  ## What's Changed

  ### Core — Image Reference Resolution (`agent_loop.py`)
  - Detects `@ref.ext` patterns in user messages where the extension is a known image format
  - Encodes the image as base64 and attaches it to the message as `ImageContentPart`
  - Raises a clear `FileNotFoundError` if the referenced file does not exist
  - Image resolution runs before `render_path_prompt` to avoid interference with file refs

  ### Core — Types (`types.py`)
  - Added `ImageContentPart` model with `image_url` (base64 data URI) and `media_type`
  - Added `image_parts` field to `LLMMessage`
  - Added `VisionModelCallback` type alias

  ### Core — Config (`config.py`)
  - Added `supports_vision: bool` to `ModelConfig`
  - Added `active_vision_model` field to `VibeConfig`
  - Added `get_active_vision_model()` method
  - Added `IMAGE_EXTENSIONS` constant
  - Added `VISION_MODEL_CATEGORIES` grouping vision models into **Premier** and **Efficient** tiers
  - Updated `MISTRAL_VISION_MODELS` to reflect current available models (removed deprecated ones)

  ### Backend — Mistral Mapper (`mistral.py`)
  - `MistralMapper` builds `[TextChunk, ImageURLChunk, ...]` for messages with image parts
  - Added `_strip_image_parts_if_needed()` — strips image parts from all messages when
    the active model does not support vision, preventing 400 errors on follow-up turns

  ### Vision Guard — UX Flow (`agent_loop.py` + `app.py`)
  When a user sends an image message and the active model does not support vision:
  1. If a default vision model is saved → use it silently, no interruption
  2. Otherwise → prompt the user:
     - **Use a vision model for this message** → pick from Premier / Efficient categories
     - **Drop this task** → cancel gracefully
  3. After picking a model → offer to save it as the default for future vision tasks
  4. The active model always remains unchanged after the turn

  ### UI — `/vision-model` Command (`commands.py` + `app.py`)
  - Added `/vision-model` slash command to change or clear the default vision model at any time
  - Uses the same two-step category → model picker
  - Persists the selection to `~/.vibe/config.toml` and updates the in-memory config immediately

  ### UI — Chat Feedback (`messages.py` + `app.tcss`)
  - Uploaded image filenames are shown below the user message: `Uploaded Images: [photo.png]`
  - Styled with a left border and muted color to match the terminal aesthetic

  

  ## Supported Image Formats

  `.png` `.jpg` `.jpeg` `.gif` `.webp` `.bmp` `.tiff` `.tif`

  ## Supported Vision Models

  **Premier:** `pixtral-large`, `mistral-large-3`, `mistral-medium-3`, `mistral-small-3`
  **Efficient:** `ministral-14b`, `ministral-8b`, `ministral-3b`


  ## Tests

  29 new tests added:

  | File | Coverage |
  |---|---|
  | `tests/test_multimodal.py` | Image ref detection, base64 encoding, missing file error, extension filtering |
  | `tests/test_vision_guard.py` | Vision guard logic, model override, callback returning None, active model unchanged |
  | `tests/backend/test_mistral_image.py` | Mistral mapper with image chunks, strip logic for non-vision models |

To run test 

 ```bash
  uv run pytest tests/test_multimodal.py tests/test_vision_guard.py tests/backend/test_mistral_image.py -v
 ```

  ### How to Test Manually

  1. Run uv run vibe
  2. Send: What is in this image? @photo.png
  3. If the active model does not support vision, you will be prompted to pick one
  4. Select a model — optionally save it as default
  5. Send another image message — the default model is used silently
  6. Use /vision-model to change or clear the default
  7. Switch back to a non-vision message — no errors, conversation continues normally