### PR TITLE
fix(types): make ToolCall type optional for vLLM/Ollama compatibility

### DIFF
--- a/vibe/core/types.py
+++ b/vibe/core/types.py
@@ -178,7 +178,7 @@ class ToolCall(BaseModel):
     id: str | None = None
     index: int | None = None
     function: FunctionCall = Field(default_factory=FunctionCall)
-    type: Literal["function"] = "function"
+    type: Literal["function"] | None = "function"
 
 
 def _content_before(v: Any) -> str:


### PR DESCRIPTION
Some open-source inference servers (like vLLM or Ollama) may return 'null' or omit the 'type' field in tool call responses, even though the OpenAI spec suggests 'function'.

This change makes the 'type' field in ToolCall optional (| None), preventing Pydantic validation errors and crashes when using these backends. It maintains 'function' as the default value.