### PR TITLE
fix: add explicit UTF-8 encoding to file reads for Windows compatibility

### DIFF
--- a/vibe/cli/terminal_setup.py
+++ b/vibe/cli/terminal_setup.py
@@ -189,7 +189,7 @@ def _setup_vscode_like_terminal(terminal: Terminal) -> SetupResult:
 
 def _read_existing_keybindings(keybindings_path: Path) -> list[dict[str, Any]]:
     if keybindings_path.exists():
-        content = keybindings_path.read_text()
+        content = keybindings_path.read_text(encoding="utf-8")
         return _parse_keybindings(content)
     keybindings_path.parent.mkdir(parents=True, exist_ok=True)
     return []

--- a/vibe/cli/textual_ui/external_editor.py
+++ b/vibe/cli/textual_ui/external_editor.py
@@ -24,7 +24,7 @@ class ExternalEditor:
             parts = shlex.split(editor)
             subprocess.run([*parts, filepath], check=True)
 
-            content = Path(filepath).read_text().rstrip()
+            content = Path(filepath).read_text(encoding="utf-8").rstrip()
             return content if content != initial_content else None
         except (OSError, subprocess.CalledProcessError):
             return

--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -482,7 +482,7 @@ class VibeConfig(BaseSettings):
                 ".md"
             )
             if custom_sp_path.is_file():
-                return custom_sp_path.read_text()
+                return custom_sp_path.read_text(encoding="utf-8")
 
         raise MissingPromptFileError(
             self.system_prompt_id, *(str(d) for d in prompt_dirs)

--- a/vibe/core/tools/builtins/exit_plan_mode.py
+++ b/vibe/core/tools/builtins/exit_plan_mode.py
@@ -74,7 +74,7 @@ class ExitPlanMode(
         plan_content: str | None = None
         if ctx.plan_file_path and ctx.plan_file_path.is_file():
             try:
-                plan_content = ctx.plan_file_path.read_text()
+                plan_content = ctx.plan_file_path.read_text(encoding="utf-8")
             except OSError as e:
                 raise ToolError(
                     f"Failed to read plan file at {ctx.plan_file_path}: {e}"


### PR DESCRIPTION
Fixes #461

Adds "encoding=utf-8" to all Path.read_text() calls that were missing explicit encoding, preventing UnicodeDecodeError on Windows where the default encoding (cp1252) cannot decode UTF-8 characters.

The session_loader.py fix in v2.4.0 addressed the /resume issue; this PR applies the same fix to:
- exit_plan_mode.py: reading plan files
- _settings.py: reading custom system prompt files  
- external_editor.py: reading edited content
- terminal_setup.py: reading VS Code keybindings

All 18 related tests pass.