### PR TITLE
fix(generic): exclude internal fields from OpenAI backend payload

### DIFF
--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -97,7 +97,10 @@ class OpenAIAdapter(APIAdapter):
         field_name = provider.reasoning_field_name
         converted_messages = [
             self._reasoning_to_api(
-                msg.model_dump(exclude_none=True, exclude={"message_id"}), field_name
+                msg.model_dump(
+                    exclude_none=True, exclude={"message_id", "injected", "reasoning_signature"}
+                ),
+                field_name,
             )
             for msg in merged_messages
         ]


### PR DESCRIPTION
This change excludes 'injected', 'reasoning_signature', and 'message_id' from the JSON payload sent to OpenAI-compatible backends.

This fixes '400 Bad Request' errors on backends with strict Pydantic validation (like vLLM or Devstral) which reject extra fields in SystemMessage/UserMessage.