### PR TITLE
fix: remove 'Eating a pain au chocolat' easter egg from CLI

### DIFF
--- a/vibe/cli/textual_ui/widgets/loading.py
+++ b/vibe/cli/textual_ui/widgets/loading.py
@@ -33,7 +33,6 @@ class LoadingWidget(SpinnerMixin, Static):
 
     EASTER_EGGS: ClassVar[list[str]] = [
         "Eating a chocolatine",
-        "Eating a pain au chocolat",
         "Réflexion",
         "Analyse",
         "Contemplation",


### PR DESCRIPTION
Removes the 'Eating a pain au chocolat' entry from the CLI loading easter eggs, keeping only 'Eating a chocolatine' as the correct expression. Fixes #233.

Addresses #233.