### PR TITLE
fix(cli): preserve stdin content when /dev/tty unavailable in headless mode

### DIFF
--- a/vibe/cli/cli.py
+++ b/vibe/cli/cli.py
@@ -39,7 +39,10 @@ def get_prompt_from_stdin() -> str | None:
         return None
     try:
         if content := sys.stdin.read().strip():
-            sys.stdin = sys.__stdin__ = open("/dev/tty")
+            try:
+                sys.stdin = sys.__stdin__ = open("/dev/tty")
+            except OSError:
+                pass  # Headless environment, no TTY available
             return content
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
## Problem

When `vibe -p` is invoked from a subprocess with piped stdin in a headless environment, `get_prompt_from_stdin()` reads the content successfully but then `open('/dev/tty')` raises `OSError`. This is caught by the outer `except OSError` which returns `None`, silently discarding the already-read stdin content.

## Root Cause

The `open('/dev/tty')` call (line 42) is at the same exception-handling level as the stdin read. When it fails in headless environments (no TTY), the outer `except OSError: return None` swallows the content.

## Solution

Wrap the `open('/dev/tty')` call in its own `try/except OSError` so the TTY reopen failure is handled locally. The function still returns the content regardless of TTY availability.

Fixes #573