### PR TITLE
Add /improve command with session digest analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ Vibe provides several built-in slash commands. Use slash commands by typing them
 > /help
 ```
 
+Useful built-ins include `/help`, `/compact`, `/resume`, and `/improve` to analyze recent sessions and ask Vibe how it should improve.
+
 ### Custom Slash Commands via Skills
 
 You can define your own slash commands through the skills system. Skills are reusable components that extend Vibe's functionality.

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -10,6 +10,7 @@ class TestCommandRegistry:
         assert registry.get_command_name("/config") == "config"
         assert registry.get_command_name("/model") == "config"
         assert registry.get_command_name("/clear") == "clear"
+        assert registry.get_command_name("/improve") == "improve"
         assert registry.get_command_name("/exit") == "exit"
 
     def test_get_command_name_normalizes_input(self) -> None:
@@ -46,6 +47,12 @@ class TestCommandRegistry:
                 assert cmd is not None
                 assert cmd_name in registry.commands
                 assert registry.commands[cmd_name] is cmd
+
+    def test_improve_command_registration(self) -> None:
+        registry = CommandRegistry()
+        cmd = registry.find_command("/improve")
+        assert cmd is not None
+        assert cmd.handler == "_improve_from_sessions"
 
     def test_excluded_commands_not_in_registry(self) -> None:
         registry = CommandRegistry(excluded_commands=["exit"])

--- a/tests/cli/test_improve_command.py
+++ b/tests/cli/test_improve_command.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import (
+    build_test_agent_loop,
+    build_test_vibe_app,
+    build_test_vibe_config,
+)
+from tests.mock.utils import mock_llm_chunk
+from tests.stubs.fake_backend import FakeBackend
+from vibe.cli.textual_ui.widgets.messages import AssistantMessage
+from vibe.core.config import SessionLoggingConfig
+from vibe.core.types import Role
+
+
+@pytest.mark.asyncio
+async def test_improve_command_builds_prompt_and_submits_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+    built_prompt = "Analyze my recent sessions and tell me where Vibe should improve."
+
+    def fake_build_improve_prompt(
+        session_config: SessionLoggingConfig,
+        current_session_dir: Path | None,
+        limit: int,
+    ) -> str:
+        captured["session_config"] = session_config
+        captured["current_session_dir"] = current_session_dir
+        captured["limit"] = limit
+        return built_prompt
+
+    monkeypatch.setattr(
+        "vibe.cli.textual_ui.app.build_improve_prompt", fake_build_improve_prompt
+    )
+
+    session_logging = SessionLoggingConfig(
+        save_dir=str(tmp_path / "sessions"),
+        session_prefix="test",
+        enabled=True,
+    )
+    config = build_test_vibe_config(session_logging=session_logging)
+    backend = FakeBackend(
+        [[mock_llm_chunk(content="Tighten slash command defaults.")]]
+    )
+    agent_loop = build_test_agent_loop(config=config, backend=backend)
+    app = build_test_vibe_app(agent_loop=agent_loop)
+
+    async with app.run_test() as pilot:
+        await pilot.press(*"/improve")
+        await pilot.press("enter")
+        await pilot.pause(0.5)
+        assistant_messages = app.query(AssistantMessage)
+        assert len(assistant_messages) == 1
+        assert assistant_messages[0]._content == "Tighten slash command defaults."
+
+    assert captured["session_config"] == session_logging
+    assert captured["current_session_dir"] == agent_loop.session_logger.session_dir
+    assert captured["limit"] == 50
+
+    assert any(
+        message.role == Role.user
+        and message.content == built_prompt
+        and message.persist_to_session_log is False
+        for message in agent_loop.messages
+    )
+    assert any(
+        message.role == Role.assistant
+        and message.content == "Tighten slash command defaults."
+        and message.persist_to_session_log is False
+        for message in agent_loop.messages
+    )

--- a/tests/session/test_improve_prompt.py
+++ b/tests/session/test_improve_prompt.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 from datetime import datetime
 import json
+import logging
 from pathlib import Path
 import time
 
 import pytest
 
 from vibe.core.config import SessionLoggingConfig
+from vibe.core.logger import logger
 from vibe.core.session.improve_prompt import (
     DEFAULT_IMPROVE_SESSION_LIMIT,
+    SessionAnalysis,
     build_improve_prompt,
 )
 from vibe.core.types import FunctionCall, LLMMessage, Role, ToolCall
@@ -196,3 +199,53 @@ def test_build_improve_prompt_ignores_legacy_improve_turns(
     assert "Investigate slow test startup" in prompt
     assert "old /improve output" not in prompt
     assert "legacy-improve" not in prompt
+
+
+def test_build_improve_prompt_logs_analysis_failures(
+    session_config: SessionLoggingConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    session_root = Path(session_config.save_dir)
+    create_session(
+        session_root,
+        "healthy-session",
+        user_prompt="Investigate flaky session handling",
+        assistant_text="I will inspect the session analyzer first.",
+        cwd="/repo/healthy",
+    )
+    time.sleep(0.01)
+    broken_session = create_session(
+        session_root,
+        "broken-session",
+        user_prompt="This session should log an analysis failure",
+        assistant_text="I will inspect the session analyzer first.",
+        cwd="/repo/broken",
+    )
+
+    original_from_session = SessionAnalysis.from_session
+
+    def fake_from_session(
+        cls: type[SessionAnalysis],
+        session_dir: Path,
+        messages: list[LLMMessage],
+        metadata: dict[str, object],
+    ) -> SessionAnalysis:
+        if session_dir == broken_session:
+            raise RuntimeError("boom")
+        return original_from_session(session_dir, messages, metadata)
+
+    monkeypatch.setattr(
+        SessionAnalysis, "from_session", classmethod(fake_from_session)
+    )
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        prompt = build_improve_prompt(session_config=session_config)
+
+    assert "Investigate flaky session handling" in prompt
+    assert any(
+        record.getMessage()
+        == f"Skipping session {broken_session} after analysis failure"
+        and record.exc_info is not None
+        for record in caplog.records
+    )

--- a/tests/session/test_improve_prompt.py
+++ b/tests/session/test_improve_prompt.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from pathlib import Path
+import time
+
+import pytest
+
+from vibe.core.config import SessionLoggingConfig
+from vibe.core.session.improve_prompt import (
+    DEFAULT_IMPROVE_SESSION_LIMIT,
+    build_improve_prompt,
+)
+from vibe.core.types import FunctionCall, LLMMessage, Role, ToolCall
+
+
+def create_session(
+    session_root: Path,
+    session_id: str,
+    *,
+    user_prompt: str,
+    assistant_text: str,
+    cwd: str,
+    bash_command: str | None = None,
+    bash_failed: bool = False,
+) -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    session_dir = session_root / f"test_{timestamp}_{session_id[:8]}"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    messages = [LLMMessage(role=Role.user, content=user_prompt)]
+    if bash_command is None:
+        messages.append(LLMMessage(role=Role.assistant, content=assistant_text))
+    else:
+        tool_call = ToolCall(
+            id=f"call_{session_id}",
+            index=0,
+            function=FunctionCall(
+                name="bash",
+                arguments=json.dumps({"command": bash_command}),
+            ),
+        )
+        messages.extend(
+            [
+                LLMMessage(
+                    role=Role.assistant,
+                    content=assistant_text,
+                    tool_calls=[tool_call],
+                ),
+                LLMMessage(
+                    role=Role.tool,
+                    name="bash",
+                    tool_call_id=tool_call.id,
+                    content=(
+                        "<tool_error>bash failed: Command failed</tool_error>"
+                        if bash_failed
+                        else f"command: {bash_command}\nstdout: ok\nstderr: \nreturncode: 0"
+                    ),
+                ),
+            ]
+        )
+
+    messages_path = session_dir / "messages.jsonl"
+    with messages_path.open("w", encoding="utf-8") as f:
+        for message in messages:
+            f.write(json.dumps(message.model_dump(exclude_none=True)) + "\n")
+
+    metadata = {
+        "session_id": session_id,
+        "start_time": "2026-03-10T12:00:00Z",
+        "end_time": "2026-03-10T12:05:00Z",
+        "title": user_prompt,
+        "total_messages": len(messages),
+        "stats": {
+            "steps": 8 if bash_failed else 3,
+            "session_prompt_tokens": 120,
+            "session_completion_tokens": 60,
+            "tool_calls_failed": 1 if bash_failed else 0,
+            "tool_calls_rejected": 1 if bash_failed else 0,
+        },
+        "system_prompt": {"content": "System prompt", "role": "system"},
+        "username": "testuser",
+        "environment": {"working_directory": cwd},
+        "git_commit": None,
+        "git_branch": None,
+    }
+    (session_dir / "meta.json").write_text(
+        json.dumps(metadata, indent=2), encoding="utf-8"
+    )
+    return session_dir
+
+
+@pytest.fixture
+def session_config(tmp_path: Path) -> SessionLoggingConfig:
+    session_root = tmp_path / "sessions"
+    session_root.mkdir()
+    return SessionLoggingConfig(
+        save_dir=str(session_root),
+        session_prefix="test",
+        enabled=True,
+    )
+
+
+def test_build_improve_prompt_uses_recent_sessions_and_excludes_current(
+    session_config: SessionLoggingConfig,
+) -> None:
+    session_root = Path(session_config.save_dir)
+    current_session = create_session(
+        session_root,
+        "current-session",
+        user_prompt="Current session should be excluded",
+        assistant_text="I will inspect the command plumbing first.",
+        cwd="/repo/current",
+        bash_command="uv run pytest tests/cli/test_commands.py",
+    )
+    time.sleep(0.01)
+    create_session(
+        session_root,
+        "failing-session",
+        user_prompt="Investigate repeated CLI failures",
+        assistant_text="I will inspect the command plumbing first.",
+        cwd="/repo/a",
+        bash_command="uv run pytest tests/cli/test_commands.py",
+        bash_failed=True,
+    )
+    time.sleep(0.01)
+    create_session(
+        session_root,
+        "recent-session",
+        user_prompt="Implement a new slash command",
+        assistant_text="I will inspect the command plumbing first.",
+        cwd="/repo/b",
+        bash_command="uv run pytest tests/session/test_session_loader.py",
+    )
+
+    prompt = build_improve_prompt(
+        session_config=session_config,
+        current_session_dir=current_session,
+        limit=DEFAULT_IMPROVE_SESSION_LIMIT,
+    )
+
+    assert "Investigate repeated CLI failures" in prompt
+    assert "Implement a new slash command" in prompt
+    assert "Current session should be excluded" not in prompt
+    assert "Repeated assistant phrases" in prompt
+    assert "I will inspect the command plumbing first." in prompt
+    assert "Most failed bash commands" in prompt
+    assert "uv run pytest tests/cli/test_commands.py" in prompt
+    assert "Friction to address" in prompt
+    assert "Suggestions to try" in prompt
+    assert "Repetition to remove" in prompt
+    assert "Ship next" in prompt
+
+
+def test_build_improve_prompt_requires_previous_sessions(
+    session_config: SessionLoggingConfig,
+) -> None:
+    with pytest.raises(
+        ValueError, match="No previous interactive sessions were found to analyze."
+    ):
+        build_improve_prompt(session_config=session_config)
+
+
+def test_build_improve_prompt_ignores_legacy_improve_turns(
+    session_config: SessionLoggingConfig,
+) -> None:
+    session_root = Path(session_config.save_dir)
+    create_session(
+        session_root,
+        "legacy-improve",
+        user_prompt=(
+            "Analyze this digest of my last 2 interactive Mistral Vibe sessions "
+            "and tell me how Vibe should improve.\n\n"
+            "Respond with these sections:\n"
+            "1. Friction to address\n"
+            "2. Suggestions to try\n"
+            "3. Repetition to remove\n"
+            "4. Ship next\n"
+        ),
+        assistant_text="This is old /improve output that should be ignored.",
+        cwd="/repo/legacy",
+    )
+    time.sleep(0.01)
+    create_session(
+        session_root,
+        "real-session",
+        user_prompt="Investigate slow test startup",
+        assistant_text="I will inspect the startup path first.",
+        cwd="/repo/real",
+        bash_command="uv run pytest tests/session/test_session_logger.py",
+    )
+
+    prompt = build_improve_prompt(session_config=session_config)
+
+    assert "Investigate slow test startup" in prompt
+    assert "old /improve output" not in prompt
+    assert "legacy-improve" not in prompt

--- a/tests/session/test_improve_prompt.py
+++ b/tests/session/test_improve_prompt.py
@@ -15,6 +15,7 @@ from vibe.core.session.improve_prompt import (
     SessionAnalysis,
     build_improve_prompt,
 )
+from vibe.core.session.session_loader import SessionLoader
 from vibe.core.types import FunctionCall, LLMMessage, Role, ToolCall
 
 
@@ -199,6 +200,50 @@ def test_build_improve_prompt_ignores_legacy_improve_turns(
     assert "Investigate slow test startup" in prompt
     assert "old /improve output" not in prompt
     assert "legacy-improve" not in prompt
+
+
+def test_build_improve_prompt_logs_corrupted_sessions(
+    session_config: SessionLoggingConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    session_root = Path(session_config.save_dir)
+    create_session(
+        session_root,
+        "healthy-session",
+        user_prompt="Investigate flaky session handling",
+        assistant_text="I will inspect the session analyzer first.",
+        cwd="/repo/healthy",
+    )
+    time.sleep(0.01)
+    broken_session = create_session(
+        session_root,
+        "broken-session",
+        user_prompt="This session should log a load failure",
+        assistant_text="I will inspect the session analyzer first.",
+        cwd="/repo/broken",
+    )
+
+    original_load_session = SessionLoader.load_session
+
+    def fake_load_session(
+        session_dir: Path,
+    ) -> tuple[list[LLMMessage], dict[str, object]]:
+        if session_dir == broken_session:
+            raise ValueError("corrupt session")
+        return original_load_session(session_dir)
+
+    monkeypatch.setattr(SessionLoader, "load_session", staticmethod(fake_load_session))
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        prompt = build_improve_prompt(session_config=session_config)
+
+    assert "Investigate flaky session handling" in prompt
+    assert any(
+        record.getMessage() == f"Skipping corrupted session at {broken_session}"
+        and record.exc_info is not None
+        for record in caplog.records
+    )
 
 
 def test_build_improve_prompt_logs_analysis_failures(

--- a/tests/session/test_improve_prompt.py
+++ b/tests/session/test_improve_prompt.py
@@ -28,6 +28,7 @@ def create_session(
     cwd: str,
     bash_command: str | None = None,
     bash_failed: bool = False,
+    skill_invocation: dict[str, str] | None = None,
 ) -> Path:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     session_dir = session_root / f"test_{timestamp}_{session_id[:8]}"
@@ -88,7 +89,15 @@ def create_session(
         "environment": {"working_directory": cwd},
         "git_commit": None,
         "git_branch": None,
+        "skill_invocations": [],
     }
+    if skill_invocation is not None:
+        user_message_id = messages[0].message_id
+        assert user_message_id is not None
+        metadata["skill_invocations"].append({
+            "message_id": user_message_id,
+            **skill_invocation,
+        })
     (session_dir / "meta.json").write_text(
         json.dumps(metadata, indent=2), encoding="utf-8"
     )
@@ -200,6 +209,36 @@ def test_build_improve_prompt_ignores_legacy_improve_turns(
     assert "Investigate slow test startup" in prompt
     assert "old /improve output" not in prompt
     assert "legacy-improve" not in prompt
+
+
+def test_build_improve_prompt_uses_skill_invocation_preview(
+    session_config: SessionLoggingConfig,
+) -> None:
+    session_root = Path(session_config.save_dir)
+    create_session(
+        session_root,
+        "skill-session",
+        user_prompt=(
+            "---\n"
+            "name: carl\n"
+            "description: Continuously run Propel code review.\n"
+            "---\n\n"
+            "# CARL\n"
+            "Use this skill when the goal is to clear Propel review comments.\n"
+        ),
+        assistant_text="I will inspect the current review findings first.",
+        cwd="/repo/review",
+        skill_invocation={
+            "skill_name": "carl",
+            "invocation": "/carl --base main",
+            "skill_path": "/Users/tony/.codex/skills/carl/SKILL.md",
+        },
+    )
+
+    prompt = build_improve_prompt(session_config=session_config)
+
+    assert "/carl --base main (skill)" in prompt
+    assert "Continuously run Propel code review." not in prompt
 
 
 def test_build_improve_prompt_logs_corrupted_sessions(

--- a/tests/session/test_session_loader.py
+++ b/tests/session/test_session_loader.py
@@ -972,6 +972,45 @@ class TestSessionLoaderUTF8Encoding:
         assert metadata.start_time == "2023-01-01T12:00:00Z"
         assert metadata.username is not None
 
+    def test_load_metadata_with_skill_invocations(
+        self, session_config: SessionLoggingConfig, create_test_session
+    ) -> None:
+        session_dir = Path(session_config.save_dir)
+        session_folder = create_test_session(
+            session_dir,
+            "skill-meta-test",
+            metadata={
+                "session_id": "skill-meta-test",
+                "start_time": "2023-01-01T12:00:00Z",
+                "end_time": "2023-01-01T12:05:00Z",
+                "total_messages": 2,
+                "stats": {
+                    "steps": 1,
+                    "session_prompt_tokens": 10,
+                    "session_completion_tokens": 20,
+                },
+                "system_prompt": {"content": "System prompt", "role": "system"},
+                "username": "testuser",
+                "environment": {"working_directory": "/test"},
+                "git_commit": None,
+                "git_branch": None,
+                "skill_invocations": [
+                    {
+                        "message_id": "message-123",
+                        "skill_name": "carl",
+                        "invocation": "/carl --base main",
+                        "skill_path": "/Users/tony/.codex/skills/carl/SKILL.md",
+                    }
+                ],
+            },
+        )
+
+        metadata = SessionLoader.load_metadata(session_folder)
+
+        assert len(metadata.skill_invocations) == 1
+        assert metadata.skill_invocations[0].skill_name == "carl"
+        assert metadata.skill_invocations[0].invocation == "/carl --base main"
+
     def test_load_metadata_with_unicode_characters(
         self, session_config: SessionLoggingConfig
     ) -> None:

--- a/tests/session/test_session_logger.py
+++ b/tests/session/test_session_logger.py
@@ -503,6 +503,61 @@ class TestSessionLoggerSaveInteraction:
             assert len(f.readlines()) == 2
 
     @pytest.mark.asyncio
+    async def test_save_interaction_skips_transient_messages(
+        self,
+        session_config: SessionLoggingConfig,
+        mock_vibe_config: VibeConfig,
+        mock_tool_manager: ToolManager,
+        mock_agent_profile: AgentProfile,
+    ) -> None:
+        session_id = "test-session-123"
+        logger = SessionLogger(session_config, session_id)
+
+        messages = [
+            LLMMessage(role=Role.system, content="System prompt"),
+            LLMMessage(
+                role=Role.user,
+                content="Internal improve prompt",
+                persist_to_session_log=False,
+            ),
+            LLMMessage(
+                role=Role.assistant,
+                content="Internal improve output",
+                persist_to_session_log=False,
+            ),
+            LLMMessage(role=Role.user, content="Real user prompt"),
+            LLMMessage(role=Role.assistant, content="Real assistant output"),
+        ]
+
+        stats = AgentStats(
+            steps=2, session_prompt_tokens=10, session_completion_tokens=20
+        )
+
+        await logger.save_interaction(
+            messages=messages,
+            stats=stats,
+            base_config=mock_vibe_config,
+            tool_manager=mock_tool_manager,
+            agent_profile=mock_agent_profile,
+        )
+
+        assert logger.session_dir is not None
+        metadata_file = logger.session_dir / "meta.json"
+        messages_file = logger.session_dir / "messages.jsonl"
+
+        with open(metadata_file) as f:
+            metadata = json.load(f)
+            assert metadata["title"] == "Real user prompt"
+            assert metadata["total_messages"] == 2
+
+        with open(messages_file) as f:
+            messages_data = [json.loads(line) for line in f.readlines()]
+            assert [message["content"] for message in messages_data] == [
+                "Real user prompt",
+                "Real assistant output",
+            ]
+
+    @pytest.mark.asyncio
     async def test_save_interaction_throttles_tmp_cleanup(
         self,
         session_config: SessionLoggingConfig,

--- a/tests/session/test_session_logger.py
+++ b/tests/session/test_session_logger.py
@@ -237,6 +237,60 @@ class TestSessionLoggerSaveInteraction:
             assert "system_prompt" in metadata
 
     @pytest.mark.asyncio
+    async def test_save_interaction_persists_skill_invocations(
+        self,
+        session_config: SessionLoggingConfig,
+        mock_vibe_config: VibeConfig,
+        mock_tool_manager: ToolManager,
+        mock_agent_profile: AgentProfile,
+    ) -> None:
+        session_id = "test-session-123"
+        logger = SessionLogger(session_config, session_id)
+
+        messages = [
+            LLMMessage(role=Role.system, content="System prompt"),
+            LLMMessage(
+                role=Role.user,
+                content="Long skill instructions that should not become the title.",
+            ),
+            LLMMessage(role=Role.assistant, content="Hi there!"),
+        ]
+        user_message_id = messages[1].message_id
+        assert user_message_id is not None
+
+        logger.record_skill_invocation(
+            message_id=user_message_id,
+            skill_name="carl",
+            invocation="/carl --base main",
+            skill_path=Path("/Users/tony/.codex/skills/carl/SKILL.md"),
+        )
+
+        await logger.save_interaction(
+            messages=messages,
+            stats=AgentStats(
+                steps=1, session_prompt_tokens=10, session_completion_tokens=20
+            ),
+            base_config=mock_vibe_config,
+            tool_manager=mock_tool_manager,
+            agent_profile=mock_agent_profile,
+        )
+
+        assert logger.session_dir is not None
+        metadata_file = logger.session_dir / "meta.json"
+        with metadata_file.open() as f:
+            metadata = json.load(f)
+
+        assert metadata["title"] == "/carl --base main"
+        assert metadata["skill_invocations"] == [
+            {
+                "message_id": user_message_id,
+                "skill_name": "carl",
+                "invocation": "/carl --base main",
+                "skill_path": "/Users/tony/.codex/skills/carl/SKILL.md",
+            }
+        ]
+
+    @pytest.mark.asyncio
     async def test_save_interaction_system_prompt_in_metadata(
         self,
         session_config: SessionLoggingConfig,

--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -46,6 +46,11 @@ class CommandRegistry:
                 description="Compact conversation history by summarizing",
                 handler="_compact_history",
             ),
+            "improve": Command(
+                aliases=frozenset(["/improve"]),
+                description="Analyze recent sessions and suggest product improvements",
+                handler="_improve_from_sessions",
+            ),
             "exit": Command(
                 aliases=frozenset(["/exit"]),
                 description="Exit the application",

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -93,6 +93,10 @@ from vibe.core.autocompletion.path_prompt_adapter import render_path_prompt
 from vibe.core.config import Backend, VibeConfig
 from vibe.core.logger import logger
 from vibe.core.paths import HISTORY_FILE
+from vibe.core.session.improve_prompt import (
+    DEFAULT_IMPROVE_SESSION_LIMIT,
+    build_improve_prompt,
+)
 from vibe.core.session.session_loader import SessionLoader
 from vibe.core.teleport.types import (
     TeleportAuthCompleteEvent,
@@ -600,14 +604,16 @@ class VibeApp(App):  # noqa: PLR0904
                 ErrorMessage(f"Command failed: {e}", collapsed=self._tools_collapsed)
             )
 
-    async def _handle_user_message(self, message: str) -> None:
+    async def _handle_user_message(
+        self, message: str, persist_to_session_log: bool = True
+    ) -> None:
         user_message = UserMessage(message)
 
         await self._mount_and_scroll(user_message)
 
         if not self._agent_running:
             self._agent_task = asyncio.create_task(
-                self._handle_agent_loop_turn(message)
+                self._handle_agent_loop_turn(message, persist_to_session_log)
             )
 
     def _reset_ui_state(self) -> None:
@@ -703,7 +709,9 @@ class VibeApp(App):  # noqa: PLR0904
         self._pending_question = None
         return result
 
-    async def _handle_agent_loop_turn(self, prompt: str) -> None:
+    async def _handle_agent_loop_turn(
+        self, prompt: str, persist_to_session_log: bool = True
+    ) -> None:
         self._agent_running = True
 
         loading_area = self._cached_loading_area or self.query_one(
@@ -716,7 +724,9 @@ class VibeApp(App):  # noqa: PLR0904
 
         try:
             rendered_prompt = render_path_prompt(prompt, base_dir=Path.cwd())
-            async for event in self.agent_loop.act(rendered_prompt):
+            async for event in self.agent_loop.act(
+                rendered_prompt, persist_to_session_log=persist_to_session_log
+            ):
                 if self.event_handler:
                     await self.event_handler.handle_event(
                         event,
@@ -901,6 +911,50 @@ class VibeApp(App):  # noqa: PLR0904
 - **Cost**: ${stats.session_cost:.4f}
 """
         await self._mount_and_scroll(UserCommandMessage(status_text))
+
+    async def _improve_from_sessions(self) -> None:
+        session_config = self.config.session_logging
+
+        if not session_config.enabled:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    "Session logging is disabled in configuration.",
+                    collapsed=self._tools_collapsed,
+                )
+            )
+            return
+
+        await self._mount_and_scroll(
+            UserCommandMessage(
+                "Preparing /improve analysis from the last "
+                f"{DEFAULT_IMPROVE_SESSION_LIMIT} interactive sessions."
+            )
+        )
+
+        try:
+            prompt = await asyncio.to_thread(
+                build_improve_prompt,
+                session_config,
+                self.agent_loop.session_logger.session_dir,
+                DEFAULT_IMPROVE_SESSION_LIMIT,
+            )
+        except ValueError as e:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    f"/improve failed: {e}", collapsed=self._tools_collapsed
+                )
+            )
+            return
+        except Exception as e:
+            logger.exception("Failed to prepare /improve prompt")
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    f"/improve failed: {e}", collapsed=self._tools_collapsed
+                )
+            )
+            return
+
+        await self._handle_user_message(prompt, persist_to_session_log=False)
 
     async def _show_config(self) -> None:
         """Switch to the configuration app in the bottom panel."""

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -122,6 +122,7 @@ from vibe.core.types import (
     LLMMessage,
     RateLimitError,
     Role,
+    TurnSkillInvocation,
 )
 from vibe.core.utils import (
     CancellationReason,
@@ -565,7 +566,14 @@ class VibeApp(App):  # noqa: PLR0904
         if len(parts) > 1:
             skill_content = f"{user_input}\n\n{skill_content}"
 
-        await self._handle_user_message(skill_content)
+        await self._handle_user_message(
+            skill_content,
+            skill_invocation=TurnSkillInvocation(
+                skill_name=skill_name,
+                invocation=user_input,
+                skill_path=str(skill_info.skill_path),
+            ),
+        )
         return True
 
     async def _handle_bash_command(self, command: str) -> None:
@@ -605,7 +613,10 @@ class VibeApp(App):  # noqa: PLR0904
             )
 
     async def _handle_user_message(
-        self, message: str, persist_to_session_log: bool = True
+        self,
+        message: str,
+        persist_to_session_log: bool = True,
+        skill_invocation: TurnSkillInvocation | None = None,
     ) -> None:
         user_message = UserMessage(message)
 
@@ -613,7 +624,11 @@ class VibeApp(App):  # noqa: PLR0904
 
         if not self._agent_running:
             self._agent_task = asyncio.create_task(
-                self._handle_agent_loop_turn(message, persist_to_session_log)
+                self._handle_agent_loop_turn(
+                    message,
+                    persist_to_session_log,
+                    skill_invocation=skill_invocation,
+                )
             )
 
     def _reset_ui_state(self) -> None:
@@ -710,7 +725,10 @@ class VibeApp(App):  # noqa: PLR0904
         return result
 
     async def _handle_agent_loop_turn(
-        self, prompt: str, persist_to_session_log: bool = True
+        self,
+        prompt: str,
+        persist_to_session_log: bool = True,
+        skill_invocation: TurnSkillInvocation | None = None,
     ) -> None:
         self._agent_running = True
 
@@ -725,7 +743,9 @@ class VibeApp(App):  # noqa: PLR0904
         try:
             rendered_prompt = render_path_prompt(prompt, base_dir=Path.cwd())
             async for event in self.agent_loop.act(
-                rendered_prompt, persist_to_session_log=persist_to_session_log
+                rendered_prompt,
+                persist_to_session_log=persist_to_session_log,
+                skill_invocation=skill_invocation,
             ):
                 if self.event_handler:
                     await self.event_handler.handle_event(

--- a/vibe/core/agent_loop.py
+++ b/vibe/core/agent_loop.py
@@ -198,6 +198,7 @@ class AgentLoop:
         self.entrypoint_metadata = entrypoint_metadata
         self.session_id = str(uuid4())
         self._current_user_message_id: str | None = None
+        self._persist_current_turn_to_session_log = True
 
         self.telemetry_client = TelemetryClient(
             config_getter=lambda: self.config, session_id_getter=lambda: self.session_id
@@ -278,9 +279,11 @@ class AgentLoop:
             self.agent_profile,
         )
 
-    async def act(self, msg: str) -> AsyncGenerator[BaseEvent]:
+    async def act(
+        self, msg: str, persist_to_session_log: bool = True
+    ) -> AsyncGenerator[BaseEvent]:
         self._clean_message_history()
-        async for event in self._conversation_loop(msg):
+        async for event in self._conversation_loop(msg, persist_to_session_log):
             yield event
 
     @property
@@ -314,7 +317,11 @@ class AgentLoop:
                 "model": self.config.active_model,
                 "stats": self.stats.model_dump(),
             },
-            messages=[msg.model_dump(exclude_none=True) for msg in self.messages[1:]],
+            messages=[
+                msg.model_dump(exclude_none=True)
+                for msg in self.messages[1:]
+                if msg.persist_to_session_log
+            ],
         )
         return self._teleport_generator(prompt, session)
 
@@ -387,8 +394,8 @@ class AgentLoop:
 
             case MiddlewareAction.INJECT_MESSAGE:
                 if result.message:
-                    injected_message = LLMMessage(
-                        role=Role.user, content=result.message
+                    injected_message = self._message_for_current_turn(
+                        LLMMessage(role=Role.user, content=result.message)
                     )
                     self.messages.append(injected_message)
 
@@ -439,18 +446,26 @@ class AgentLoop:
             })
         return headers
 
-    async def _conversation_loop(self, user_msg: str) -> AsyncGenerator[BaseEvent]:
-        user_message = LLMMessage(role=Role.user, content=user_msg)
-        self.messages.append(user_message)
-        self.stats.steps += 1
-        self._current_user_message_id = user_message.message_id
-
-        if user_message.message_id is None:
-            raise AgentLoopError("User message must have a message_id")
-
-        yield UserMessageEvent(content=user_msg, message_id=user_message.message_id)
-
+    async def _conversation_loop(
+        self, user_msg: str, persist_to_session_log: bool = True
+    ) -> AsyncGenerator[BaseEvent]:
+        previous_persist_value = self._persist_current_turn_to_session_log
+        self._persist_current_turn_to_session_log = persist_to_session_log
         try:
+            user_message = self._message_for_current_turn(
+                LLMMessage(role=Role.user, content=user_msg)
+            )
+            self.messages.append(user_message)
+            self.stats.steps += 1
+            self._current_user_message_id = user_message.message_id
+
+            if user_message.message_id is None:
+                raise AgentLoopError("User message must have a message_id")
+
+            yield UserMessageEvent(
+                content=user_msg, message_id=user_message.message_id
+            )
+
             should_break_loop = False
             while not should_break_loop:
                 result = await self.middleware_pipeline.run_before_turn(
@@ -477,7 +492,14 @@ class AgentLoop:
                     return
 
         finally:
+            self._current_user_message_id = None
+            self._persist_current_turn_to_session_log = previous_persist_value
             await self._save_messages()
+
+    def _message_for_current_turn(self, message: LLMMessage) -> LLMMessage:
+        if self._persist_current_turn_to_session_log:
+            return message
+        return message.model_copy(update={"persist_to_session_log": False})
 
     async def _perform_llm_turn(self) -> AsyncGenerator[BaseEvent, None]:
         if self.enable_streaming:
@@ -565,8 +587,10 @@ class AgentLoop:
             )
             self.stats.tool_calls_failed += 1
             self.messages.append(
-                self.format_handler.create_failed_tool_response_message(
-                    failed, error_msg
+                self._message_for_current_turn(
+                    self.format_handler.create_failed_tool_response_message(
+                        failed, error_msg
+                    )
                 )
             )
 
@@ -701,8 +725,10 @@ class AgentLoop:
         result: dict[str, Any] | None = None,
     ) -> None:
         self.messages.append(
-            LLMMessage.model_validate(
-                self.format_handler.create_tool_response_message(tool_call, text)
+            self._message_for_current_turn(
+                LLMMessage.model_validate(
+                    self.format_handler.create_tool_response_message(tool_call, text)
+                )
             )
         )
 
@@ -746,7 +772,7 @@ class AgentLoop:
             processed_message = self.format_handler.process_api_response_message(
                 result.message
             )
-            self.messages.append(processed_message)
+            self.messages.append(self._message_for_current_turn(processed_message))
             return LLMChunk(message=processed_message, usage=result.usage)
 
         except Exception as e:
@@ -796,7 +822,7 @@ class AgentLoop:
                 )
             self._update_stats(usage=usage, time_seconds=end_time - start_time)
 
-            self.messages.append(chunk_agg.message)
+            self.messages.append(self._message_for_current_turn(chunk_agg.message))
 
         except Exception as e:
             if _should_raise_rate_limit_error(e):

--- a/vibe/core/agent_loop.py
+++ b/vibe/core/agent_loop.py
@@ -83,6 +83,7 @@ from vibe.core.types import (
     ToolCallEvent,
     ToolResultEvent,
     ToolStreamEvent,
+    TurnSkillInvocation,
     UserInputCallback,
     UserMessageEvent,
 )
@@ -280,10 +281,17 @@ class AgentLoop:
         )
 
     async def act(
-        self, msg: str, persist_to_session_log: bool = True
+        self,
+        msg: str,
+        persist_to_session_log: bool = True,
+        skill_invocation: TurnSkillInvocation | None = None,
     ) -> AsyncGenerator[BaseEvent]:
         self._clean_message_history()
-        async for event in self._conversation_loop(msg, persist_to_session_log):
+        async for event in self._conversation_loop(
+            msg,
+            persist_to_session_log,
+            skill_invocation=skill_invocation,
+        ):
             yield event
 
     @property
@@ -447,7 +455,10 @@ class AgentLoop:
         return headers
 
     async def _conversation_loop(
-        self, user_msg: str, persist_to_session_log: bool = True
+        self,
+        user_msg: str,
+        persist_to_session_log: bool = True,
+        skill_invocation: TurnSkillInvocation | None = None,
     ) -> AsyncGenerator[BaseEvent]:
         previous_persist_value = self._persist_current_turn_to_session_log
         self._persist_current_turn_to_session_log = persist_to_session_log
@@ -461,6 +472,14 @@ class AgentLoop:
 
             if user_message.message_id is None:
                 raise AgentLoopError("User message must have a message_id")
+
+            if persist_to_session_log and skill_invocation is not None:
+                self.session_logger.record_skill_invocation(
+                    message_id=user_message.message_id,
+                    skill_name=skill_invocation.skill_name,
+                    invocation=skill_invocation.invocation,
+                    skill_path=Path(skill_invocation.skill_path),
+                )
 
             yield UserMessageEvent(
                 content=user_msg, message_id=user_message.message_id

--- a/vibe/core/session/improve_prompt.py
+++ b/vibe/core/session/improve_prompt.py
@@ -1,0 +1,801 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+from typing import Any
+
+from vibe.core.config import SessionLoggingConfig
+from vibe.core.session.session_loader import MESSAGES_FILENAME, SessionLoader
+from vibe.core.types import LLMMessage, Role
+from vibe.core.utils import CANCELLATION_TAG, TOOL_ERROR_TAG, TaggedText
+
+
+DEFAULT_IMPROVE_SESSION_LIMIT = 50
+AGGREGATE_LIMIT = 8
+FRICTION_LIMIT = 8
+PREVIEW_CHAR_LIMIT = 110
+PHRASE_CHAR_LIMIT = 120
+NO_PREVIEW = "(no user preview recorded)"
+
+
+@dataclass(slots=True)
+class SessionAnalysis:
+    created_at: str
+    preview: str = NO_PREVIEW
+    cwd: str | None = None
+    user_messages: int = 0
+    assistant_messages: int = 0
+    reasoning_messages: int = 0
+    tool_calls: int = 0
+    tool_failures: int = 0
+    tool_cancellations: int = 0
+    bash_calls: int = 0
+    failed_bash_calls: int = 0
+    tool_counts: Counter[str] = field(default_factory=Counter)
+    failed_tool_counts: Counter[str] = field(default_factory=Counter)
+    bash_command_counts: Counter[str] = field(default_factory=Counter)
+    failed_bash_command_counts: Counter[str] = field(default_factory=Counter)
+    assistant_phrase_samples: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_session(
+        cls, session_dir: Path, messages: list[LLMMessage], metadata: dict[str, Any]
+    ) -> SessionAnalysis:
+        environment = metadata.get("environment", {})
+        cwd = (
+            environment.get("working_directory")
+            if isinstance(environment, dict)
+            else None
+        )
+        analysis = cls(
+            created_at=str(
+                metadata.get("end_time")
+                or metadata.get("start_time")
+                or session_dir.name
+            ),
+            cwd=shorten_path(Path(cwd)) if isinstance(cwd, str) and cwd else None,
+        )
+        fallback_preview = metadata.get("title")
+        bash_calls_by_id: dict[str, str] = {}
+        skip_turn = False
+
+        for message in messages:
+            match message.role:
+                case Role.user:
+                    if (
+                        text := extract_message_text(message)
+                    ) is not None and is_improve_generated_prompt(text):
+                        skip_turn = True
+                        continue
+                    skip_turn = False
+                    analysis.user_messages += 1
+                    if (
+                        analysis.preview == NO_PREVIEW
+                        and text is not None
+                    ):
+                        analysis.preview = shorten(text, PREVIEW_CHAR_LIMIT)
+                case Role.assistant:
+                    if skip_turn:
+                        continue
+                    analysis.assistant_messages += 1
+                    if message.reasoning_content:
+                        analysis.reasoning_messages += 1
+                    if (
+                        sample := assistant_phrase_sample(message.content or "")
+                    ) is not None:
+                        analysis.assistant_phrase_samples.append(sample)
+                    for tool_call in message.tool_calls or []:
+                        tool_name = tool_call.function.name or "unknown"
+                        analysis.tool_calls += 1
+                        analysis.tool_counts[tool_name] += 1
+                        if tool_name != "bash":
+                            continue
+                        if (
+                            command := summarize_bash_command(
+                                tool_call.function.arguments
+                            )
+                        ) is None:
+                            continue
+                        analysis.bash_calls += 1
+                        analysis.bash_command_counts[command] += 1
+                        if tool_call.id:
+                            bash_calls_by_id[tool_call.id] = command
+                case Role.tool:
+                    if skip_turn:
+                        continue
+                    if (
+                        tag := tool_message_tag(message.content or "")
+                    ) == CANCELLATION_TAG:
+                        analysis.tool_cancellations += 1
+                        continue
+                    if tag != TOOL_ERROR_TAG:
+                        continue
+                    tool_name = message.name or "unknown"
+                    analysis.tool_failures += 1
+                    analysis.failed_tool_counts[tool_name] += 1
+                    if tool_name != "bash":
+                        continue
+                    analysis.failed_bash_calls += 1
+                    if (
+                        message.tool_call_id
+                        and (command := bash_calls_by_id.get(message.tool_call_id))
+                    ):
+                        analysis.failed_bash_command_counts[command] += 1
+                case _:
+                    continue
+
+        if analysis.preview == NO_PREVIEW and isinstance(fallback_preview, str):
+            analysis.preview = shorten(fallback_preview, PREVIEW_CHAR_LIMIT)
+
+        return analysis
+
+    def friction_score(self) -> int:
+        return (
+            self.tool_failures * 4
+            + self.tool_cancellations * 3
+            + self.failed_bash_calls * 2
+            + max(self.tool_calls - 8, 0)
+        )
+
+    def has_signal(self) -> bool:
+        return any(
+            (
+                self.user_messages,
+                self.assistant_messages,
+                self.tool_calls,
+                self.tool_failures,
+                self.tool_cancellations,
+            )
+        )
+
+    def summary_line(self) -> str:
+        line = (
+            f"- {self.created_at} | {self.preview} | users {self.user_messages}, "
+            f"assistant {self.assistant_messages}, reasoning {self.reasoning_messages}, "
+            f"tools {self.tool_calls}, failures {self.tool_failures}, "
+            f"cancellations {self.tool_cancellations}, bash failures {self.failed_bash_calls}"
+        )
+        if self.cwd is not None:
+            line += f" | cwd {self.cwd}"
+        return line
+
+    def friction_line(self) -> str:
+        reasons: list[str] = []
+        if self.tool_failures > 0:
+            reasons.append(f"tool failures {self.tool_failures}")
+        if self.tool_cancellations > 0:
+            reasons.append(f"tool cancellations {self.tool_cancellations}")
+        if self.failed_bash_calls > 0:
+            reasons.append(f"bash failures {self.failed_bash_calls}")
+        if not reasons and self.tool_calls > 0:
+            reasons.append(f"tool calls {self.tool_calls}")
+
+        line = (
+            f"- score {self.friction_score()} | {self.created_at} | {self.preview} | "
+            f"{', '.join(reasons) if reasons else 'no strong friction signal'}"
+        )
+        if top_failed := format_count_entries(top_counts(self.failed_tool_counts, 3)):
+            line += f" | failed tools: {top_failed}"
+        if top_failed_bash := format_count_entries(
+            top_counts(self.failed_bash_command_counts, 2)
+        ):
+            line += f" | failed bash: {top_failed_bash}"
+        return line
+
+
+@dataclass(slots=True)
+class ImproveDigest:
+    sessions: list[SessionAnalysis]
+    total_user_messages: int
+    total_assistant_messages: int
+    total_reasoning_messages: int
+    total_tool_calls: int
+    total_tool_failures: int
+    total_tool_cancellations: int
+    total_bash_calls: int
+    total_failed_bash_calls: int
+    top_tools: list[tuple[str, int]]
+    top_failed_tools: list[tuple[str, int]]
+    top_bash_commands: list[tuple[str, int]]
+    top_failed_bash_commands: list[tuple[str, int]]
+    top_cwds: list[tuple[str, int]]
+    repeated_phrases: list[tuple[str, int]]
+
+    @classmethod
+    def from_sessions(cls, sessions: list[SessionAnalysis]) -> ImproveDigest:
+        tool_counts: Counter[str] = Counter()
+        failed_tool_counts: Counter[str] = Counter()
+        bash_command_counts: Counter[str] = Counter()
+        failed_bash_command_counts: Counter[str] = Counter()
+        cwd_counts: Counter[str] = Counter()
+        phrase_counts: dict[str, tuple[str, int]] = {}
+
+        for session in sessions:
+            tool_counts.update(session.tool_counts)
+            failed_tool_counts.update(session.failed_tool_counts)
+            bash_command_counts.update(session.bash_command_counts)
+            failed_bash_command_counts.update(session.failed_bash_command_counts)
+            if session.cwd is not None:
+                cwd_counts[session.cwd] += 1
+            for sample in session.assistant_phrase_samples:
+                if (key := repetition_key(sample)) is None:
+                    continue
+                current_sample, count = phrase_counts.get(key, (sample, 0))
+                phrase_counts[key] = (current_sample, count + 1)
+
+        repeated_phrases = sorted(
+            (
+                (sample, count)
+                for sample, count in phrase_counts.values()
+                if count > 1
+            ),
+            key=lambda entry: (-entry[1], entry[0]),
+        )[:AGGREGATE_LIMIT]
+
+        return cls(
+            sessions=sessions,
+            total_user_messages=sum(session.user_messages for session in sessions),
+            total_assistant_messages=sum(
+                session.assistant_messages for session in sessions
+            ),
+            total_reasoning_messages=sum(
+                session.reasoning_messages for session in sessions
+            ),
+            total_tool_calls=sum(session.tool_calls for session in sessions),
+            total_tool_failures=sum(session.tool_failures for session in sessions),
+            total_tool_cancellations=sum(
+                session.tool_cancellations for session in sessions
+            ),
+            total_bash_calls=sum(session.bash_calls for session in sessions),
+            total_failed_bash_calls=sum(
+                session.failed_bash_calls for session in sessions
+            ),
+            top_tools=top_counts(tool_counts, AGGREGATE_LIMIT),
+            top_failed_tools=top_counts(failed_tool_counts, AGGREGATE_LIMIT),
+            top_bash_commands=top_counts(bash_command_counts, AGGREGATE_LIMIT),
+            top_failed_bash_commands=top_counts(
+                failed_bash_command_counts, AGGREGATE_LIMIT
+            ),
+            top_cwds=top_counts(cwd_counts, 5),
+            repeated_phrases=repeated_phrases,
+        )
+
+    def render_prompt(self, requested_limit: int) -> str:
+        lines = [
+            (
+                f"Analyze this digest of my last {len(self.sessions)} interactive "
+                "Mistral Vibe sessions and tell me how Vibe should improve."
+            ),
+            "",
+            "Focus on:",
+            (
+                "- Concrete friction patterns and the smallest prompt or "
+                "default-behavior change that would address each one."
+            ),
+            (
+                "- Explicit suggestions to try next, including prompt wording, "
+                "default behaviors, and automation when the evidence is strong."
+            ),
+            "- Repeated explanations or phrasing that should be cut, shortened, or standardized.",
+            "- Evidence-driven recommendations only. If support is weak, say so.",
+            (
+                "- Only suggest a new skill, slash command, hook, or helper script "
+                "when the same workflow or friction shows up in at least two sessions."
+            ),
+            "- Keep the response concise: use at most 3 bullets per section.",
+            "- In every section, make each bullet start with the change.",
+            (
+                "- Do not restate the digest; cite only the minimum evidence needed "
+                "to justify each recommendation."
+            ),
+            "",
+            "Respond with these sections:",
+            "1. Friction to address",
+            "2. Suggestions to try",
+            "3. Repetition to remove",
+            "4. Ship next",
+            "",
+            "## Aggregate stats",
+            f"- Sessions analyzed: {len(self.sessions)}",
+            (
+                f"- Messages: user {self.total_user_messages}, assistant "
+                f"{self.total_assistant_messages}, reasoning "
+                f"{self.total_reasoning_messages}"
+            ),
+            (
+                f"- Workload: tool calls {self.total_tool_calls}, tool failures "
+                f"{self.total_tool_failures}, tool cancellations "
+                f"{self.total_tool_cancellations}"
+            ),
+            (
+                f"- Bash usage: commands {self.total_bash_calls}, failed bash "
+                f"commands {self.total_failed_bash_calls}"
+            ),
+        ]
+        if len(self.sessions) < requested_limit:
+            lines.append(
+                f"- Sample size note: only {len(self.sessions)} earlier sessions were available."
+            )
+
+        lines.extend(
+            [
+                "",
+                "## Most used tools",
+                *render_count_section(self.top_tools),
+                "",
+                "## Most failed tools",
+                *render_count_section(self.top_failed_tools),
+                "",
+                "## Most used bash commands",
+                *render_count_section(self.top_bash_commands),
+                "",
+                "## Most failed bash commands",
+                *render_count_section(self.top_failed_bash_commands),
+                "",
+                "## Common working directories",
+                *render_count_section(self.top_cwds),
+                "",
+                "## Repeated assistant phrases",
+            ]
+        )
+        if not self.repeated_phrases:
+            lines.append(
+                "- No strongly repeated assistant phrasing was detected in the local digest."
+            )
+        else:
+            lines.extend(
+                f"- {sample} (seen {count} times)"
+                for sample, count in self.repeated_phrases
+            )
+
+        lines.extend(["", "## Highest-friction sessions"])
+        friction_sessions = sorted(
+            self.sessions,
+            key=lambda session: (
+                -session.friction_score(),
+                -session.tool_failures,
+                session.created_at,
+            ),
+        )
+        added_friction = 0
+        for session in friction_sessions:
+            if session.friction_score() <= 0:
+                continue
+            lines.append(session.friction_line())
+            added_friction += 1
+            if added_friction >= FRICTION_LIMIT:
+                break
+        if added_friction == 0:
+            lines.append(
+                "- No strong friction signal stood out in the sampled sessions."
+            )
+
+        lines.extend(["", "## Session summaries"])
+        lines.extend(session.summary_line() for session in self.sessions)
+        return "\n".join(lines)
+
+
+def build_improve_prompt(
+    session_config: SessionLoggingConfig,
+    current_session_dir: Path | None = None,
+    limit: int = DEFAULT_IMPROVE_SESSION_LIMIT,
+) -> str:
+    """
+    Build an improvement prompt by analyzing recent Vibe sessions.
+    
+    This function analyzes recent interactive sessions to generate a comprehensive
+    prompt that can be used to get suggestions for improving Vibe's functionality,
+    defaults, and user experience.
+    
+    Args:
+        session_config: Configuration for session logging
+        current_session_dir: Optional path to the current session directory to exclude
+        limit: Maximum number of recent sessions to analyze
+        
+    Returns:
+        A formatted prompt string containing session analysis and improvement suggestions
+        
+    Raises:
+        ValueError: If no previous sessions are found or cannot be read
+        
+    Note:
+        The function uses lazy loading and early termination to efficiently handle
+        large numbers of sessions. It stops processing once the requested limit
+        of valid sessions is reached.
+    """
+    requested_limit = max(limit, 1)
+    
+    # Use generator for lazy loading of session directories
+    session_dirs = collect_recent_session_dirs(
+        session_config=session_config,
+        current_session_dir=current_session_dir,
+    )
+    
+    if not session_dirs:
+        raise ValueError("No previous interactive sessions were found to analyze.")
+
+    analyses: list[SessionAnalysis] = []
+    
+    # Process sessions lazily - stop when we have enough valid analyses
+    for session_dir in session_dirs:
+        if len(analyses) >= requested_limit:
+            break
+            
+        try:
+            messages, metadata = SessionLoader.load_session(session_dir)
+        except ValueError:
+            # Skip corrupted or invalid sessions
+            continue
+            
+        try:
+            analysis = SessionAnalysis.from_session(session_dir, messages, metadata)
+        except Exception:
+            # Skip sessions that fail analysis
+            continue
+            
+        if not analysis.has_signal():
+            continue
+            
+        analyses.append(analysis)
+
+    if not analyses:
+        raise ValueError("Unable to read any previous interactive sessions.")
+
+    digest = ImproveDigest.from_sessions(analyses)
+    return digest.render_prompt(requested_limit=requested_limit)
+
+
+def collect_recent_session_dirs(
+    session_config: SessionLoggingConfig,
+    current_session_dir: Path | None = None,
+) -> list[Path]:
+    """
+    Collect recent session directories for analysis.
+    
+    This function finds all session directories matching the configured prefix,
+    excluding the current session if provided, and returns them sorted by
+    modification time (newest first).
+    
+    Args:
+        session_config: Configuration containing session directory location and prefix
+        current_session_dir: Optional path to exclude (typically the current session)
+        
+    Returns:
+        List of Path objects to session directories, sorted from newest to oldest
+        
+    Note:
+        This function uses a generator expression for memory efficiency when
+        dealing with large numbers of session directories.
+    """
+    save_dir = Path(session_config.save_dir)
+    if not save_dir.exists():
+        return []
+
+    pattern = f"{session_config.session_prefix}_*"
+    return sorted(
+        (
+            session_dir
+            for session_dir in save_dir.glob(pattern)
+            if session_dir.is_dir() and session_dir != current_session_dir
+        ),
+        key=session_sort_key,
+        reverse=True,
+    )
+
+
+def session_sort_key(session_dir: Path) -> tuple[float, str]:
+    """
+    Generate a sort key for session directories.
+    
+    This function creates a tuple key for sorting session directories
+    by modification time (primary) and name (secondary).
+    
+    Args:
+        session_dir: Path to the session directory
+        
+    Returns:
+        Tuple of (modification_time, directory_name) for sorting
+        
+    Note:
+        Uses 0.0 as fallback modification time if the messages file doesn't exist
+        or cannot be accessed.
+    """
+    messages_path = session_dir / MESSAGES_FILENAME
+    try:
+        mtime = messages_path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    return (mtime, session_dir.name)
+
+
+def extract_message_text(message: LLMMessage) -> str | None:
+    """
+    Extract and normalize text content from an LLM message.
+    
+    Args:
+        message: The LLMMessage to extract text from
+        
+    Returns:
+        Normalized text content or None if message has no content
+    """
+    if message.content is None:
+        return None
+    text = collapse_whitespace(message.content)
+    return text or None
+
+
+def tool_message_tag(content: str) -> str:
+    """
+    Extract the tag from a tool message content.
+    
+    Args:
+        content: The tool message content
+        
+    Returns:
+        The extracted tag from the content
+    """
+    return TaggedText.from_string(content).tag
+
+
+def summarize_bash_command(raw_arguments: str | None) -> str | None:
+    """
+    Summarize a bash command from tool call arguments.
+    
+    This function extracts and summarizes bash commands from tool call arguments,
+    handling both JSON-formatted arguments and raw strings.
+    
+    Args:
+        raw_arguments: Raw arguments string from a tool call
+        
+    Returns:
+        Short summary of the bash command or None if extraction fails
+        
+    Note:
+        Returns the first 4 words of the first shell segment for brevity.
+    """
+    if not raw_arguments:
+        return None
+
+    try:
+        parsed = json.loads(raw_arguments)
+    except json.JSONDecodeError:
+        collapsed = collapse_whitespace(raw_arguments)
+        return shorten(collapsed, PREVIEW_CHAR_LIMIT) if collapsed else None
+
+    if not isinstance(parsed, dict):
+        return None
+    command = parsed.get("command")
+    if not isinstance(command, str):
+        return None
+
+    segment = first_shell_segment(command)
+    summary = take_command_words(segment, 4)
+    if summary:
+        return summary
+    collapsed = collapse_whitespace(command)
+    return shorten(collapsed, PREVIEW_CHAR_LIMIT) if collapsed else None
+
+
+def assistant_phrase_sample(text: str) -> str | None:
+    """
+    Extract a sample phrase from assistant message text.
+    
+    This function extracts the first non-empty, non-code line from assistant text
+    and shortens it for use in repetition detection.
+    
+    Args:
+        text: The assistant message text
+        
+    Returns:
+        Shortened sample phrase or None if no suitable text found
+    """
+    first_line = next(
+        (
+            stripped
+            for line in text.splitlines()
+            if (stripped := line.strip()) and not stripped.startswith("```")
+        ),
+        None,
+    )
+    if first_line is None:
+        return None
+
+    shortened = shorten(first_line, PHRASE_CHAR_LIMIT)
+    return shortened if repetition_key(shortened) is not None else None
+
+
+def is_improve_generated_prompt(text: str) -> bool:
+    """
+    Check if text is an auto-generated improve prompt.
+    
+    This function detects whether a given text is an automatically generated
+    improve prompt that should be excluded from analysis.
+    
+    Args:
+        text: The text to check
+        
+    Returns:
+        True if the text matches the pattern of an auto-generated improve prompt
+    """
+    normalized = collapse_whitespace(text)
+    return (
+        normalized.startswith("Analyze this digest of my last ")
+        and "interactive Mistral Vibe sessions and tell me how Vibe should improve."
+        in normalized
+        and "Respond with these sections:" in normalized
+        and "1. Friction to address" in normalized
+        and "4. Ship next" in normalized
+    )
+
+
+def repetition_key(text: str) -> str | None:
+    """
+    Generate a normalized key for detecting repeated phrases.
+    
+    This function normalizes text for repetition detection by:
+    - Converting to lowercase
+    - Removing non-alphanumeric characters
+    - Expanding common contractions (ll->will, ve->have, etc.)
+    - Requiring minimum length and word count
+    
+    Args:
+        text: The text to generate a key for
+        
+    Returns:
+        Normalized key string or None if text is too short
+    """
+    normalized_chars: list[str] = []
+    previous_space = False
+    for char in text:
+        if char.isascii() and char.isalnum():
+            normalized_chars.append(char.lower())
+            previous_space = False
+            continue
+        if previous_space or not normalized_chars:
+            continue
+        normalized_chars.append(" ")
+        previous_space = True
+
+    normalized_words: list[str] = []
+    for word in "".join(normalized_chars).split():
+        if word == "ll" and normalized_words:
+            normalized_words.append("will")
+            continue
+        if word == "ve" and normalized_words:
+            normalized_words.append("have")
+            continue
+        if word == "re" and normalized_words:
+            normalized_words.append("are")
+            continue
+        if word == "m" and normalized_words:
+            normalized_words.append("am")
+            continue
+        normalized_words.append(word)
+
+    normalized = " ".join(normalized_words)
+    if len(normalized) < 24 or len(normalized_words) < 4:
+        return None
+    return normalized
+
+
+def first_shell_segment(command: str) -> str:
+    """
+    Extract the first shell segment from a command string.
+    
+    This function finds the first segment of a shell command by looking for
+    common shell separators (&&, ||, ;, |, newline).
+    
+    Args:
+        command: The full command string
+        
+    Returns:
+        The first segment of the command before any shell separators
+    """
+    best = len(command)
+    for needle in ("&&", "||", ";", "|", "\n"):
+        index = command.find(needle)
+        if index == -1:
+            continue
+        best = min(best, index)
+    return command[:best].strip()
+
+
+def take_command_words(text: str, limit: int) -> str:
+    """
+    Take the first N words from text.
+    
+    Args:
+        text: The input text
+        limit: Maximum number of words to return
+        
+    Returns:
+        String containing the first N words
+    """
+    return " ".join(text.split()[:limit])
+
+
+def collapse_whitespace(text: str) -> str:
+    """
+    Collapse multiple whitespace characters into single spaces.
+    
+    Args:
+        text: Input text with potential multiple/mixed whitespace
+        
+    Returns:
+        Text with whitespace normalized to single spaces
+    """
+    return " ".join(text.split())
+
+
+def shorten(text: str, max_chars: int) -> str:
+    """
+    Shorten text to a maximum character limit with ellipsis.
+    
+    Args:
+        text: Input text to shorten
+        max_chars: Maximum number of characters to return
+        
+    Returns:
+        Shortened text with ellipsis if truncated, original text if within limit
+    """
+    collapsed = collapse_whitespace(text)
+    if len(collapsed) <= max_chars:
+        return collapsed
+    return f"{collapsed[:max_chars]}..."
+
+
+def shorten_path(path: Path) -> str:
+    """
+    Shorten a path string for display.
+    
+    Args:
+        path: Path object to shorten
+        
+    Returns:
+        Shortened path string (max 72 characters)
+    """
+    return shorten(str(path), 72)
+
+
+def top_counts(counts: Counter[str], limit: int) -> list[tuple[str, int]]:
+    """
+    Get the top N items from a counter by count.
+    
+    Args:
+        counts: Counter object with item counts
+        limit: Maximum number of top items to return
+        
+    Returns:
+        List of (item, count) tuples sorted by count descending, then by item name
+    """
+    return sorted(counts.items(), key=lambda entry: (-entry[1], entry[0]))[:limit]
+
+
+def format_count_entries(entries: list[tuple[str, int]]) -> str:
+    """
+    Format count entries as a comma-separated string.
+    
+    Args:
+        entries: List of (name, count) tuples
+        
+    Returns:
+        Formatted string like "item1 x3, item2 x2"
+    """
+    return ", ".join(f"{name} x{count}" for name, count in entries)
+
+
+def render_count_section(entries: list[tuple[str, int]]) -> list[str]:
+    """
+    Render count entries as a list of formatted strings.
+    
+    Args:
+        entries: List of (name, count) tuples
+        
+    Returns:
+        List of formatted strings like ["- item1: 3", "- item2: 2"]
+    """
+    if not entries:
+        return ["- None recorded in the sampled sessions."]
+    return [f"- {name}: {count}" for name, count in entries]

--- a/vibe/core/session/improve_prompt.py
+++ b/vibe/core/session/improve_prompt.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from vibe.core.config import SessionLoggingConfig
+from vibe.core.logger import logger
 from vibe.core.session.session_loader import MESSAGES_FILENAME, SessionLoader
 from vibe.core.types import LLMMessage, Role
 from vibe.core.utils import CANCELLATION_TAG, TOOL_ERROR_TAG, TaggedText
@@ -384,60 +385,64 @@ def build_improve_prompt(
 ) -> str:
     """
     Build an improvement prompt by analyzing recent Vibe sessions.
-    
+
     This function analyzes recent interactive sessions to generate a comprehensive
     prompt that can be used to get suggestions for improving Vibe's functionality,
     defaults, and user experience.
-    
+
     Args:
         session_config: Configuration for session logging
         current_session_dir: Optional path to the current session directory to exclude
         limit: Maximum number of recent sessions to analyze
-        
+
     Returns:
         A formatted prompt string containing session analysis and improvement suggestions
-        
+
     Raises:
         ValueError: If no previous sessions are found or cannot be read
-        
+
     Note:
         The function uses lazy loading and early termination to efficiently handle
         large numbers of sessions. It stops processing once the requested limit
         of valid sessions is reached.
     """
     requested_limit = max(limit, 1)
-    
+
     # Use generator for lazy loading of session directories
     session_dirs = collect_recent_session_dirs(
         session_config=session_config,
         current_session_dir=current_session_dir,
     )
-    
+
     if not session_dirs:
         raise ValueError("No previous interactive sessions were found to analyze.")
 
     analyses: list[SessionAnalysis] = []
-    
+
     # Process sessions lazily - stop when we have enough valid analyses
     for session_dir in session_dirs:
         if len(analyses) >= requested_limit:
             break
-            
+
         try:
             messages, metadata = SessionLoader.load_session(session_dir)
         except ValueError:
             # Skip corrupted or invalid sessions
             continue
-            
+
         try:
             analysis = SessionAnalysis.from_session(session_dir, messages, metadata)
-        except Exception:
-            # Skip sessions that fail analysis
+        except Exception as exc:
+            logger.warning(
+                "Skipping session %s after analysis failure",
+                session_dir,
+                exc_info=exc,
+            )
             continue
-            
+
         if not analysis.has_signal():
             continue
-            
+
         analyses.append(analysis)
 
     if not analyses:
@@ -453,18 +458,18 @@ def collect_recent_session_dirs(
 ) -> list[Path]:
     """
     Collect recent session directories for analysis.
-    
+
     This function finds all session directories matching the configured prefix,
     excluding the current session if provided, and returns them sorted by
     modification time (newest first).
-    
+
     Args:
         session_config: Configuration containing session directory location and prefix
         current_session_dir: Optional path to exclude (typically the current session)
-        
+
     Returns:
         List of Path objects to session directories, sorted from newest to oldest
-        
+
     Note:
         This function uses a generator expression for memory efficiency when
         dealing with large numbers of session directories.
@@ -488,16 +493,16 @@ def collect_recent_session_dirs(
 def session_sort_key(session_dir: Path) -> tuple[float, str]:
     """
     Generate a sort key for session directories.
-    
+
     This function creates a tuple key for sorting session directories
     by modification time (primary) and name (secondary).
-    
+
     Args:
         session_dir: Path to the session directory
-        
+
     Returns:
         Tuple of (modification_time, directory_name) for sorting
-        
+
     Note:
         Uses 0.0 as fallback modification time if the messages file doesn't exist
         or cannot be accessed.
@@ -513,10 +518,10 @@ def session_sort_key(session_dir: Path) -> tuple[float, str]:
 def extract_message_text(message: LLMMessage) -> str | None:
     """
     Extract and normalize text content from an LLM message.
-    
+
     Args:
         message: The LLMMessage to extract text from
-        
+
     Returns:
         Normalized text content or None if message has no content
     """

--- a/vibe/core/session/improve_prompt.py
+++ b/vibe/core/session/improve_prompt.py
@@ -9,7 +9,7 @@ from typing import Any
 from vibe.core.config import SessionLoggingConfig
 from vibe.core.logger import logger
 from vibe.core.session.session_loader import MESSAGES_FILENAME, SessionLoader
-from vibe.core.types import LLMMessage, Role
+from vibe.core.types import LLMMessage, Role, SessionSkillInvocation
 from vibe.core.utils import CANCELLATION_TAG, TOOL_ERROR_TAG, TaggedText
 
 
@@ -60,23 +60,31 @@ class SessionAnalysis:
         )
         fallback_preview = metadata.get("title")
         bash_calls_by_id: dict[str, str] = {}
+        skill_invocations = skill_invocations_by_message_id(metadata)
         skip_turn = False
 
         for message in messages:
             match message.role:
                 case Role.user:
-                    if (
-                        text := extract_message_text(message)
-                    ) is not None and is_improve_generated_prompt(text):
+                    text = extract_message_text(message)
+                    if text is not None and is_improve_generated_prompt(text):
                         skip_turn = True
                         continue
                     skip_turn = False
                     analysis.user_messages += 1
                     if (
                         analysis.preview == NO_PREVIEW
-                        and text is not None
+                        and (
+                            preview := preview_text(
+                                text,
+                                skill_invocations.get(message.message_id)
+                                if message.message_id is not None
+                                else None,
+                            )
+                        )
+                        is not None
                     ):
-                        analysis.preview = shorten(text, PREVIEW_CHAR_LIMIT)
+                        analysis.preview = preview
                 case Role.assistant:
                     if skip_turn:
                         continue
@@ -533,6 +541,36 @@ def extract_message_text(message: LLMMessage) -> str | None:
         return None
     text = collapse_whitespace(message.content)
     return text or None
+
+
+def skill_invocations_by_message_id(
+    metadata: dict[str, Any],
+) -> dict[str, SessionSkillInvocation]:
+    raw_skill_invocations = metadata.get("skill_invocations")
+    if not isinstance(raw_skill_invocations, list):
+        return {}
+
+    skill_invocations: dict[str, SessionSkillInvocation] = {}
+    for item in raw_skill_invocations:
+        try:
+            invocation = SessionSkillInvocation.model_validate(item)
+        except ValueError:
+            continue
+        skill_invocations[invocation.message_id] = invocation
+    return skill_invocations
+
+
+def preview_text(
+    text: str | None, skill_invocation: SessionSkillInvocation | None
+) -> str | None:
+    if skill_invocation is not None:
+        if invocation := collapse_whitespace(skill_invocation.invocation):
+            return shorten(f"{invocation} (skill)", PREVIEW_CHAR_LIMIT)
+        return f"/{skill_invocation.skill_name} (skill)"
+
+    if text is None:
+        return None
+    return shorten(text, PREVIEW_CHAR_LIMIT)
 
 
 def tool_message_tag(content: str) -> str:

--- a/vibe/core/session/improve_prompt.py
+++ b/vibe/core/session/improve_prompt.py
@@ -426,8 +426,12 @@ def build_improve_prompt(
 
         try:
             messages, metadata = SessionLoader.load_session(session_dir)
-        except ValueError:
-            # Skip corrupted or invalid sessions
+        except ValueError as exc:
+            logger.warning(
+                "Skipping corrupted session at %s",
+                session_dir,
+                exc_info=exc,
+            )
             continue
 
         try:

--- a/vibe/core/session/session_logger.py
+++ b/vibe/core/session/session_logger.py
@@ -135,9 +135,19 @@ class SessionLogger:
             environment={"working_directory": str(Path.cwd())},
         )
 
+    @staticmethod
+    def _persisted_non_system_messages(
+        messages: Sequence[LLMMessage],
+    ) -> list[LLMMessage]:
+        return [
+            message
+            for message in messages
+            if message.role != Role.system and message.persist_to_session_log
+        ]
+
     def _get_title(self, messages: Sequence[LLMMessage]) -> str:
         first_user_message = None
-        for message in messages:
+        for message in self._persisted_non_system_messages(messages):
             if message.role == Role.user:
                 first_user_message = message
                 break
@@ -216,7 +226,7 @@ class SessionLogger:
         if self.session_metadata is None:
             return
 
-        if not any(msg.role != Role.system for msg in messages):
+        if not self._persisted_non_system_messages(messages):
             return
 
         # If the session directory does not exist, create it
@@ -243,7 +253,7 @@ class SessionLogger:
             ) from e
 
         try:
-            non_system_messages = [m for m in messages if m.role != Role.system]
+            non_system_messages = self._persisted_non_system_messages(messages)
             # Append new messages
             new_messages = non_system_messages[old_total_messages:]
 

--- a/vibe/core/session/session_logger.py
+++ b/vibe/core/session/session_logger.py
@@ -17,7 +17,13 @@ from vibe.core.session.session_loader import (
     METADATA_FILENAME,
     SessionLoader,
 )
-from vibe.core.types import AgentStats, LLMMessage, Role, SessionMetadata
+from vibe.core.types import (
+    AgentStats,
+    LLMMessage,
+    Role,
+    SessionMetadata,
+    SessionSkillInvocation,
+)
 from vibe.core.utils import is_windows, utc_now
 
 if TYPE_CHECKING:
@@ -135,6 +141,31 @@ class SessionLogger:
             environment={"working_directory": str(Path.cwd())},
         )
 
+    def record_skill_invocation(
+        self,
+        *,
+        message_id: str,
+        skill_name: str,
+        invocation: str,
+        skill_path: Path,
+    ) -> None:
+        if self.session_metadata is None:
+            return
+
+        invocation_entry = SessionSkillInvocation(
+            message_id=message_id,
+            skill_name=skill_name,
+            invocation=invocation,
+            skill_path=str(skill_path),
+        )
+        skill_invocations = [
+            existing
+            for existing in self.session_metadata.skill_invocations
+            if existing.message_id != message_id
+        ]
+        skill_invocations.append(invocation_entry)
+        self.session_metadata.skill_invocations = skill_invocations
+
     @staticmethod
     def _persisted_non_system_messages(
         messages: Sequence[LLMMessage],
@@ -146,6 +177,14 @@ class SessionLogger:
         ]
 
     def _get_title(self, messages: Sequence[LLMMessage]) -> str:
+        skill_invocations_by_message_id = (
+            {
+                invocation.message_id: invocation
+                for invocation in self.session_metadata.skill_invocations
+            }
+            if self.session_metadata is not None
+            else {}
+        )
         first_user_message = None
         for message in self._persisted_non_system_messages(messages):
             if message.role == Role.user:
@@ -156,7 +195,16 @@ class SessionLogger:
             title = "Untitled session"
         else:
             MAX_TITLE_LENGTH = 50
-            text = str(first_user_message.content)
+            skill_invocation = (
+                skill_invocations_by_message_id.get(first_user_message.message_id)
+                if first_user_message.message_id is not None
+                else None
+            )
+            text = (
+                skill_invocation.invocation
+                if skill_invocation is not None
+                else str(first_user_message.content)
+            )
             title = text[:MAX_TITLE_LENGTH]
             if len(text) > MAX_TITLE_LENGTH:
                 title += "…"

--- a/vibe/core/types.py
+++ b/vibe/core/types.py
@@ -215,6 +215,7 @@ class LLMMessage(BaseModel):
     name: str | None = None
     tool_call_id: str | None = None
     message_id: str | None = None
+    persist_to_session_log: bool = Field(default=True, exclude=True)
 
     @model_validator(mode="before")
     @classmethod
@@ -222,6 +223,7 @@ class LLMMessage(BaseModel):
         if isinstance(v, dict):
             v.setdefault("content", "")
             v.setdefault("role", "assistant")
+            v.setdefault("persist_to_session_log", True)
             if "message_id" not in v and v.get("role") != "tool":
                 v["message_id"] = str(uuid4())
             return v
@@ -236,6 +238,7 @@ class LLMMessage(BaseModel):
             "tool_call_id": getattr(v, "tool_call_id", None),
             "message_id": getattr(v, "message_id", None)
             or (str(uuid4()) if role != "tool" else None),
+            "persist_to_session_log": getattr(v, "persist_to_session_log", True),
         }
 
     def __add__(self, other: LLMMessage) -> LLMMessage:
@@ -295,6 +298,9 @@ class LLMMessage(BaseModel):
             name=self.name,
             tool_call_id=self.tool_call_id,
             message_id=self.message_id,
+            persist_to_session_log=(
+                self.persist_to_session_log and other.persist_to_session_log
+            ),
         )
 
 

--- a/vibe/core/types.py
+++ b/vibe/core/types.py
@@ -127,6 +127,19 @@ class SessionInfo(BaseModel):
     save_dir: str
 
 
+class SessionSkillInvocation(BaseModel):
+    message_id: str
+    skill_name: str
+    invocation: str
+    skill_path: str
+
+
+class TurnSkillInvocation(BaseModel):
+    skill_name: str
+    invocation: str
+    skill_path: str
+
+
 class SessionMetadata(BaseModel):
     session_id: str
     start_time: str
@@ -135,6 +148,7 @@ class SessionMetadata(BaseModel):
     git_branch: str | None
     environment: dict[str, str | None]
     username: str
+    skill_invocations: list[SessionSkillInvocation] = Field(default_factory=list)
 
 
 class ClientMetadata(BaseModel):


### PR DESCRIPTION
**Add `/improve` command with session digest analysis and transient logging controls**

This PR introduces a new `/improve` slash command that builds an improvement prompt by analyzing recent session logs and submits it through the Textual UI without persisting the generated prompt or response to session logs. The core implementation adds a session digest pipeline in `vibe/core/session/improve_prompt.py`, wires the command into the CLI command registry and UI flow, and updates the agent loop and session logger to support per-turn persistence control via `LLMMessage.persist_to_session_log`.

It also adds skill invocation tracking to session metadata, updates message/title generation to use persisted messages and skill invocations, and expands tests across session analysis, command registration, transient logging, and metadata loading. Documentation is updated to mention `/improve` in `README.md`.