### PR TITLE
fix: detect file encoding in search_replace tool

### DIFF
--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from vibe.core.utils import get_server_url_from_api_base
-from vibe.core.utils.io import read_safe
+from vibe.core.utils.io import detect_encoding, read_safe, read_with_detected_encoding
 
 
 @pytest.mark.parametrize(
@@ -62,3 +62,46 @@ class TestReadSafe:
     def test_file_not_found_raises(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):
             read_safe(tmp_path / "nope.txt")
+
+
+class TestDetectEncoding:
+    def test_utf8(self) -> None:
+        assert detect_encoding("hello world".encode("utf-8")) == "ascii"
+
+    def test_shift_jis(self) -> None:
+        raw = "こんにちは世界".encode("shift_jis")
+        enc = detect_encoding(raw)
+        assert enc.lower().replace("-", "_") in ("shift_jis", "shift_jis_2004", "cp932")
+
+    def test_empty_bytes(self) -> None:
+        assert detect_encoding(b"") == "utf-8"
+
+
+class TestReadWithDetectedEncoding:
+    def test_reads_utf8(self, tmp_path: Path) -> None:
+        f = tmp_path / "utf8.txt"
+        f.write_text("café\n", encoding="utf-8")
+        content, encoding = read_with_detected_encoding(f)
+        assert content == "café\n"
+        assert encoding == "utf-8"
+
+    def test_reads_shift_jis(self, tmp_path: Path) -> None:
+        f = tmp_path / "sjis.txt"
+        original = "こんにちは世界\n"
+        f.write_bytes(original.encode("shift_jis"))
+        content, encoding = read_with_detected_encoding(f)
+        assert content == original
+        assert encoding.lower().replace("-", "_") in (
+            "shift_jis",
+            "shift_jis_2004",
+            "cp932",
+        )
+
+    def test_roundtrip_shift_jis(self, tmp_path: Path) -> None:
+        """Verify that reading a Shift-JIS file and writing it back preserves bytes."""
+        f = tmp_path / "roundtrip.txt"
+        original_bytes = "テスト文字列\n".encode("shift_jis")
+        f.write_bytes(original_bytes)
+        content, encoding = read_with_detected_encoding(f)
+        f.write_text(content, encoding=encoding)
+        assert f.read_bytes() == original_bytes

--- a/vibe/acp/tools/builtins/search_replace.py
+++ b/vibe/acp/tools/builtins/search_replace.py
@@ -35,7 +35,7 @@ class SearchReplace(CoreSearchReplaceTool, BaseAcpTool[AcpSearchReplaceState]):
     def _get_tool_state_class(cls) -> type[AcpSearchReplaceState]:
         return AcpSearchReplaceState
 
-    async def _read_file(self, file_path: Path) -> str:
+    async def _read_file(self, file_path: Path) -> tuple[str, str]:
         client, session_id, _ = self._load_state()
 
         await self._send_in_progress_session_update()
@@ -48,7 +48,8 @@ class SearchReplace(CoreSearchReplaceTool, BaseAcpTool[AcpSearchReplaceState]):
             raise ToolError(f"Unexpected error reading {file_path}: {e}") from e
 
         self.state.file_backup_content = response.content
-        return response.content
+        # ACP client handles encoding on the server side, default to utf-8
+        return response.content, "utf-8"
 
     async def _backup_file(self, file_path: Path) -> None:
         if self.state.file_backup_content is None:
@@ -59,7 +60,9 @@ class SearchReplace(CoreSearchReplaceTool, BaseAcpTool[AcpSearchReplaceState]):
             self.state.file_backup_content,
         )
 
-    async def _write_file(self, file_path: Path, content: str) -> None:
+    async def _write_file(
+        self, file_path: Path, content: str, encoding: str = "utf-8"
+    ) -> None:
         client, session_id, _ = self._load_state()
 
         try:

--- a/vibe/core/tools/builtins/search_replace.py
+++ b/vibe/core/tools/builtins/search_replace.py
@@ -22,7 +22,7 @@ from vibe.core.tools.permissions import PermissionContext
 from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
 from vibe.core.tools.utils import resolve_file_tool_permission
 from vibe.core.types import ToolResultEvent, ToolStreamEvent
-from vibe.core.utils.io import read_safe_async
+from vibe.core.utils.io import read_with_detected_encoding_async
 
 SEARCH_REPLACE_BLOCK_RE = re.compile(
     r"<{5,} SEARCH\r?\n(.*?)\r?\n?={5,}\r?\n(.*?)\r?\n?>{5,} REPLACE", flags=re.DOTALL
@@ -130,7 +130,7 @@ class SearchReplace(
     ) -> AsyncGenerator[ToolStreamEvent | SearchReplaceResult, None]:
         file_path, search_replace_blocks = self._prepare_and_validate_args(args)
 
-        original_content = await self._read_file(file_path)
+        original_content, file_encoding = await self._read_file(file_path)
 
         block_result = self._apply_blocks(
             original_content,
@@ -165,7 +165,7 @@ class SearchReplace(
             except Exception:
                 pass
 
-            await self._write_file(file_path, modified_content)
+            await self._write_file(file_path, modified_content, file_encoding)
 
         yield SearchReplaceResult(
             file=str(file_path),
@@ -220,9 +220,9 @@ class SearchReplace(
 
         return file_path, search_replace_blocks
 
-    async def _read_file(self, file_path: Path) -> str:
+    async def _read_file(self, file_path: Path) -> tuple[str, str]:
         try:
-            return await read_safe_async(file_path, raise_on_error=True)
+            return await read_with_detected_encoding_async(file_path)
         except PermissionError:
             raise ToolError(f"Permission denied reading file: {file_path}")
         except OSError as e:
@@ -233,10 +233,12 @@ class SearchReplace(
     async def _backup_file(self, file_path: Path) -> None:
         shutil.copy2(file_path, file_path.with_suffix(file_path.suffix + ".bak"))
 
-    async def _write_file(self, file_path: Path, content: str) -> None:
+    async def _write_file(
+        self, file_path: Path, content: str, encoding: str = "utf-8"
+    ) -> None:
         try:
             async with await anyio.Path(file_path).open(
-                mode="w", encoding="utf-8"
+                mode="w", encoding=encoding
             ) as f:
                 await f.write(content)
         except PermissionError:

--- a/vibe/core/utils/io.py
+++ b/vibe/core/utils/io.py
@@ -3,6 +3,21 @@ from __future__ import annotations
 from pathlib import Path
 
 import anyio
+from charset_normalizer import from_bytes
+
+
+def detect_encoding(raw: bytes) -> str:
+    """Detect the encoding of raw bytes using charset_normalizer.
+
+    Returns the best-guess encoding name, defaulting to utf-8 when detection
+    is inconclusive.
+    """
+    if not raw:
+        return "utf-8"
+    result = from_bytes(raw).best()
+    if result is None:
+        return "utf-8"
+    return result.encoding
 
 
 def read_safe(path: Path, *, raise_on_error: bool = False) -> str:
@@ -17,6 +32,32 @@ def read_safe(path: Path, *, raise_on_error: bool = False) -> str:
         if raise_on_error:
             return path.read_text()
         return path.read_text(errors="replace")
+
+
+def read_with_detected_encoding(path: Path) -> tuple[str, str]:
+    """Read a text file, detecting its encoding automatically.
+
+    Returns a (content, encoding) tuple. Tries UTF-8 first, then uses
+    charset_normalizer to detect the actual encoding for non-UTF-8 files
+    (e.g., Shift-JIS, EUC-KR, Windows-1252).
+    """
+    raw = path.read_bytes()
+    try:
+        return raw.decode("utf-8"), "utf-8"
+    except (UnicodeDecodeError, ValueError):
+        encoding = detect_encoding(raw)
+        return raw.decode(encoding), encoding
+
+
+async def read_with_detected_encoding_async(path: Path) -> tuple[str, str]:
+    """Async version of read_with_detected_encoding."""
+    apath = anyio.Path(path)
+    raw = await apath.read_bytes()
+    try:
+        return raw.decode("utf-8"), "utf-8"
+    except (UnicodeDecodeError, ValueError):
+        encoding = detect_encoding(raw)
+        return raw.decode(encoding), encoding
 
 
 async def read_safe_async(path: Path, *, raise_on_error: bool = False) -> str:


### PR DESCRIPTION
The `search_replace` tool assumes UTF-8 encoding, which breaks editing files in other encodings like Shift-JIS — either throwing `UnicodeDecodeError` or silently corrupting content.

Adds encoding detection using `charset_normalizer` (already a transitive dependency). Tries UTF-8 first, falls back to detected encoding on failure, and writes back using the original encoding.

Closes #543