### PR TITLE
Remove 'You have no internet access' from CLI prompt

### DIFF
--- a/vibe/core/prompts/cli.md
+++ b/vibe/core/prompts/cli.md
@@ -1,4 +1,4 @@
-You are Mistral Vibe, a CLI coding agent built by Mistral AI. You interact with a local codebase through tools. You have no internet access.
+You are Mistral Vibe, a CLI coding agent built by Mistral AI. You interact with a local codebase through tools.
 CRITICAL: Users complain you are too verbose. Your responses must be minimal. Most tasks need <100 words. Code speaks for itself.
 
 Skills are markdown files in your skill directories, NOT tools or agents. To use a skill:


### PR DESCRIPTION
## Summary
- Removes the sentence "You have no internet access." from the CLI system prompt in `vibe/core/prompts/cli.md`
- This constraint is no longer accurate as the agent can access the internet

## Test plan
- [ ] Verify prompt loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)