### PR TITLE
fix: preserve scroll position when pruning old messages

### DIFF
--- a/tests/cli/test_scroll_preservation.py
+++ b/tests/cli/test_scroll_preservation.py
@@ -1,0 +1,85 @@
+"""Test scroll position preservation during pruning."""
+from __future__ import annotations
+
+import pytest
+
+from tests.cli.plan_offer.adapters.fake_whoami_gateway import FakeWhoAmIGateway
+from tests.conftest import build_test_agent_loop
+from vibe.cli.plan_offer.ports.whoami_gateway import WhoAmIPlanType, WhoAmIResponse
+from vibe.cli.textual_ui.app import ChatScroll, VibeApp
+from vibe.cli.textual_ui.widgets.messages import UserMessage
+from vibe.core.config import SessionLoggingConfig, VibeConfig
+from vibe.core.types import LLMMessage, Role
+
+
+@pytest.fixture
+def vibe_config() -> VibeConfig:
+    return VibeConfig(
+        session_logging=SessionLoggingConfig(enabled=False), enable_update_checks=False
+    )
+
+
+def _pro_plan_gateway() -> FakeWhoAmIGateway:
+    return FakeWhoAmIGateway(
+        response=WhoAmIResponse(
+            plan_type=WhoAmIPlanType.CHAT,
+            plan_name="INDIVIDUAL",
+            prompt_switching_to_pro_plan=False,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_scroll_position_preserved_when_pruning(vibe_config: VibeConfig) -> None:
+    """Test that scroll position is preserved when old messages are pruned.
+    
+    This addresses the bug where the chat would scroll to the start of the
+    conversation when old messages were removed to keep memory usage bounded.
+    """
+    # Create enough messages to trigger pruning
+    # PRUNE_HIGH_MARK is 1500, so we need to exceed that virtual height
+    agent_loop = build_test_agent_loop(config=vibe_config, enable_streaming=False)
+    
+    # Add many messages with substantial content to exceed pruning threshold
+    for idx in range(100):
+        agent_loop.messages.append(
+            LLMMessage(
+                role=Role.user,
+                content=f"Message {idx}\n" + "\n".join([f"Line {i}" for i in range(20)])
+            )
+        )
+
+    app = VibeApp(agent_loop=agent_loop, plan_offer_gateway=_pro_plan_gateway())
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        # Wait for initial messages to load
+        await pilot.pause(0.5)
+        
+        chat = app.query_one("#chat", ChatScroll)
+        
+        # Scroll to middle (not at bottom)
+        chat.scroll_y = 500
+        await pilot.pause(0.1)
+        
+        # Store position before any potential pruning
+        was_at_bottom_before = chat.is_at_bottom
+        
+        # Trigger pruning by adding more messages
+        for idx in range(100, 150):
+            msg = UserMessage(
+                content=f"Message {idx}\n" + "\n".join([f"Line {i}" for i in range(20)])
+            )
+            await app._mount_and_scroll(msg)
+            await pilot.pause(0.05)
+        
+        await pilot.pause(0.5)
+        
+        # If we weren't at bottom, scroll position should be preserved
+        # (approximately - may change due to content removal)
+        if not was_at_bottom_before:
+            # The scroll position should not jump to 0 (start of conversation)
+            # It should maintain relative position or be adjusted for removed content
+            assert chat.scroll_y > 100, (
+                f"Scroll position jumped to {chat.scroll_y}, "
+                "likely reset to start of conversation"
+            )

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -167,12 +167,16 @@ PRUNE_HIGH_MARK = 1500
 
 
 async def prune_oldest_children(
-    messages_area: Widget, low_mark: int, high_mark: int
+    messages_area: Widget,
+    chat_scroll: ChatScroll,
+    low_mark: int,
+    high_mark: int,
 ) -> bool:
     """Remove the oldest children so the virtual height stays within bounds.
 
     Walks children back-to-front to find how much to keep (up to *low_mark*
     of visible height), then removes everything before that point.
+    Preserves scroll position if the user is not at the bottom.
     """
     total_height = messages_area.virtual_size.height
     if total_height <= high_mark:
@@ -198,7 +202,20 @@ async def prune_oldest_children(
     if not to_remove:
         return False
 
+    # Preserve scroll position if user is not at bottom
+    was_at_bottom = chat_scroll.is_at_bottom
+    scroll_offset_from_bottom = 0
+    if not was_at_bottom:
+        scroll_offset_from_bottom = chat_scroll.max_scroll_y - chat_scroll.scroll_y
+
     await messages_area.remove_children(to_remove)
+
+    # Restore scroll position after pruning
+    if not was_at_bottom:
+        # Recalculate scroll position based on new max_scroll_y
+        new_scroll_y = max(0, chat_scroll.max_scroll_y - scroll_offset_from_bottom)
+        chat_scroll.scroll_y = new_scroll_y
+
     return True
 
 
@@ -1620,15 +1637,14 @@ class VibeApp(App):  # noqa: PLR0904
 
     async def _try_prune(self) -> None:
         messages_area = self._cached_messages_area or self.query_one("#messages")
+        chat = self._cached_chat or self.query_one("#chat", ChatScroll)
         pruned = await prune_oldest_children(
-            messages_area, PRUNE_LOW_MARK, PRUNE_HIGH_MARK
+            messages_area, chat, PRUNE_LOW_MARK, PRUNE_HIGH_MARK
         )
         if self._load_more.widget and not self._load_more.widget.parent:
             self._load_more.widget = None
-        if pruned:
-            chat = self._cached_chat or self.query_one("#chat", ChatScroll)
-            if chat.is_at_bottom:
-                self.call_later(chat.anchor)
+        if pruned and chat.is_at_bottom:
+            self.call_later(chat.anchor)
 
     async def _refresh_windowing_from_history(self) -> None:
         if self._load_more.widget is None:


### PR DESCRIPTION
When the conversation history exceeds the pruning threshold (1500 virtual height units), old messages are removed from the top to keep memory usage bounded. Previously, this removal caused Textual to reset the scroll position to 0, forcing users to see the start of the conversation unexpectedly.

## Changes

- Modified  to preserve scroll position when removing old messages
- If the user is not at the bottom, their scroll offset from bottom is saved before pruning and restored after
- Users already at bottom continue to have their view anchored to new messages

## Testing

- Added test  to verify the fix
- All 191 existing CLI tests pass
- Type checking and linting pass

Fixes #485