### PR TITLE
Add install-skill command and repository-based installer

### DIFF
--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -16,6 +16,18 @@ class TestCommandRegistry:
         registry = CommandRegistry()
         assert registry.get_command_name("  /help  ") == "help"
         assert registry.get_command_name("/HELP") == "help"
+        assert registry.get_command_name(
+            "  /INSTALL-SKILL https://github.com/propel-gtm/propel-code-skills  "
+        ) == "install-skill"
+
+    def test_get_command_args_returns_argument_tail(self) -> None:
+        registry = CommandRegistry()
+        assert (
+            registry.get_command_args(
+                " /install-skill https://github.com/propel-gtm/propel-code-skills carl "
+            )
+            == "https://github.com/propel-gtm/propel-code-skills carl"
+        )
 
     def test_get_command_name_returns_none_for_unknown(self) -> None:
         registry = CommandRegistry()

--- a/tests/skills/test_installer.py
+++ b/tests/skills/test_installer.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from vibe.core.skills.installer import (
+    CLONE_TIMEOUT_SECONDS,
+    SkillInstallResult,
+    install_skill,
+)
+
+
+def test_install_skill_captures_clone_output(
+    monkeypatch, tmp_path: Path
+) -> None:
+    observed: dict[str, object] = {}
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        observed.update(
+            {
+                "command": command,
+                "check": check,
+                "capture_output": capture_output,
+                "text": text,
+                "timeout": timeout,
+            }
+        )
+        repo_dir = Path(command[-1])
+        skill_dir = repo_dir / "skills" / "carl"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("name: carl\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = install_skill(
+        "https://github.com/propel-gtm/propel-code-skills",
+        target_dir=tmp_path / "installed-skills",
+    )
+
+    assert result == SkillInstallResult(
+        success=True,
+        message="Skills installed successfully. Restart the application to use them.",
+    )
+    assert (tmp_path / "installed-skills" / "carl").is_dir()
+    assert observed["check"] is True
+    assert observed["capture_output"] is True
+    assert observed["text"] is True
+    assert observed["timeout"] == CLONE_TIMEOUT_SECONDS
+    command = observed["command"]
+    assert isinstance(command, list)
+    assert command[:3] == [
+        "git",
+        "clone",
+        "https://github.com/propel-gtm/propel-code-skills",
+    ]
+
+
+def test_install_skill_returns_error_when_named_skill_is_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        repo_dir = Path(command[-1])
+        skill_dir = repo_dir / "skills" / "other-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("name: other-skill\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = install_skill(
+        "https://github.com/propel-gtm/propel-code-skills",
+        skill_name="carl",
+        target_dir=tmp_path / "installed-skills",
+    )
+
+    assert result == SkillInstallResult(
+        success=False,
+        message="Skill 'carl' was not found in the repository.",
+    )
+
+
+def test_install_skill_returns_clone_error_without_terminal_output(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            128,
+            command,
+            stderr="fatal: repository not found",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = install_skill(
+        "https://github.com/propel-gtm/missing-skills",
+        target_dir=tmp_path / "installed-skills",
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert result == SkillInstallResult(
+        success=False,
+        message="Git clone failed: fatal: repository not found",
+    )

--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -77,6 +77,11 @@ class CommandRegistry:
                 description="Browse and resume past sessions",
                 handler="_show_session_picker",
             ),
+            "install-skill": Command(
+                aliases=frozenset(["/install-skill"]),
+                description="Install a skill from a repository",
+                handler="_install_skill",
+            ),
         }
 
         for command in excluded_commands:

--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -9,6 +9,7 @@ class Command:
     description: str
     handler: str
     exits: bool = False
+    accepts_arguments: bool = False
 
 
 class CommandRegistry:
@@ -79,8 +80,9 @@ class CommandRegistry:
             ),
             "install-skill": Command(
                 aliases=frozenset(["/install-skill"]),
-                description="Install a skill from a repository",
+                description="Install skills from a repository",
                 handler="_install_skill",
+                accepts_arguments=True,
             ),
         }
 
@@ -97,7 +99,25 @@ class CommandRegistry:
         return self.commands.get(cmd_name) if cmd_name else None
 
     def get_command_name(self, user_input: str) -> str | None:
-        return self._alias_map.get(user_input.lower().strip())
+        command_alias, _ = self._split_input(user_input)
+        return self._alias_map.get(command_alias)
+
+    def get_command_args(self, user_input: str) -> str:
+        _, command_args = self._split_input(user_input)
+        return command_args
+
+    @staticmethod
+    def _split_input(user_input: str) -> tuple[str, str]:
+        if not (stripped := user_input.strip()):
+            return "", ""
+
+        match stripped.split(maxsplit=1):
+            case [command_alias, command_args]:
+                return command_alias.lower(), command_args
+            case [command_alias]:
+                return command_alias.lower(), ""
+            case _:
+                return "", ""
 
     def get_help_text(self) -> str:
         lines: list[str] = [

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -521,6 +521,29 @@ class VibeApp(App):  # noqa: PLR0904
             return True
         return False
 
+    async def _install_skill(self) -> None:
+        """Handle the installation of a skill from a repository."""
+        await self._mount_and_scroll(UserCommandMessage("Installing skill..."))
+        
+        # Parse the command to extract repo_url and skill_name
+        # This is a placeholder; actual parsing logic should be implemented
+        repo_url = "https://github.com/propel-gtm/propel-code-skills.git"  # Default for testing
+        skill_name = None  # Install all skills by default
+        
+        from vibe.core.skills.installer import install_skill
+        success = install_skill(repo_url, skill_name)
+        if success:
+            await self._mount_and_scroll(
+                UserCommandMessage("Skill installed successfully. Restart the application to use it.")
+            )
+        else:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    "Failed to install skill. Check the repository URL and skill name.",
+                    collapsed=self._tools_collapsed
+                )
+            )
+
     def _get_skill_entries(self) -> list[tuple[str, str]]:
         if not self.agent_loop:
             return []
@@ -556,6 +579,22 @@ class VibeApp(App):  # noqa: PLR0904
 
         await self._handle_user_message(skill_content)
         return True
+
+    async def _install_skill(self, repo_url: str, skill_name: str | None = None) -> None:
+        from vibe.core.skills.installer import install_skill
+        
+        success = install_skill(repo_url, skill_name)
+        if success:
+            await self._mount_and_scroll(
+                f"Skill installed successfully. Restart the application to use it."
+            )
+        else:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    "Failed to install skill. Check the repository URL and skill name.",
+                    collapsed=self._tools_collapsed
+                )
+            )
 
     async def _handle_bash_command(self, command: str) -> None:
         if not command:

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -524,23 +524,24 @@ class VibeApp(App):  # noqa: PLR0904
     async def _install_skill(self) -> None:
         """Handle the installation of a skill from a repository."""
         await self._mount_and_scroll(UserCommandMessage("Installing skill..."))
-        
-        # Parse the command to extract repo_url and skill_name
-        # This is a placeholder; actual parsing logic should be implemented
+
         repo_url = "https://github.com/propel-gtm/propel-code-skills.git"  # Default for testing
         skill_name = None  # Install all skills by default
-        
+
         from vibe.core.skills.installer import install_skill
-        success = install_skill(repo_url, skill_name)
+
+        success = await asyncio.to_thread(install_skill, repo_url, skill_name)
         if success:
             await self._mount_and_scroll(
-                UserCommandMessage("Skill installed successfully. Restart the application to use it.")
+                UserCommandMessage(
+                    "Skill installed successfully. Restart the application to use it."
+                )
             )
         else:
             await self._mount_and_scroll(
                 ErrorMessage(
                     "Failed to install skill. Check the repository URL and skill name.",
-                    collapsed=self._tools_collapsed
+                    collapsed=self._tools_collapsed,
                 )
             )
 
@@ -579,22 +580,6 @@ class VibeApp(App):  # noqa: PLR0904
 
         await self._handle_user_message(skill_content)
         return True
-
-    async def _install_skill(self, repo_url: str, skill_name: str | None = None) -> None:
-        from vibe.core.skills.installer import install_skill
-        
-        success = install_skill(repo_url, skill_name)
-        if success:
-            await self._mount_and_scroll(
-                f"Skill installed successfully. Restart the application to use it."
-            )
-        else:
-            await self._mount_and_scroll(
-                ErrorMessage(
-                    "Failed to install skill. Check the repository URL and skill name.",
-                    collapsed=self._tools_collapsed
-                )
-            )
 
     async def _handle_bash_command(self, command: str) -> None:
         if not command:

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -4,6 +4,7 @@ import asyncio
 from enum import StrEnum, auto
 import os
 from pathlib import Path
+import shlex
 import signal
 import subprocess
 import time
@@ -514,33 +515,58 @@ class VibeApp(App):  # noqa: PLR0904
                 )
             await self._mount_and_scroll(UserMessage(user_input))
             handler = getattr(self, command.handler)
+            handler_args = (
+                (self.commands.get_command_args(user_input),)
+                if command.accepts_arguments
+                else ()
+            )
             if asyncio.iscoroutinefunction(handler):
-                await handler()
+                await handler(*handler_args)
             else:
-                handler()
+                handler(*handler_args)
             return True
         return False
 
-    async def _install_skill(self) -> None:
+    async def _install_skill(self, command_args: str) -> None:
         """Handle the installation of a skill from a repository."""
-        await self._mount_and_scroll(UserCommandMessage("Installing skill..."))
+        try:
+            install_args = shlex.split(command_args)
+        except ValueError as exc:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    f"Invalid install-skill arguments: {exc}",
+                    collapsed=self._tools_collapsed,
+                )
+            )
+            return
 
-        repo_url = "https://github.com/propel-gtm/propel-code-skills.git"  # Default for testing
-        skill_name = None  # Install all skills by default
+        match install_args:
+            case [repo_url]:
+                skill_name = None
+            case [repo_url, skill_name]:
+                pass
+            case _:
+                await self._mount_and_scroll(
+                    ErrorMessage(
+                        "Usage: /install-skill <repo_url> [skill_name]",
+                        collapsed=self._tools_collapsed,
+                    )
+                )
+                return
+
+        await self._mount_and_scroll(UserCommandMessage("Installing skill..."))
 
         from vibe.core.skills.installer import install_skill
 
-        success = await asyncio.to_thread(install_skill, repo_url, skill_name)
-        if success:
+        result = await asyncio.to_thread(install_skill, repo_url, skill_name)
+        if result.success:
             await self._mount_and_scroll(
-                UserCommandMessage(
-                    "Skill installed successfully. Restart the application to use it."
-                )
+                UserCommandMessage(result.message)
             )
         else:
             await self._mount_and_scroll(
                 ErrorMessage(
-                    "Failed to install skill. Check the repository URL and skill name.",
+                    result.message,
                     collapsed=self._tools_collapsed,
                 )
             )

--- a/vibe/core/skills/installer.py
+++ b/vibe/core/skills/installer.py
@@ -1,9 +1,44 @@
-from pathlib import Path
-import subprocess
 import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+DEFAULT_SKILLS_DIR = Path(".vibe/skills")
+CLONE_TIMEOUT_SECONDS = 120
 
 
-def install_skill(repo_url: str, skill_name: str | None = None, target_dir: Path | None = None) -> bool:
+def _find_skills_dir(repo_dir: Path) -> Path | None:
+    for relative_path in (
+        Path("skills"),
+        Path("plugins/propel-code-review/skills"),
+        Path("plugins/skills"),
+    ):
+        candidate = repo_dir / relative_path
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def _copy_skills(skills_dir: Path, target_dir: Path, skill_name: str | None) -> bool:
+    if skill_name is not None:
+        skill_source = skills_dir / skill_name
+        if not skill_source.is_dir():
+            return False
+        shutil.copytree(skill_source, target_dir / skill_name, dirs_exist_ok=True)
+        return True
+
+    copied_any = False
+    for skill_dir in skills_dir.iterdir():
+        if not skill_dir.is_dir():
+            continue
+        shutil.copytree(skill_dir, target_dir / skill_dir.name, dirs_exist_ok=True)
+        copied_any = True
+    return copied_any
+
+
+def install_skill(
+    repo_url: str, skill_name: str | None = None, target_dir: Path | None = None
+) -> bool:
     """Install a skill from a repository.
 
     Args:
@@ -14,43 +49,22 @@ def install_skill(repo_url: str, skill_name: str | None = None, target_dir: Path
     Returns:
         True if installation was successful, False otherwise.
     """
-    if target_dir is None:
-        target_dir = Path(".vibe/skills")
+    target_path = target_dir or DEFAULT_SKILLS_DIR
+    target_path.mkdir(parents=True, exist_ok=True)
 
     try:
-        # Clone the repository
-        repo_dir = Path(f"temp_{repo_url.split('/')[-1]}")
-        subprocess.run(["git", "clone", repo_url, repo_dir], check=True)
+        with tempfile.TemporaryDirectory(prefix="vibe-skill-install-") as temp_dir:
+            repo_dir = Path(temp_dir) / "repo"
+            subprocess.run(
+                ["git", "clone", repo_url, str(repo_dir)],
+                check=True,
+                timeout=CLONE_TIMEOUT_SECONDS,
+            )
 
-        # Locate the skills directory
-        skills_dir = repo_dir / "skills"
-        if not skills_dir.exists():
-            # Try alternative paths for skills
-            alternative_paths = [
-                repo_dir / "plugins" / "propel-code-review" / "skills",
-                repo_dir / "plugins" / "skills",
-            ]
-            for path in alternative_paths:
-                if path.exists():
-                    skills_dir = path
-                    break
-            else:
+            if (skills_dir := _find_skills_dir(repo_dir)) is None:
                 return False
 
-        # Copy the skill(s) to the target directory
-        if skill_name:
-            skill_source = skills_dir / skill_name
-            if skill_source.exists():
-                shutil.copytree(skill_source, target_dir / skill_name, dirs_exist_ok=True)
-        else:
-            for skill in skills_dir.iterdir():
-                if skill.is_dir():
-                    shutil.copytree(skill, target_dir / skill.name, dirs_exist_ok=True)
-
-        # Clean up
-        shutil.rmtree(repo_dir)
-
-        return True
-    except Exception as e:
-        print(f"Error installing skill: {e}")
+            return _copy_skills(skills_dir, target_path, skill_name)
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"Error installing skill: {exc}")
         return False

--- a/vibe/core/skills/installer.py
+++ b/vibe/core/skills/installer.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import subprocess
+import shutil
+
+
+def install_skill(repo_url: str, skill_name: str | None = None, target_dir: Path | None = None) -> bool:
+    """Install a skill from a repository.
+
+    Args:
+        repo_url: URL of the repository containing the skill.
+        skill_name: Name of the skill to install. If None, install all skills.
+        target_dir: Target directory to install the skill. Defaults to .vibe/skills/.
+
+    Returns:
+        True if installation was successful, False otherwise.
+    """
+    if target_dir is None:
+        target_dir = Path(".vibe/skills")
+
+    try:
+        # Clone the repository
+        repo_dir = Path(f"temp_{repo_url.split('/')[-1]}")
+        subprocess.run(["git", "clone", repo_url, repo_dir], check=True)
+
+        # Locate the skills directory
+        skills_dir = repo_dir / "skills"
+        if not skills_dir.exists():
+            # Try alternative paths for skills
+            alternative_paths = [
+                repo_dir / "plugins" / "propel-code-review" / "skills",
+                repo_dir / "plugins" / "skills",
+            ]
+            for path in alternative_paths:
+                if path.exists():
+                    skills_dir = path
+                    break
+            else:
+                return False
+
+        # Copy the skill(s) to the target directory
+        if skill_name:
+            skill_source = skills_dir / skill_name
+            if skill_source.exists():
+                shutil.copytree(skill_source, target_dir / skill_name, dirs_exist_ok=True)
+        else:
+            for skill in skills_dir.iterdir():
+                if skill.is_dir():
+                    shutil.copytree(skill, target_dir / skill.name, dirs_exist_ok=True)
+
+        # Clean up
+        shutil.rmtree(repo_dir)
+
+        return True
+    except Exception as e:
+        print(f"Error installing skill: {e}")
+        return False

--- a/vibe/core/skills/installer.py
+++ b/vibe/core/skills/installer.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import shutil
 import subprocess
 import tempfile
@@ -5,6 +6,12 @@ from pathlib import Path
 
 DEFAULT_SKILLS_DIR = Path(".vibe/skills")
 CLONE_TIMEOUT_SECONDS = 120
+
+
+@dataclass(frozen=True, slots=True)
+class SkillInstallResult:
+    success: bool
+    message: str
 
 
 def _find_skills_dir(repo_dir: Path) -> Path | None:
@@ -21,6 +28,9 @@ def _find_skills_dir(repo_dir: Path) -> Path | None:
 
 def _copy_skills(skills_dir: Path, target_dir: Path, skill_name: str | None) -> bool:
     if skill_name is not None:
+        # Reject path separators and traversal components to prevent directory traversal
+        if '/' in skill_name or '\\' in skill_name or skill_name in ('.', '..'):
+            return False
         skill_source = skills_dir / skill_name
         if not skill_source.is_dir():
             return False
@@ -36,9 +46,41 @@ def _copy_skills(skills_dir: Path, target_dir: Path, skill_name: str | None) -> 
     return copied_any
 
 
+def _stringify_output(output: bytes | str | None) -> str:
+    match output:
+        case bytes():
+            return output.decode("utf-8", errors="replace").strip()
+        case str():
+            return output.strip()
+        case _:
+            return ""
+
+
+def _format_install_error(exc: OSError | subprocess.SubprocessError) -> str:
+    match exc:
+        case subprocess.TimeoutExpired():
+            return (
+                f"Repository clone timed out after {CLONE_TIMEOUT_SECONDS} seconds."
+            )
+        case subprocess.CalledProcessError():
+            if details := _stringify_output(exc.stderr) or _stringify_output(exc.stdout):
+                return f"Git clone failed: {details}"
+            return "Git clone failed."
+        case OSError():
+            return f"Skill installation failed: {exc}"
+        case _:
+            return f"Skill installation failed: {exc}"
+
+
+def _success_message(skill_name: str | None) -> str:
+    if skill_name is None:
+        return "Skills installed successfully. Restart the application to use them."
+    return f"Skill '{skill_name}' installed successfully. Restart the application to use it."
+
+
 def install_skill(
     repo_url: str, skill_name: str | None = None, target_dir: Path | None = None
-) -> bool:
+) -> SkillInstallResult:
     """Install a skill from a repository.
 
     Args:
@@ -47,24 +89,42 @@ def install_skill(
         target_dir: Target directory to install the skill. Defaults to .vibe/skills/.
 
     Returns:
-        True if installation was successful, False otherwise.
+        Structured install result with status and user-facing message.
     """
-    target_path = target_dir or DEFAULT_SKILLS_DIR
-    target_path.mkdir(parents=True, exist_ok=True)
-
     try:
+        target_path = target_dir or DEFAULT_SKILLS_DIR
+        target_path.mkdir(parents=True, exist_ok=True)
+
         with tempfile.TemporaryDirectory(prefix="vibe-skill-install-") as temp_dir:
             repo_dir = Path(temp_dir) / "repo"
             subprocess.run(
                 ["git", "clone", repo_url, str(repo_dir)],
                 check=True,
+                capture_output=True,
+                text=True,
                 timeout=CLONE_TIMEOUT_SECONDS,
             )
 
             if (skills_dir := _find_skills_dir(repo_dir)) is None:
-                return False
+                return SkillInstallResult(
+                    success=False,
+                    message="No skills directory found in the repository.",
+                )
 
-            return _copy_skills(skills_dir, target_path, skill_name)
+            if not _copy_skills(skills_dir, target_path, skill_name):
+                if skill_name is None:
+                    return SkillInstallResult(
+                        success=False,
+                        message="No installable skills were found in the repository.",
+                    )
+                return SkillInstallResult(
+                    success=False,
+                    message=f"Skill '{skill_name}' was not found in the repository.",
+                )
+
+            return SkillInstallResult(
+                success=True,
+                message=_success_message(skill_name),
+            )
     except (OSError, subprocess.SubprocessError) as exc:
-        print(f"Error installing skill: {exc}")
-        return False
+        return SkillInstallResult(success=False, message=_format_install_error(exc))


### PR DESCRIPTION
**Add `/install-skill` CLI command and repository-based installer**

This PR introduces a repository-driven skill installation flow by adding a new `install_skill` utility in `vibe/core/skills/installer.py` and wiring a `/install-skill` command into the textual UI. The command parser now supports argument tails, enabling the command to accept a repo URL and optional skill name, and runs the installer in a background thread.