### PR TITLE
fix(cicd): protect workflows against supply chain attacks #553

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -15,6 +15,11 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Set matrix
         id: set-matrix
         run: |
@@ -51,6 +56,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: echo
         run: echo github.repository=${{ github.repository }}
 
@@ -106,6 +116,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Download all artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
@@ -138,6 +153,11 @@ jobs:
       matrix: ${{ fromJSON(needs.configure.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         if: matrix.os != 'windows'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -148,6 +148,11 @@ jobs:
       matrix: ${{ fromJSON(needs.configure.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         if: matrix.os != 'windows'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -179,6 +184,11 @@ jobs:
     container: ${{ matrix.container || '' }}
 
     steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
       contents: read
 
     steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
@@ -57,6 +62,11 @@ jobs:
       contents: read
 
     steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
@@ -93,6 +103,11 @@ jobs:
       contents: read
 
     steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,62 +1,67 @@
 name: Issue Labeler
 
 on:
-    issues:
-        types: [opened]
+  issues:
+    types: [opened]
 
 jobs:
-    label-component:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            issues: write
-        steps:
-            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+  label-component:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
 
-            - name: Parse bug report form
-              id: parse-bug
-              uses: stefanbuck/github-issue-parser@25f1485edffc1fee3ea68eb9f59a72e58720ffc4 # v3
-              with:
-                  template-path: .github/ISSUE_TEMPLATE/bug-report.yml
-              continue-on-error: true
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
-            - name: Parse feature request form
-              id: parse-feature
-              uses: stefanbuck/github-issue-parser@25f1485edffc1fee3ea68eb9f59a72e58720ffc4 # v3
-              with:
-                  template-path: .github/ISSUE_TEMPLATE/feature-request.yml
-              continue-on-error: true
+      - name: Parse bug report form
+        id: parse-bug
+        uses: stefanbuck/github-issue-parser@25f1485edffc1fee3ea68eb9f59a72e58720ffc4 # v3
+        with:
+          template-path: .github/ISSUE_TEMPLATE/bug-report.yml
+        continue-on-error: true
 
-            - name: Apply component label
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-              with:
-                  script: |
-                      // Get component from either bug report or feature request
-                      const bugComponent = '${{ steps.parse-bug.outputs.issueparser_component }}';
-                      const featureComponent = '${{ steps.parse-feature.outputs.issueparser_component }}';
-                      const component = bugComponent || featureComponent;
+      - name: Parse feature request form
+        id: parse-feature
+        uses: stefanbuck/github-issue-parser@25f1485edffc1fee3ea68eb9f59a72e58720ffc4 # v3
+        with:
+          template-path: .github/ISSUE_TEMPLATE/feature-request.yml
+        continue-on-error: true
 
-                      if (!component) {
-                        console.log('No component field found, skipping labeling');
-                        return;
-                      }
+      - name: Apply component label
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            // Get component from either bug report or feature request
+            const bugComponent = '${{ steps.parse-bug.outputs.issueparser_component }}';
+            const featureComponent = '${{ steps.parse-feature.outputs.issueparser_component }}';
+            const component = bugComponent || featureComponent;
 
-                      const labels = [];
+            if (!component) {
+              console.log('No component field found, skipping labeling');
+              return;
+            }
 
-                      if (component === 'CLI') {
-                        labels.push('CLI');
-                      } else if (component === 'ACP') {
-                        labels.push('ACP');
-                      } else if (component === 'Both') {
-                        labels.push('CLI', 'ACP');
-                      }
+            const labels = [];
 
-                      if (labels.length > 0) {
-                        await github.rest.issues.addLabels({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          issue_number: context.issue.number,
-                          labels: labels
-                        });
-                        console.log(`Added labels: ${labels.join(', ')}`);
-                      }
+            if (component === 'CLI') {
+              labels.push('CLI');
+            } else if (component === 'ACP') {
+              labels.push('ACP');
+            } else if (component === 'Both') {
+              labels.push('CLI', 'ACP');
+            }
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labels
+              });
+              console.log(`Added labels: ${labels.join(', ')}`);
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
       contents: read
 
     steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
@@ -53,6 +58,11 @@ jobs:
     environment:
       name: zed
     steps:
+      - name: Harden the runner # Audit all outbound calls
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - uses: huacnlee/zed-extension-action@8cd592a0d24e1e41157740f1a529aeabddc88a1b # v2
         with:
           extension-name: mistral-vibe


### PR DESCRIPTION
This PR adds StepSecurity Harden Runner to CI workflows. 

Harden Runner provides runtime security for GitHub Actions by monitoring outbound network traffic, file access, and process execution, helping to detect supply chain attacks in which compromised dependencies or Actions make unexpected network calls.

It's used by thousands of open-source repositories, including projects under Microsoft, Google, and other major organisations, and has detected multiple real-world supply chain incidents (details).

Here's a snapshot of the network endpoints called from one of my repo as an example:

<img width="1132" height="647" alt="Screenshot 2026-04-01 at 11 29 26" src="https://github.com/user-attachments/assets/67ae4d8c-6062-4b19-90c0-c3bfa084087e" />

This is added in audit mode (egress-policy: audit), so it introduces no breaking changes — it only adds observability into CI behaviour.