### PR TITLE
feat: add MiniMax as built-in LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,37 @@ Vibe supports multiple ways to configure your API keys:
 
 **Note**: The `.env` file is specifically for API keys and other provider credentials. General Vibe configuration should be done in `config.toml`.
 
+### Alternative LLM Providers
+
+Vibe supports multiple LLM providers out of the box. In addition to Mistral's native models, you can use any OpenAI-compatible provider through the generic backend.
+
+#### MiniMax
+
+[MiniMax](https://www.minimax.io/) models are available as a built-in provider. To use MiniMax, set your API key and switch to a MiniMax model:
+
+```bash
+export MINIMAX_API_KEY="your_minimax_api_key"
+```
+
+Or add it to your `~/.vibe/.env` file:
+
+```bash
+MINIMAX_API_KEY=your_minimax_api_key
+```
+
+Then select a MiniMax model in your `config.toml`:
+
+```toml
+active_model = "minimax-m2.7"
+```
+
+Available MiniMax models:
+
+| Model | Alias | Context Window |
+| ----- | ----- | -------------- |
+| MiniMax-M2.7 | `minimax-m2.7` | 1M tokens |
+| MiniMax-M2.7-highspeed | `minimax-m2.7-highspeed` | 1M tokens |
+
 ### Custom System Prompts
 
 You can create custom system prompts to replace the default one (`prompts/cli.md`). Create a markdown file in the `~/.vibe/prompts/` directory with your custom prompt content.

--- a/tests/backend/data/minimax.py
+++ b/tests/backend/data/minimax.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from tests.backend.data import Chunk, JsonResponse, ResultData, Url
+
+SIMPLE_CONVERSATION_PARAMS: list[tuple[Url, JsonResponse, ResultData]] = [
+    (
+        "https://api.minimax.io",
+        {
+            "id": "fake_id_minimax_1234",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "MiniMax-M2.7",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Some content",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 100,
+                "total_tokens": 300,
+                "completion_tokens": 200,
+            },
+        },
+        {
+            "message": "Some content",
+            "usage": {
+                "prompt_tokens": 100,
+                "total_tokens": 300,
+                "completion_tokens": 200,
+            },
+        },
+    )
+]
+
+TOOL_CONVERSATION_PARAMS: list[tuple[Url, JsonResponse, ResultData]] = [
+    (
+        "https://api.minimax.io",
+        {
+            "id": "fake_id_minimax_1234",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "MiniMax-M2.7",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "fake_id_minimax_5678",
+                                "type": "function",
+                                "function": {
+                                    "name": "some_tool",
+                                    "arguments": '{"some_argument": "some_argument_value"}',
+                                },
+                                "name": None,
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 200,
+            },
+        },
+        {
+            "message": "",
+            "tool_calls": [
+                {
+                    "name": "some_tool",
+                    "arguments": '{"some_argument": "some_argument_value"}',
+                    "index": 0,
+                }
+            ],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 200},
+        },
+    )
+]
+
+STREAMED_SIMPLE_CONVERSATION_PARAMS: list[tuple[Url, list[Chunk], list[ResultData]]] = [
+    (
+        "https://api.minimax.io",
+        [
+            rb'data: {"id":"fake_id_minimax_1234","object":"chat.completion.chunk","created":1234567890,"model":"MiniMax-M2.7","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}],"usage":null}',
+            rb'data: {"id":"fake_id_minimax_1234","object":"chat.completion.chunk","created":1234567890,"model":"MiniMax-M2.7","choices":[{"index":0,"delta":{"content":"Some content"},"finish_reason":null}],"usage":null}',
+            rb'data: {"id":"fake_id_minimax_1234","object":"chat.completion.chunk","created":1234567890,"model":"MiniMax-M2.7","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"total_tokens":300,"completion_tokens":200}}',
+            rb"data: [DONE]",
+        ],
+        [
+            {"message": "", "usage": {"prompt_tokens": 0, "completion_tokens": 0}},
+            {
+                "message": "Some content",
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0},
+            },
+            {"message": "", "usage": {"prompt_tokens": 100, "completion_tokens": 200}},
+        ],
+    )
+]
+
+
+STREAMED_TOOL_CONVERSATION_PARAMS: list[tuple[Url, list[Chunk], list[ResultData]]] = [
+    (
+        "https://api.minimax.io",
+        [
+            rb'data: {"id": "fake_id_minimax_1234","object": "chat.completion.chunk","created": 1234567890,"model": "MiniMax-M2.7","choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": null}],"usage": null}',
+            rb'data: {"id": "fake_id_minimax_1234","object": "chat.completion.chunk","created": 1234567890,"model": "MiniMax-M2.7","choices": [{"index": 0,"delta": {"content": "Some content"},"finish_reason": null}],"usage": null}',
+            rb'data: {"id": "fake_id_minimax_1234","object": "chat.completion.chunk","created": 1234567890,"model": "MiniMax-M2.7","choices": [{"index": 0,"delta": {"tool_calls": [{"index": 0,"id": "fake_id_minimax_151617","type": "function","function": {"name": "some_tool"}}]},"finish_reason": null}],"usage": null}',
+            rb'data: {"id": "fake_id_minimax_1234","object": "chat.completion.chunk","created": 1234567890,"model": "MiniMax-M2.7","choices": [{"index": 0,"delta": {"tool_calls": [{"index": 0,"id": null,"type": "function","function": {"arguments": "{\"some_argument\": \"some_arguments_value\"}"}}]},"finish_reason": null}],"usage": null}',
+            rb'data: {"id": "fake_id_minimax_1234","object": "chat.completion.chunk","created": 1234567890,"model": "MiniMax-M2.7","choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],"usage": {"prompt_tokens": 100,"total_tokens": 300,"completion_tokens": 200}}',
+            rb"data: [DONE]",
+        ],
+        [
+            {"message": "", "usage": {"prompt_tokens": 0, "completion_tokens": 0}},
+            {
+                "message": "Some content",
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0},
+            },
+            {
+                "message": "",
+                "tool_calls": [{"name": "some_tool", "arguments": None, "index": 0}],
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0},
+            },
+            {
+                "message": "",
+                "tool_calls": [
+                    {
+                        "name": None,
+                        "arguments": '{"some_argument": "some_arguments_value"}',
+                        "index": 0,
+                    }
+                ],
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0},
+            },
+            {"message": "", "usage": {"prompt_tokens": 100, "completion_tokens": 200}},
+        ],
+    )
+]

--- a/tests/backend/test_backend.py
+++ b/tests/backend/test_backend.py
@@ -27,6 +27,12 @@ from tests.backend.data.fireworks import (
     STREAMED_TOOL_CONVERSATION_PARAMS as FIREWORKS_STREAMED_TOOL_CONVERSATION_PARAMS,
     TOOL_CONVERSATION_PARAMS as FIREWORKS_TOOL_CONVERSATION_PARAMS,
 )
+from tests.backend.data.minimax import (
+    SIMPLE_CONVERSATION_PARAMS as MINIMAX_SIMPLE_CONVERSATION_PARAMS,
+    STREAMED_SIMPLE_CONVERSATION_PARAMS as MINIMAX_STREAMED_SIMPLE_CONVERSATION_PARAMS,
+    STREAMED_TOOL_CONVERSATION_PARAMS as MINIMAX_STREAMED_TOOL_CONVERSATION_PARAMS,
+    TOOL_CONVERSATION_PARAMS as MINIMAX_TOOL_CONVERSATION_PARAMS,
+)
 from tests.backend.data.mistral import (
     SIMPLE_CONVERSATION_PARAMS as MISTRAL_SIMPLE_CONVERSATION_PARAMS,
     STREAMED_SIMPLE_CONVERSATION_PARAMS as MISTRAL_STREAMED_SIMPLE_CONVERSATION_PARAMS,
@@ -60,6 +66,8 @@ class TestBackend:
         [
             *FIREWORKS_SIMPLE_CONVERSATION_PARAMS,
             *FIREWORKS_TOOL_CONVERSATION_PARAMS,
+            *MINIMAX_SIMPLE_CONVERSATION_PARAMS,
+            *MINIMAX_TOOL_CONVERSATION_PARAMS,
             *MISTRAL_SIMPLE_CONVERSATION_PARAMS,
             *MISTRAL_TOOL_CONVERSATION_PARAMS,
         ],
@@ -128,6 +136,8 @@ class TestBackend:
         [
             *FIREWORKS_STREAMED_SIMPLE_CONVERSATION_PARAMS,
             *FIREWORKS_STREAMED_TOOL_CONVERSATION_PARAMS,
+            *MINIMAX_STREAMED_SIMPLE_CONVERSATION_PARAMS,
+            *MINIMAX_STREAMED_TOOL_CONVERSATION_PARAMS,
             *MISTRAL_STREAMED_SIMPLE_CONVERSATION_PARAMS,
             *MISTRAL_STREAMED_TOOL_CONVERSATION_PARAMS,
         ],
@@ -217,6 +227,16 @@ class TestBackend:
                 httpx.Response(status_code=429, text="Rate Limit Exceeded"),
             ),
             (
+                "https://api.minimax.io",
+                GenericBackend,
+                httpx.Response(status_code=500, text="Internal Server Error"),
+            ),
+            (
+                "https://api.minimax.io",
+                GenericBackend,
+                httpx.Response(status_code=429, text="Rate Limit Exceeded"),
+            ),
+            (
                 "https://api.mistral.ai",
                 MistralBackend,
                 httpx.Response(status_code=500, text="Internal Server Error"),
@@ -268,6 +288,7 @@ class TestBackend:
         "base_url,provider_name,expected_stream_options",
         [
             ("https://api.fireworks.ai", "fireworks", {"include_usage": True}),
+            ("https://api.minimax.io", "minimax", {"include_usage": True}),
             (
                 "https://api.mistral.ai",
                 "mistral",

--- a/tests/backend/test_minimax.py
+++ b/tests/backend/test_minimax.py
@@ -1,0 +1,293 @@
+"""Unit tests for MiniMax provider integration.
+
+Tests cover provider configuration, model resolution, backend selection,
+and OpenAI-compatible API request formatting via the GenericBackend.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from vibe.core.config import (
+    DEFAULT_MODELS,
+    DEFAULT_PROVIDERS,
+    Backend,
+    ModelConfig,
+    ProviderConfig,
+)
+from vibe.core.llm.backend.factory import BACKEND_FACTORY
+from vibe.core.llm.backend.generic import GenericBackend
+from vibe.core.types import LLMChunk, LLMMessage, Role
+
+
+class TestMiniMaxDefaultProviderConfig:
+    def test_minimax_in_default_providers(self) -> None:
+        provider_names = [p.name for p in DEFAULT_PROVIDERS]
+        assert "minimax" in provider_names
+
+    def test_minimax_provider_api_base(self) -> None:
+        minimax = next(p for p in DEFAULT_PROVIDERS if p.name == "minimax")
+        assert minimax.api_base == "https://api.minimax.io/v1"
+
+    def test_minimax_provider_uses_generic_backend(self) -> None:
+        minimax = next(p for p in DEFAULT_PROVIDERS if p.name == "minimax")
+        assert minimax.backend == Backend.GENERIC
+
+    def test_minimax_provider_uses_openai_api_style(self) -> None:
+        minimax = next(p for p in DEFAULT_PROVIDERS if p.name == "minimax")
+        assert minimax.api_style == "openai"
+
+    def test_minimax_provider_api_key_env_var(self) -> None:
+        minimax = next(p for p in DEFAULT_PROVIDERS if p.name == "minimax")
+        assert minimax.api_key_env_var == "MINIMAX_API_KEY"
+
+
+class TestMiniMaxDefaultModelConfig:
+    def test_minimax_m27_in_default_models(self) -> None:
+        model_aliases = [m.alias for m in DEFAULT_MODELS]
+        assert "minimax-m2.7" in model_aliases
+
+    def test_minimax_m27_highspeed_in_default_models(self) -> None:
+        model_aliases = [m.alias for m in DEFAULT_MODELS]
+        assert "minimax-m2.7-highspeed" in model_aliases
+
+    def test_minimax_m27_model_name(self) -> None:
+        m27 = next(m for m in DEFAULT_MODELS if m.alias == "minimax-m2.7")
+        assert m27.name == "MiniMax-M2.7"
+        assert m27.provider == "minimax"
+
+    def test_minimax_m27_highspeed_model_name(self) -> None:
+        m27hs = next(m for m in DEFAULT_MODELS if m.alias == "minimax-m2.7-highspeed")
+        assert m27hs.name == "MiniMax-M2.7-highspeed"
+        assert m27hs.provider == "minimax"
+
+    def test_minimax_model_pricing(self) -> None:
+        m27 = next(m for m in DEFAULT_MODELS if m.alias == "minimax-m2.7")
+        assert m27.input_price == 0.15
+        assert m27.output_price == 0.45
+
+    def test_minimax_highspeed_pricing(self) -> None:
+        m27hs = next(m for m in DEFAULT_MODELS if m.alias == "minimax-m2.7-highspeed")
+        assert m27hs.input_price == 0.05
+        assert m27hs.output_price == 0.15
+
+
+class TestMiniMaxBackendFactory:
+    def test_generic_backend_created_for_minimax(self) -> None:
+        provider = ProviderConfig(
+            name="minimax",
+            api_base="https://api.minimax.io/v1",
+            api_key_env_var="MINIMAX_API_KEY",
+        )
+        backend = BACKEND_FACTORY[provider.backend](provider=provider)
+        assert isinstance(backend, GenericBackend)
+
+
+class TestMiniMaxRequestFormatting:
+    @pytest.mark.asyncio
+    async def test_minimax_complete_sends_correct_payload(self) -> None:
+        base_url = "https://api.minimax.io"
+        with respx.mock(base_url=base_url) as mock_api:
+            route = mock_api.post("/v1/chat/completions").mock(
+                return_value=httpx.Response(
+                    status_code=200,
+                    json={
+                        "id": "test-id",
+                        "object": "chat.completion",
+                        "created": 1234567890,
+                        "model": "MiniMax-M2.7",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "Hello!",
+                                },
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {
+                            "prompt_tokens": 10,
+                            "completion_tokens": 5,
+                        },
+                    },
+                )
+            )
+
+            provider = ProviderConfig(
+                name="minimax",
+                api_base=f"{base_url}/v1",
+                api_key_env_var="MINIMAX_API_KEY",
+            )
+            backend = GenericBackend(provider=provider)
+            model = ModelConfig(
+                name="MiniMax-M2.7",
+                provider="minimax",
+                alias="minimax-m2.7",
+            )
+            messages = [LLMMessage(role=Role.user, content="Hi")]
+
+            result = await backend.complete(
+                model=model,
+                messages=messages,
+                temperature=0.2,
+                tools=None,
+                max_tokens=None,
+                tool_choice=None,
+                extra_headers=None,
+            )
+
+            assert route.called
+            request = route.calls.last.request
+            payload = json.loads(request.content)
+
+            assert payload["model"] == "MiniMax-M2.7"
+            assert payload["temperature"] == 0.2
+            assert payload["messages"][0]["role"] == "user"
+            assert payload["messages"][0]["content"] == "Hi"
+
+            assert result.message.content == "Hello!"
+            assert result.usage is not None
+            assert result.usage.prompt_tokens == 10
+            assert result.usage.completion_tokens == 5
+
+    @pytest.mark.asyncio
+    async def test_minimax_bearer_auth_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+        base_url = "https://api.minimax.io"
+        with respx.mock(base_url=base_url) as mock_api:
+            route = mock_api.post("/v1/chat/completions").mock(
+                return_value=httpx.Response(
+                    status_code=200,
+                    json={
+                        "id": "test-id",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": "hi"},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                    },
+                )
+            )
+
+            provider = ProviderConfig(
+                name="minimax",
+                api_base=f"{base_url}/v1",
+                api_key_env_var="MINIMAX_API_KEY",
+            )
+            backend = GenericBackend(provider=provider)
+            model = ModelConfig(
+                name="MiniMax-M2.7", provider="minimax", alias="minimax-m2.7"
+            )
+            messages = [LLMMessage(role=Role.user, content="hi")]
+
+            await backend.complete(
+                model=model,
+                messages=messages,
+                temperature=0.2,
+                tools=None,
+                max_tokens=None,
+                tool_choice=None,
+                extra_headers=None,
+            )
+
+            assert route.called
+            request = route.calls.last.request
+            assert request.headers["Authorization"] == "Bearer test-minimax-key"
+
+    @pytest.mark.asyncio
+    async def test_minimax_streaming_complete(self) -> None:
+        base_url = "https://api.minimax.io"
+        with respx.mock(base_url=base_url) as mock_api:
+            mock_api.post("/v1/chat/completions").mock(
+                return_value=httpx.Response(
+                    status_code=200,
+                    stream=httpx.ByteStream(
+                        b'data: {"choices": [{"delta": {"role": "assistant", "content": ""}, "finish_reason": null}], "usage": null}\n\n'
+                        b'data: {"choices": [{"delta": {"content": "Hello"}, "finish_reason": null}], "usage": null}\n\n'
+                        b'data: {"choices": [{"delta": {}, "finish_reason": "stop"}], "usage": {"prompt_tokens": 10, "completion_tokens": 5}}\n\n'
+                        b"data: [DONE]\n\n"
+                    ),
+                    headers={"Content-Type": "text/event-stream"},
+                )
+            )
+
+            provider = ProviderConfig(
+                name="minimax",
+                api_base=f"{base_url}/v1",
+                api_key_env_var="MINIMAX_API_KEY",
+            )
+            backend = GenericBackend(provider=provider)
+            model = ModelConfig(
+                name="MiniMax-M2.7", provider="minimax", alias="minimax-m2.7"
+            )
+            messages = [LLMMessage(role=Role.user, content="Hi")]
+
+            results: list[LLMChunk] = []
+            async for chunk in backend.complete_streaming(
+                model=model,
+                messages=messages,
+                temperature=0.2,
+                tools=None,
+                max_tokens=None,
+                tool_choice=None,
+                extra_headers=None,
+            ):
+                results.append(chunk)
+
+            assert len(results) == 3
+            contents = [r.message.content for r in results if r.message.content]
+            assert "Hello" in contents
+
+    @pytest.mark.asyncio
+    async def test_minimax_temperature_zero(self) -> None:
+        base_url = "https://api.minimax.io"
+        with respx.mock(base_url=base_url) as mock_api:
+            route = mock_api.post("/v1/chat/completions").mock(
+                return_value=httpx.Response(
+                    status_code=200,
+                    json={
+                        "id": "test-id",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": "ok"},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                    },
+                )
+            )
+
+            provider = ProviderConfig(
+                name="minimax",
+                api_base=f"{base_url}/v1",
+                api_key_env_var="MINIMAX_API_KEY",
+            )
+            backend = GenericBackend(provider=provider)
+            model = ModelConfig(
+                name="MiniMax-M2.7", provider="minimax", alias="minimax-m2.7"
+            )
+            messages = [LLMMessage(role=Role.user, content="hi")]
+
+            await backend.complete(
+                model=model,
+                messages=messages,
+                temperature=0.0,
+                tools=None,
+                max_tokens=None,
+                tool_choice=None,
+                extra_headers=None,
+            )
+
+            assert route.called
+            payload = json.loads(route.calls.last.request.content)
+            assert payload["temperature"] == 0.0

--- a/tests/backend/test_minimax_integration.py
+++ b/tests/backend/test_minimax_integration.py
@@ -1,0 +1,176 @@
+"""Integration tests for MiniMax provider.
+
+These tests verify end-to-end MiniMax integration through the GenericBackend,
+including error handling, tool calls, and config-driven provider resolution.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from tests.conftest import build_test_vibe_config
+from vibe.core.config import (
+    DEFAULT_MODELS,
+    DEFAULT_PROVIDERS,
+    ModelConfig,
+    ProviderConfig,
+)
+from vibe.core.llm.backend.factory import BACKEND_FACTORY
+from vibe.core.llm.backend.generic import GenericBackend
+from vibe.core.llm.exceptions import BackendError
+from vibe.core.types import LLMMessage, Role
+
+
+class TestMiniMaxEndToEndFlow:
+    """Test MiniMax provider through the full config -> backend -> request pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_config_to_backend_to_completion(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MINIMAX_API_KEY", "integration-test-key")
+        base_url = "https://api.minimax.io"
+
+        cfg = build_test_vibe_config(
+            active_model="minimax-m2.7",
+            providers=list(DEFAULT_PROVIDERS),
+            models=list(DEFAULT_MODELS),
+        )
+        model = cfg.get_active_model()
+        provider = cfg.get_provider_for_model(model)
+
+        with respx.mock(base_url=base_url) as mock_api:
+            mock_api.post("/v1/chat/completions").mock(
+                return_value=httpx.Response(
+                    status_code=200,
+                    json={
+                        "id": "integ-1",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": "Integration test response"},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 20, "completion_tokens": 10},
+                    },
+                )
+            )
+
+            backend = BACKEND_FACTORY[provider.backend](provider=provider)
+            assert isinstance(backend, GenericBackend)
+
+            result = await backend.complete(
+                model=model,
+                messages=[LLMMessage(role=Role.user, content="Test prompt")],
+                temperature=model.temperature,
+                tools=None,
+                max_tokens=None,
+                tool_choice=None,
+                extra_headers=None,
+            )
+
+            assert result.message.content == "Integration test response"
+            assert result.usage is not None
+            assert result.usage.prompt_tokens == 20
+
+    @pytest.mark.asyncio
+    async def test_minimax_tool_call_flow(self) -> None:
+        base_url = "https://api.minimax.io"
+        with respx.mock(base_url=base_url) as mock_api:
+            mock_api.post("/v1/chat/completions").mock(
+                return_value=httpx.Response(
+                    status_code=200,
+                    json={
+                        "id": "tool-1",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "",
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call_abc123",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "read_file",
+                                                "arguments": '{"path": "src/main.py"}',
+                                            },
+                                        }
+                                    ],
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 50, "completion_tokens": 25},
+                    },
+                )
+            )
+
+            provider = ProviderConfig(
+                name="minimax",
+                api_base=f"{base_url}/v1",
+                api_key_env_var="MINIMAX_API_KEY",
+            )
+            backend = GenericBackend(provider=provider)
+            model = ModelConfig(
+                name="MiniMax-M2.7", provider="minimax", alias="minimax-m2.7"
+            )
+
+            result = await backend.complete(
+                model=model,
+                messages=[LLMMessage(role=Role.user, content="Read main.py")],
+                temperature=0.2,
+                tools=None,
+                max_tokens=None,
+                tool_choice=None,
+                extra_headers=None,
+            )
+
+            assert result.message.tool_calls is not None
+            assert len(result.message.tool_calls) == 1
+            assert result.message.tool_calls[0].function.name == "read_file"
+            assert '"path": "src/main.py"' in result.message.tool_calls[0].function.arguments
+
+    @pytest.mark.asyncio
+    async def test_minimax_error_handling(self) -> None:
+        base_url = "https://api.minimax.io"
+        with respx.mock(base_url=base_url) as mock_api:
+            mock_api.post("/v1/chat/completions").mock(
+                return_value=httpx.Response(
+                    status_code=401,
+                    json={
+                        "error": {
+                            "message": "Invalid API key",
+                            "type": "authentication_error",
+                        }
+                    },
+                )
+            )
+
+            provider = ProviderConfig(
+                name="minimax",
+                api_base=f"{base_url}/v1",
+                api_key_env_var="MINIMAX_API_KEY",
+            )
+            backend = GenericBackend(provider=provider)
+            model = ModelConfig(
+                name="MiniMax-M2.7", provider="minimax", alias="minimax-m2.7"
+            )
+
+            with pytest.raises(BackendError) as exc_info:
+                await backend.complete(
+                    model=model,
+                    messages=[LLMMessage(role=Role.user, content="test")],
+                    temperature=0.2,
+                    tools=None,
+                    max_tokens=None,
+                    tool_choice=None,
+                    extra_headers=None,
+                )
+
+            assert exc_info.value.status == 401

--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -286,6 +286,11 @@ DEFAULT_PROVIDERS = [
         api_base="http://127.0.0.1:8080/v1",
         api_key_env_var="",  # NOTE: if you wish to use --api-key in llama-server, change this value
     ),
+    ProviderConfig(
+        name="minimax",
+        api_base="https://api.minimax.io/v1",
+        api_key_env_var="MINIMAX_API_KEY",
+    ),
 ]
 
 DEFAULT_MODELS = [
@@ -309,6 +314,20 @@ DEFAULT_MODELS = [
         alias="local",
         input_price=0.0,
         output_price=0.0,
+    ),
+    ModelConfig(
+        name="MiniMax-M2.7",
+        provider="minimax",
+        alias="minimax-m2.7",
+        input_price=0.15,
+        output_price=0.45,
+    ),
+    ModelConfig(
+        name="MiniMax-M2.7-highspeed",
+        provider="minimax",
+        alias="minimax-m2.7-highspeed",
+        input_price=0.05,
+        output_price=0.15,
     ),
 ]
 


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimax.io/) AI as a first-class LLM provider, leveraging the existing `GenericBackend` with OpenAI-compatible API style. Users can switch to MiniMax models by setting `MINIMAX_API_KEY` and changing `active_model` in `config.toml`.

### Changes

- **Provider config**: Add `minimax` to `DEFAULT_PROVIDERS` with `api.minimax.io/v1` base URL and `MINIMAX_API_KEY` env var
- **Model config**: Register `MiniMax-M2.7` (alias `minimax-m2.7`) and `MiniMax-M2.7-highspeed` (alias `minimax-m2.7-highspeed`) in `DEFAULT_MODELS` with pricing
- **Test data**: Add MiniMax mock API response fixtures (`tests/backend/data/minimax.py`) covering simple conversations, tool calls, and streaming
- **Backend tests**: Add MiniMax params to existing `test_backend.py` parametrized tests (complete, streaming, error handling, stream options)
- **Unit tests**: 16 dedicated tests in `test_minimax.py` covering provider config, model config, backend factory, request formatting, auth headers, streaming, and temperature=0
- **Integration tests**: 3 tests in `test_minimax_integration.py` covering end-to-end config-to-completion flow, tool call handling, and error handling
- **Documentation**: Add MiniMax provider setup section to README with configuration examples and model table

### Usage

```bash
export MINIMAX_API_KEY="your_key"
```

```toml
# ~/.vibe/config.toml
active_model = "minimax-m2.7"
```

## Test plan

- [x] All 161 existing backend tests pass
- [x] 16 new MiniMax unit tests pass
- [x] 3 new MiniMax integration tests pass
- [x] `ruff check` passes with no errors
- [ ] Manual test with real MiniMax API key

---
*Generated with love for open source* 🐙