### PR TITLE
fix(types): accept None for ToolCall.type from vLLM backends

### DIFF
--- a/vibe/core/types.py
+++ b/vibe/core/types.py
@@ -172,7 +172,7 @@ class ToolCall(BaseModel):
     id: str | None = None
     index: int | None = None
     function: FunctionCall = Field(default_factory=FunctionCall)
-    type: Literal["function"] = "function"
+    type: Literal["function"] | None = "function"
 
 
 def _content_before(v: Any) -> str:


### PR DESCRIPTION
**Bug:** Issue #474

**Problem:**
When using vLLM backends with models like Qwen3.5-27B, the API returns \\"type\\": null for tool calls instead of \\"type\\": \\"function\\". This causes a Pydantic validation error:

```
1 validation error for LLMMessage
tool_calls.0.type
  Input should be \\function\ [type=literal_error, input_value=None, input_type=NoneType]
```

**Root Cause:**
The `ToolCall` model defined `type: Literal[\\"function\\"] = \\"function\\"`, which only accepts the string \\"function\\" and rejects `None` values.

**Fix:**
Changed the type annotation to `Literal[\\"function\\"] | None = \\"function\\"` to accept both `\\"function\\"` and `None`, while still defaulting to `\\"function\\"` when the field is missing.

**Testing:**
- 143 tests passed (1 unrelated e2e timeout)
- Verified the fix handles all cases:
  - `type: \\"function\\"` → accepted, value = \\"function\\"
  - `type: null` → accepted, value = None
  - missing `type` → accepted, defaults to \\"function\\"

Fixes #474