### PR TITLE
fix(vscode): handle Enter key in VSCode 1.111.0 terminal

### DIFF
--- a/vibe/cli/textual_ui/widgets/chat_input/text_area.py
+++ b/vibe/cli/textual_ui/widgets/chat_input/text_area.py
@@ -12,7 +12,7 @@ from vibe.cli.textual_ui.external_editor import ExternalEditor
 from vibe.cli.textual_ui.widgets.chat_input.completion_manager import (
     MultiCompletionManager,
 )
-from vibe.cli.textual_ui.widgets.vscode_compat import patch_vscode_space
+from vibe.cli.textual_ui.widgets.vscode_compat import patch_vscode_keys
 from vibe.cli.voice_manager.voice_manager_port import (
     RecordingStartError,
     TranscribeState,
@@ -250,7 +250,7 @@ class ChatTextArea(TextArea):
             event.stop()
             return
 
-        patch_vscode_space(event)
+        patch_vscode_keys(event)
 
         await super()._on_key(event)
         self._mark_cursor_moved_if_needed()

--- a/vibe/cli/textual_ui/widgets/vscode_compat.py
+++ b/vibe/cli/textual_ui/widgets/vscode_compat.py
@@ -6,21 +6,43 @@ from textual import events
 from textual.widgets import Input
 
 
+def patch_vscode_keys(event: events.Key) -> None:
+    """Patch key events sent as CSI u by VS Code 1.110+.
+
+    VS Code encodes certain keys using the kitty keyboard protocol (CSI u),
+    which Textual parses with the correct key name but ``character=None``.
+    Input widgets then silently drop the keystroke because there is no
+    printable character.
+
+    Affected keys:
+    - Space: ``\\x1b[32u`` parsed as ``Key("space", character=None)``
+    - Enter: ``\\x1b[13u`` parsed as ``Key("enter", character=None)``
+
+    Assigning the appropriate character restores normal behaviour.
+    """
+    if event.key == "space" and event.character is None:
+        event.character = " "
+    elif event.key == "enter" and event.character is None:
+        event.character = "\r"
+
+
 def patch_vscode_space(event: events.Key) -> None:
     """Patch space key events sent as CSI u by VS Code 1.110+.
+
+    .. deprecated::
+        Use :func:`patch_vscode_keys` instead to handle all affected keys.
 
     VS Code encodes space as ``\\x1b[32u`` (CSI u), which Textual parses as
     ``Key("space", character=None, is_printable=False)``.  Input widgets then
     silently drop the keystroke because there is no printable character.
     Assigning ``event.character = " "`` restores normal behaviour.
     """
-    if event.key == "space" and event.character is None:
-        event.character = " "
+    patch_vscode_keys(event)
 
 
 class VscodeCompatInput(Input):
-    """``Input`` subclass that handles the VS Code CSI-u space quirk."""
+    """``Input`` subclass that handles VS Code CSI-u key encoding quirks."""
 
     async def _on_key(self, event: events.Key) -> None:
-        patch_vscode_space(event)
+        patch_vscode_keys(event)
         await super()._on_key(event)


### PR DESCRIPTION
VSCode 1.111.0 sends Enter key as CSI u sequence (\x1b[13u) using the kitty keyboard protocol. Textual parses this as Key("enter", character=None), causing input widgets to silently drop the keystroke.

This extends the existing space key fix (v2.4.1) to also handle Enter key.

Changes:
- Add `patch_vscode_keys()` function to handle both space and enter keys  
- Keep `patch_vscode_space()` as deprecated wrapper for backwards compatibility
- Update `VscodeCompatInput` and `ChatTextArea` to use the new function

Fixes #492
