### PR TITLE
Fix ImportError on Windows startup (defer mcp DLL imports)

### DIFF
--- a/vibe/core/tools/mcp/tools.py
+++ b/vibe/core/tools/mcp/tools.py
@@ -11,9 +11,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, TextIO
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from mcp import ClientSession
-from mcp.client.stdio import StdioServerParameters, stdio_client
-from mcp.client.streamable_http import streamablehttp_client
 from vibe.core.logger import logger
 from vibe.core.tools.base import (
     BaseTool,
@@ -27,6 +24,9 @@ from vibe.core.tools.ui import ToolResultDisplay, ToolUIData
 from vibe.core.types import ToolStreamEvent
 
 if TYPE_CHECKING:
+    from mcp import ClientSession
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+    from mcp.client.streamable_http import streamablehttp_client
     from vibe.core.types import ToolResultEvent
 
 
@@ -152,6 +152,9 @@ async def list_tools_http(
     headers: dict[str, str] | None = None,
     startup_timeout_sec: float | None = None,
 ) -> list[RemoteTool]:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
     timeout = timedelta(seconds=startup_timeout_sec) if startup_timeout_sec else None
     async with streamablehttp_client(url, headers=headers) as (read, write, _):
         async with ClientSession(read, write, read_timeout_seconds=timeout) as session:
@@ -170,6 +173,9 @@ async def call_tool_http(
     tool_timeout_sec: float | None = None,
     sampling_callback: MCPSamplingHandler | None = None,
 ) -> MCPToolResult:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
     init_timeout = (
         timedelta(seconds=startup_timeout_sec) if startup_timeout_sec else None
     )
@@ -279,6 +285,9 @@ async def list_tools_stdio(
     env: dict[str, str] | None = None,
     startup_timeout_sec: float | None = None,
 ) -> list[RemoteTool]:
+    from mcp import ClientSession
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+
     params = StdioServerParameters(command=command[0], args=command[1:], env=env)
     timeout = timedelta(seconds=startup_timeout_sec) if startup_timeout_sec else None
     async with (
@@ -301,6 +310,9 @@ async def call_tool_stdio(
     tool_timeout_sec: float | None = None,
     sampling_callback: MCPSamplingHandler | None = None,
 ) -> MCPToolResult:
+    from mcp import ClientSession
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+
     params = StdioServerParameters(command=command[0], args=command[1:], env=env)
     init_timeout = (
         timedelta(seconds=startup_timeout_sec) if startup_timeout_sec else None


### PR DESCRIPTION
Fixes #479.

**Problem:** Launching `vibe` on Windows fails immediately with `ImportError: DLL load failed while importing _win32sysloader`. The root cause is that `vibe/core/tools/mcp/tools.py` imports `mcp.ClientSession`, `mcp.client.stdio`, and `mcp.client.streamable_http` at module load time. On Windows, this triggers `mcp.os.win32.utilities` → `pywintypes`, which requires pywin32 DLLs to already be on `PATH`. When Python is installed via Scoop (or similar sandboxed installers), those DLLs aren't on `PATH` at import time, so the load fails before the CLI can do anything.

**Fix:** Move the three mcp imports from module-level into the four async functions that actually use them (`list_tools_http`, `call_tool_http`, `list_tools_stdio`, `call_tool_stdio`). The mcp package is now only loaded when an MCP server is actually invoked — not at startup. The `TYPE_CHECKING` guard retains the imports for static analysis so type annotations are unaffected.

No behavior change on any platform when MCP is used normally.