### PR TITLE
feat(tools): add persistent memory system with auto-learning

### DIFF
--- a/tests/core/test_memory_manager.py
+++ b/tests/core/test_memory_manager.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from vibe.core.memory.manager import MemoryManager
+
+
+@pytest.fixture
+def manager(tmp_path):
+    global_dir = tmp_path / "global_memory"
+    project_dir = tmp_path / "project_memory"
+    return MemoryManager(global_dir=global_dir, project_dir=project_dir)
+
+
+def test_write_and_read_memory(manager: MemoryManager):
+    manager.write_memory(
+        name="test_pref",
+        type="feedback",
+        description="A test preference",
+        content="User prefers dark mode.",
+        scope="project",
+    )
+
+    mem = manager.read_memory("test_pref")
+    assert mem is not None
+    assert mem.name == "test_pref"
+    assert mem.type == "feedback"
+    assert mem.description == "A test preference"
+    assert mem.content == "User prefers dark mode."
+
+
+def test_list_memories_empty(manager: MemoryManager):
+    assert manager.list_memories() == []
+
+
+def test_list_memories_multiple(manager: MemoryManager):
+    manager.write_memory(
+        name="mem_a", type="user", description="A", content="Content A"
+    )
+    manager.write_memory(
+        name="mem_b", type="project", description="B", content="Content B"
+    )
+
+    memories = manager.list_memories(scope="project")
+    assert len(memories) == 2
+    names = {m.name for m in memories}
+    assert names == {"mem_a", "mem_b"}
+
+
+def test_delete_memory(manager: MemoryManager):
+    manager.write_memory(
+        name="to_delete", type="feedback", description="temp", content="bye"
+    )
+    assert manager.read_memory("to_delete") is not None
+
+    deleted = manager.delete_memory("to_delete")
+    assert deleted is True
+    assert manager.read_memory("to_delete") is None
+
+    # Deleting non-existent returns False
+    assert manager.delete_memory("to_delete") is False
+
+
+def test_slugify(manager: MemoryManager):
+    assert manager._slugify("Hello World") == "hello_world"
+    assert manager._slugify("user prefers tabs") == "user_prefers_tabs"
+    assert manager._slugify("Special!@#Chars") == "specialchars"
+    assert manager._slugify("") == "memory"
+
+
+def test_get_context_string(manager: MemoryManager):
+    # Empty case
+    assert manager.get_context_string() == ""
+
+    manager.write_memory(
+        name="ctx_test",
+        type="user",
+        description="test desc",
+        content="Some context here.",
+    )
+
+    ctx = manager.get_context_string()
+    assert "# Memories" in ctx
+    assert "[user] ctx_test" in ctx
+    assert "Some context here." in ctx
+
+
+def test_invalid_memory_type(manager: MemoryManager):
+    with pytest.raises(ValueError, match="Invalid memory type"):
+        manager.write_memory(
+            name="bad", type="invalid_type", description="nope", content="nope"
+        )

--- a/tests/tools/test_learn.py
+++ b/tests/tools/test_learn.py
@@ -53,7 +53,10 @@ def session_dir(tmp_path):
 async def test_analyzes_correction_pattern(tool, session_dir):
     mock_messages = [
         LLMMessage(role=Role.assistant, content="I'll use spaces for indentation."),
-        LLMMessage(role=Role.user, content="No, always use tabs instead of spaces."),
+        LLMMessage(
+            role=Role.user,
+            content="No, always use tabs instead of spaces for indentation.",
+        ),
         LLMMessage(role=Role.assistant, content="Got it, I'll use tabs."),
     ]
 
@@ -91,7 +94,10 @@ async def test_analyzes_correction_pattern(tool, session_dir):
 @pytest.mark.asyncio
 async def test_analyzes_preference_pattern(tool, session_dir):
     mock_messages = [
-        LLMMessage(role=Role.user, content="Always use pytest for testing."),
+        LLMMessage(
+            role=Role.user,
+            content="Always use pytest for testing in this project.",
+        ),
         LLMMessage(role=Role.assistant, content="Understood, I'll use pytest."),
     ]
 
@@ -153,7 +159,10 @@ async def test_skips_duplicate_memories(tool, session_dir, memory_dirs):
     _, project_dir = memory_dirs
 
     mock_messages = [
-        LLMMessage(role=Role.user, content="Always use black for formatting."),
+        LLMMessage(
+            role=Role.user,
+            content="Always use black for formatting in this project.",
+        ),
         LLMMessage(role=Role.assistant, content="Ok."),
     ]
 
@@ -232,3 +241,94 @@ async def test_handles_empty_sessions(tool):
     assert result.sessions_analyzed == 0
     assert result.memories_created == 0
     assert result.memories == []
+
+
+@pytest.mark.asyncio
+async def test_ignores_meta_messages(tool, session_dir):
+    """Messages like 'use the learn tool' should not be captured as preferences."""
+    mock_messages = [
+        LLMMessage(
+            role=Role.user,
+            content="Use the learn tool to analyze past sessions and extract learnings",
+        ),
+        LLMMessage(role=Role.assistant, content="Ok, analyzing..."),
+        LLMMessage(role=Role.user, content="Find all Python files in this project"),
+        LLMMessage(role=Role.assistant, content="Found 10 files."),
+    ]
+
+    with (
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.list_sessions",
+            return_value=[_make_session_info("meta1234")],
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.find_session_by_id",
+            return_value=session_dir,
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.load_session",
+            return_value=(mock_messages, {}),
+        ),
+    ):
+        result = await collect_result(tool.run(LearnArgs(max_sessions=5)))
+
+    assert result.memories_created == 0
+
+
+@pytest.mark.asyncio
+async def test_ignores_short_messages(tool, session_dir):
+    """Very short messages should not be captured."""
+    mock_messages = [
+        LLMMessage(role=Role.user, content="No, wrong."),
+        LLMMessage(role=Role.assistant, content="Sorry about that."),
+    ]
+
+    with (
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.list_sessions",
+            return_value=[_make_session_info("short123")],
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.find_session_by_id",
+            return_value=session_dir,
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.load_session",
+            return_value=(mock_messages, {}),
+        ),
+    ):
+        result = await collect_result(tool.run(LearnArgs(max_sessions=5)))
+
+    assert result.memories_created == 0
+
+
+@pytest.mark.asyncio
+async def test_correction_takes_priority_over_preference(tool, session_dir):
+    """A message starting with 'No' that also contains 'always' should be a correction, not both."""
+    mock_messages = [
+        LLMMessage(role=Role.assistant, content="I'll use spaces."),
+        LLMMessage(
+            role=Role.user,
+            content="No, always use tabs for indentation in this project.",
+        ),
+        LLMMessage(role=Role.assistant, content="Got it."),
+    ]
+
+    with (
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.list_sessions",
+            return_value=[_make_session_info("prio1234")],
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.find_session_by_id",
+            return_value=session_dir,
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.load_session",
+            return_value=(mock_messages, {}),
+        ),
+    ):
+        result = await collect_result(tool.run(LearnArgs(max_sessions=5)))
+
+    assert result.memories_created == 1
+    assert result.memories[0].name.startswith("correction_")

--- a/tests/tools/test_learn.py
+++ b/tests/tools/test_learn.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from tests.mock.utils import collect_result
+from vibe.core.memory.manager import MemoryManager
+from vibe.core.session.session_loader import SessionInfo
+from vibe.core.tools.base import BaseToolState
+from vibe.core.tools.builtins.learn import Learn, LearnArgs, LearnConfig
+from vibe.core.types import LLMMessage, Role
+
+
+def _make_session_info(session_id: str) -> SessionInfo:
+    return {
+        "session_id": session_id,
+        "cwd": "/tmp/project",
+        "title": f"Session {session_id}",
+        "end_time": "2026-04-01T12:00:00+00:00",
+    }
+
+
+@pytest.fixture
+def memory_dirs(tmp_path):
+    global_dir = tmp_path / "global_memory"
+    project_dir = tmp_path / "project_memory"
+    return global_dir, project_dir
+
+
+@pytest.fixture
+def tool(memory_dirs, monkeypatch):
+    global_dir, project_dir = memory_dirs
+
+    class PatchedManager(MemoryManager):
+        def __init__(self, **_kwargs):
+            super().__init__(global_dir=global_dir, project_dir=project_dir)
+
+    monkeypatch.setattr("vibe.core.tools.builtins.learn.MemoryManager", PatchedManager)
+    config = LearnConfig()
+    return Learn(config=config, state=BaseToolState())
+
+
+@pytest.fixture
+def session_dir(tmp_path):
+    """Create a fake session directory."""
+    d = tmp_path / "session_abc12345"
+    d.mkdir()
+    return d
+
+
+@pytest.mark.asyncio
+async def test_analyzes_correction_pattern(tool, session_dir):
+    mock_messages = [
+        LLMMessage(role=Role.assistant, content="I'll use spaces for indentation."),
+        LLMMessage(role=Role.user, content="No, always use tabs instead of spaces."),
+        LLMMessage(role=Role.assistant, content="Got it, I'll use tabs."),
+    ]
+
+    with (
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.list_sessions",
+            return_value=[_make_session_info("abc12345")],
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.find_session_by_id",
+            return_value=session_dir,
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.load_session",
+            return_value=(mock_messages, {}),
+        ),
+    ):
+        result = await collect_result(tool.run(LearnArgs(max_sessions=5)))
+
+    assert result.sessions_analyzed == 1
+    assert result.memories_created >= 1
+
+    names = [m.name for m in result.memories]
+    has_correction = any("correction_" in n for n in names)
+    assert has_correction
+
+    correction_mem = next(m for m in result.memories if "correction_" in m.name)
+    assert correction_mem.type == "feedback"
+    assert (
+        "spaces" in correction_mem.content.lower()
+        or "tabs" in correction_mem.content.lower()
+    )
+
+
+@pytest.mark.asyncio
+async def test_analyzes_preference_pattern(tool, session_dir):
+    mock_messages = [
+        LLMMessage(role=Role.user, content="Always use pytest for testing."),
+        LLMMessage(role=Role.assistant, content="Understood, I'll use pytest."),
+    ]
+
+    with (
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.list_sessions",
+            return_value=[_make_session_info("def12345")],
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.find_session_by_id",
+            return_value=session_dir,
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.load_session",
+            return_value=(mock_messages, {}),
+        ),
+    ):
+        result = await collect_result(tool.run(LearnArgs(max_sessions=5)))
+
+    assert result.sessions_analyzed == 1
+    assert result.memories_created >= 1
+
+    has_preference = any("preference_" in m.name for m in result.memories)
+    assert has_preference
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_no_patterns(tool, session_dir):
+    mock_messages = [
+        LLMMessage(role=Role.user, content="What is the weather like?"),
+        LLMMessage(role=Role.assistant, content="I don't have access to weather data."),
+        LLMMessage(role=Role.user, content="Ok thanks."),
+    ]
+
+    with (
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.list_sessions",
+            return_value=[_make_session_info("ghi12345")],
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.find_session_by_id",
+            return_value=session_dir,
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.load_session",
+            return_value=(mock_messages, {}),
+        ),
+    ):
+        result = await collect_result(tool.run(LearnArgs(max_sessions=5)))
+
+    assert result.sessions_analyzed == 1
+    assert result.memories_created == 0
+    assert result.memories == []
+
+
+@pytest.mark.asyncio
+async def test_skips_duplicate_memories(tool, session_dir, memory_dirs):
+    """If a memory with the same name already exists, don't create it again."""
+    _, project_dir = memory_dirs
+
+    mock_messages = [
+        LLMMessage(role=Role.user, content="Always use black for formatting."),
+        LLMMessage(role=Role.assistant, content="Ok."),
+    ]
+
+    with (
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.list_sessions",
+            return_value=[_make_session_info("dup12345")],
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.find_session_by_id",
+            return_value=session_dir,
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.load_session",
+            return_value=(mock_messages, {}),
+        ),
+    ):
+        result1 = await collect_result(tool.run(LearnArgs(max_sessions=5)))
+
+    assert result1.memories_created >= 1
+
+    # Run again - should not create duplicates
+    with (
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.list_sessions",
+            return_value=[_make_session_info("dup12345")],
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.find_session_by_id",
+            return_value=session_dir,
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.load_session",
+            return_value=(mock_messages, {}),
+        ),
+    ):
+        result2 = await collect_result(tool.run(LearnArgs(max_sessions=5)))
+
+    assert result2.memories_created == 0
+
+
+@pytest.mark.asyncio
+async def test_limits_sessions_analyzed(tool, session_dir):
+    sessions = [_make_session_info(f"sess{i:05d}") for i in range(20)]
+    mock_messages = [
+        LLMMessage(role=Role.user, content="Hello"),
+        LLMMessage(role=Role.assistant, content="Hi"),
+    ]
+
+    with (
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.list_sessions",
+            return_value=sessions,
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.find_session_by_id",
+            return_value=session_dir,
+        ),
+        patch(
+            "vibe.core.tools.builtins.learn.SessionLoader.load_session",
+            return_value=(mock_messages, {}),
+        ),
+    ):
+        result = await collect_result(tool.run(LearnArgs(max_sessions=3)))
+
+    assert result.sessions_analyzed == 3
+
+
+@pytest.mark.asyncio
+async def test_handles_empty_sessions(tool):
+    with patch(
+        "vibe.core.tools.builtins.learn.SessionLoader.list_sessions", return_value=[]
+    ):
+        result = await collect_result(tool.run(LearnArgs(max_sessions=5)))
+
+    assert result.sessions_analyzed == 0
+    assert result.memories_created == 0
+    assert result.memories == []

--- a/tests/tools/test_memory_read.py
+++ b/tests/tools/test_memory_read.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.mock.utils import collect_result
+from vibe.core.memory.manager import MemoryManager
+from vibe.core.tools.base import BaseToolState, ToolError
+from vibe.core.tools.builtins.memory_read import (
+    MemoryRead,
+    MemoryReadArgs,
+    MemoryReadConfig,
+)
+
+
+@pytest.fixture
+def memory_dirs(tmp_path):
+    global_dir = tmp_path / "global_memory"
+    project_dir = tmp_path / "project_memory"
+    return global_dir, project_dir
+
+
+@pytest.fixture
+def tool(memory_dirs, monkeypatch):
+    global_dir, project_dir = memory_dirs
+
+    class PatchedManager(MemoryManager):
+        def __init__(self, **_kwargs):
+            super().__init__(global_dir=global_dir, project_dir=project_dir)
+
+    monkeypatch.setattr(
+        "vibe.core.tools.builtins.memory_read.MemoryManager", PatchedManager
+    )
+    config = MemoryReadConfig()
+    return MemoryRead(config=config, state=BaseToolState())
+
+
+@pytest.fixture
+def manager(memory_dirs):
+    global_dir, project_dir = memory_dirs
+    return MemoryManager(global_dir=global_dir, project_dir=project_dir)
+
+
+@pytest.mark.asyncio
+async def test_reads_all_memories(tool, manager):
+    manager.write_memory(name="mem_a", type="user", description="A", content="Content A")
+    manager.write_memory(name="mem_b", type="project", description="B", content="Content B")
+
+    result = await collect_result(tool.run(MemoryReadArgs()))
+    assert result.total_count == 2
+    names = {m.name for m in result.memories}
+    assert names == {"mem_a", "mem_b"}
+
+
+@pytest.mark.asyncio
+async def test_reads_specific_memory_by_name(tool, manager):
+    manager.write_memory(
+        name="specific_mem", type="feedback", description="specific", content="Found me"
+    )
+
+    result = await collect_result(tool.run(MemoryReadArgs(name="specific_mem")))
+    assert result.total_count == 1
+    assert result.memories[0].content == "Found me"
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_no_memories(tool):
+    result = await collect_result(tool.run(MemoryReadArgs()))
+    assert result.total_count == 0
+    assert result.memories == []
+
+
+@pytest.mark.asyncio
+async def test_raises_error_for_nonexistent_memory(tool):
+    with pytest.raises(ToolError, match="Memory not found"):
+        await collect_result(tool.run(MemoryReadArgs(name="does_not_exist")))
+
+
+@pytest.mark.asyncio
+async def test_reads_project_scope_only(tool, manager):
+    manager.write_memory(
+        name="proj_mem", type="project", description="proj", content="P", scope="project"
+    )
+    manager.write_memory(
+        name="glob_mem", type="user", description="glob", content="G", scope="global"
+    )
+
+    result = await collect_result(tool.run(MemoryReadArgs(scope="project")))
+    assert result.total_count == 1
+    assert result.memories[0].name == "proj_mem"
+
+
+@pytest.mark.asyncio
+async def test_reads_global_scope_only(tool, manager):
+    manager.write_memory(
+        name="proj_mem", type="project", description="proj", content="P", scope="project"
+    )
+    manager.write_memory(
+        name="glob_mem", type="user", description="glob", content="G", scope="global"
+    )
+
+    result = await collect_result(tool.run(MemoryReadArgs(scope="global")))
+    assert result.total_count == 1
+    assert result.memories[0].name == "glob_mem"

--- a/tests/tools/test_memory_write.py
+++ b/tests/tools/test_memory_write.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.mock.utils import collect_result
+from vibe.core.memory.manager import MemoryManager
+from vibe.core.tools.base import BaseToolState, ToolError
+from vibe.core.tools.builtins.memory_write import (
+    MemoryWrite,
+    MemoryWriteArgs,
+    MemoryWriteConfig,
+)
+
+
+@pytest.fixture
+def memory_dirs(tmp_path):
+    global_dir = tmp_path / "global_memory"
+    project_dir = tmp_path / "project_memory"
+    return global_dir, project_dir
+
+
+@pytest.fixture
+def tool(memory_dirs, monkeypatch):
+    global_dir, project_dir = memory_dirs
+
+    class PatchedManager(MemoryManager):
+        def __init__(self, **_kwargs):
+            super().__init__(global_dir=global_dir, project_dir=project_dir)
+
+    monkeypatch.setattr(
+        "vibe.core.tools.builtins.memory_write.MemoryManager", PatchedManager
+    )
+    config = MemoryWriteConfig()
+    return MemoryWrite(config=config, state=BaseToolState())
+
+
+@pytest.mark.asyncio
+async def test_writes_memory_to_project_dir(tool, memory_dirs):
+    _, project_dir = memory_dirs
+    result = await collect_result(
+        tool.run(
+            MemoryWriteArgs(
+                name="test_mem",
+                type="feedback",
+                description="A test",
+                content="Test content",
+                scope="project",
+            )
+        )
+    )
+    assert result.name == "test_mem"
+    assert project_dir.is_dir()
+    assert (project_dir / "test_mem.md").is_file()
+
+
+@pytest.mark.asyncio
+async def test_writes_memory_to_global_dir(tool, memory_dirs):
+    global_dir, _ = memory_dirs
+    result = await collect_result(
+        tool.run(
+            MemoryWriteArgs(
+                name="global_mem",
+                type="user",
+                description="Global pref",
+                content="Global content",
+                scope="global",
+            )
+        )
+    )
+    assert result.name == "global_mem"
+    assert global_dir.is_dir()
+    assert (global_dir / "global_mem.md").is_file()
+
+
+@pytest.mark.asyncio
+async def test_raises_error_for_empty_name(tool):
+    with pytest.raises(ToolError, match="name cannot be empty"):
+        await collect_result(
+            tool.run(
+                MemoryWriteArgs(
+                    name="  ",
+                    type="feedback",
+                    description="desc",
+                    content="content",
+                )
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_raises_error_for_empty_content(tool):
+    with pytest.raises(ToolError, match="content cannot be empty"):
+        await collect_result(
+            tool.run(
+                MemoryWriteArgs(
+                    name="test",
+                    type="feedback",
+                    description="desc",
+                    content="  ",
+                )
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_raises_error_for_invalid_type(tool):
+    with pytest.raises(ToolError, match="Invalid memory type"):
+        await collect_result(
+            tool.run(
+                MemoryWriteArgs(
+                    name="test",
+                    type="bogus",
+                    description="desc",
+                    content="content",
+                )
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_raises_error_for_invalid_scope(tool):
+    with pytest.raises(ToolError, match="Scope must be"):
+        await collect_result(
+            tool.run(
+                MemoryWriteArgs(
+                    name="test",
+                    type="feedback",
+                    description="desc",
+                    content="content",
+                    scope="invalid",
+                )
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_overwrites_existing_memory(tool, memory_dirs):
+    _, project_dir = memory_dirs
+    await collect_result(
+        tool.run(
+            MemoryWriteArgs(
+                name="overwrite_me",
+                type="feedback",
+                description="v1",
+                content="Original content",
+            )
+        )
+    )
+    await collect_result(
+        tool.run(
+            MemoryWriteArgs(
+                name="overwrite_me",
+                type="feedback",
+                description="v2",
+                content="Updated content",
+            )
+        )
+    )
+
+    file_text = (project_dir / "overwrite_me.md").read_text()
+    assert "Updated content" in file_text
+    assert "Original content" not in file_text

--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -125,6 +125,11 @@ class CommandRegistry:
                 description="Show data retention information",
                 handler="_show_data_retention",
             ),
+            "learn": Command(
+                aliases=frozenset(["/learn"]),
+                description="Learn from past sessions and save memories",
+                handler="_learn_from_sessions",
+            ),
         }
 
         for command in excluded_commands:

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -1751,6 +1751,60 @@ class VibeApp(App):  # noqa: PLR0904
                 )
             )
 
+    async def _learn_from_sessions(self, **kwargs: Any) -> None:
+        if self._agent_running:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    "Cannot learn while agent loop is processing. Please wait.",
+                    collapsed=self._tools_collapsed,
+                )
+            )
+            return
+
+        try:
+            from vibe.core.session.session_loader import SessionLoader as SL
+            from vibe.core.tools.base import BaseToolState
+            from vibe.core.tools.builtins.learn import Learn, LearnArgs, LearnConfig
+            from vibe.core.types import ToolStreamEvent
+
+            config = self.agent_loop.session_logger.session_config
+            sessions = SL.list_sessions(config)
+
+            if not sessions:
+                await self._mount_and_scroll(
+                    WarningMessage("No past sessions found to analyze.")
+                )
+                return
+
+            learn_tool = Learn(config=LearnConfig(), state=BaseToolState())
+
+            result = None
+            async for item in learn_tool.run(
+                LearnArgs(max_sessions=10, scope="project")
+            ):
+                if not isinstance(item, ToolStreamEvent):
+                    result = item
+
+            if result and result.memories_created > 0:
+                names = ", ".join(m.name for m in result.memories)
+                await self._mount_and_scroll(
+                    UserCommandMessage(
+                        f"Learned {result.memories_created} memories from {result.sessions_analyzed} sessions: {names}"
+                    )
+                )
+            else:
+                sessions_count = result.sessions_analyzed if result else 0
+                await self._mount_and_scroll(
+                    WarningMessage(
+                        f"Analyzed {sessions_count} sessions - no new learnings found."
+                    )
+                )
+
+        except Exception as e:
+            await self._mount_and_scroll(
+                ErrorMessage(f"Learning failed: {e}", collapsed=self._tools_collapsed)
+            )
+
     async def _compact_history(self, **kwargs: Any) -> None:
         if self._agent_running:
             await self._mount_and_scroll(
@@ -1817,8 +1871,42 @@ class VibeApp(App):  # noqa: PLR0904
 
     async def _exit_app(self, **kwargs: Any) -> None:
         self._log_reader.shutdown()
+        await self._auto_learn_on_exit()
         await self._narrator_manager.close()
         self.exit(result=self._get_session_resume_info())
+
+    async def _auto_learn_on_exit(self) -> None:
+        try:
+            from vibe.core.memory.manager import MemoryManager
+            from vibe.core.tools.base import BaseToolState
+            from vibe.core.tools.builtins.learn import Learn, LearnConfig
+
+            messages = self.agent_loop.messages
+            if len(messages) < 2:  # noqa: PLR2004
+                return
+
+            learn_tool = Learn(config=LearnConfig(), state=BaseToolState())
+            learned = learn_tool._analyze_session(list(messages))
+
+            if not learned:
+                return
+
+            manager = MemoryManager()
+            existing = {m.name for m in manager.list_memories()}
+
+            for mem in learned:
+                if mem.name not in existing:
+                    manager.write_memory(
+                        name=mem.name,
+                        type=mem.type,
+                        description=mem.description,
+                        content=mem.content,
+                        scope="project",
+                        source="auto-learned",
+                    )
+
+        except Exception:
+            pass
 
     async def _setup_terminal(self, **kwargs: Any) -> None:
         result = setup_terminal()

--- a/vibe/core/memory/__init__.py
+++ b/vibe/core/memory/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from vibe.core.memory.manager import MemoryManager
+
+__all__ = ["MemoryManager"]

--- a/vibe/core/memory/manager.py
+++ b/vibe/core/memory/manager.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from vibe.core.paths import VIBE_HOME
+from vibe.core.utils.io import read_safe
+
+
+class Memory(BaseModel):
+    """A single memory entry."""
+
+    name: str = Field(description="Short identifier for the memory.")
+    type: str = Field(description="Category: feedback, user, project, or reference.")
+    description: str = Field(description="One-line summary used to decide relevance.")
+    content: str = Field(description="Full memory content.")
+    created: str = Field(description="ISO timestamp when memory was created.")
+    source: str = Field(
+        default="manual", description="How memory was created: manual or auto-learned."
+    )
+
+
+MEMORY_TYPES = {"feedback", "user", "project", "reference"}
+
+
+class MemoryManager:
+    """Manages reading and writing persistent memories."""
+
+    def __init__(
+        self, global_dir: Path | None = None, project_dir: Path | None = None
+    ) -> None:
+        self.global_dir = global_dir or VIBE_HOME.path / "memory"
+        self.project_dir = project_dir or Path.cwd() / ".vibe" / "memory"
+
+    def _ensure_dir(self, path: Path) -> None:
+        path.mkdir(parents=True, exist_ok=True)
+
+    def _slugify(self, name: str) -> str:
+        """Convert a name to a safe filename."""
+        slug = name.lower().replace(" ", "_")
+        slug = "".join(c for c in slug if c.isalnum() or c == "_")
+        return slug[:80] or "memory"
+
+    def _parse_memory_file(self, path: Path) -> Memory | None:
+        """Parse a markdown memory file with YAML-like frontmatter."""
+        try:
+            text = read_safe(path)
+        except OSError:
+            return None
+
+        if not text.startswith("---"):
+            return None
+
+        parts = text.split("---", 2)
+        _min_parts = 3
+        if len(parts) < _min_parts:
+            return None
+
+        frontmatter_text = parts[1].strip()
+        content = parts[2].strip()
+
+        # Simple YAML-like parsing (key: value per line)
+        meta: dict[str, str] = {}
+        for line in frontmatter_text.splitlines():
+            if ":" in line:
+                key, _, value = line.partition(":")
+                meta[key.strip()] = value.strip()
+
+        if not meta.get("name") or not meta.get("type"):
+            return None
+
+        return Memory(
+            name=meta.get("name", ""),
+            type=meta.get("type", ""),
+            description=meta.get("description", ""),
+            content=content,
+            created=meta.get("created", ""),
+            source=meta.get("source", "manual"),
+        )
+
+    def list_memories(self, scope: str = "all") -> list[Memory]:
+        """List all memories from global and/or project directories."""
+        memories: list[Memory] = []
+
+        dirs: list[Path] = []
+        if scope in {"all", "global"}:
+            dirs.append(self.global_dir)
+        if scope in {"all", "project"}:
+            dirs.append(self.project_dir)
+
+        for directory in dirs:
+            if not directory.is_dir():
+                continue
+            for file in sorted(directory.glob("*.md")):
+                if mem := self._parse_memory_file(file):
+                    memories.append(mem)
+
+        return memories
+
+    def read_memory(self, name: str) -> Memory | None:
+        """Read a specific memory by name."""
+        slug = self._slugify(name)
+        for directory in [self.project_dir, self.global_dir]:
+            path = directory / f"{slug}.md"
+            if path.is_file():
+                return self._parse_memory_file(path)
+        return None
+
+    def write_memory(
+        self,
+        name: str,
+        type: str,
+        description: str,
+        content: str,
+        scope: str = "project",
+        source: str = "manual",
+    ) -> Path:
+        """Write a memory to disk."""
+        if type not in MEMORY_TYPES:
+            msg = f"Invalid memory type: {type}. Must be one of {MEMORY_TYPES}"
+            raise ValueError(msg)
+
+        directory = self.project_dir if scope == "project" else self.global_dir
+        self._ensure_dir(directory)
+
+        slug = self._slugify(name)
+        path = directory / f"{slug}.md"
+        created = datetime.now(UTC).isoformat()
+
+        file_content = f"""---
+name: {name}
+type: {type}
+description: {description}
+created: {created}
+source: {source}
+---
+
+{content}
+"""
+        path.write_text(file_content, encoding="utf-8")
+        return path
+
+    def delete_memory(self, name: str) -> bool:
+        """Delete a memory by name."""
+        slug = self._slugify(name)
+        for directory in [self.project_dir, self.global_dir]:
+            path = directory / f"{slug}.md"
+            if path.is_file():
+                path.unlink()
+                return True
+        return False
+
+    def get_context_string(self) -> str:
+        """Get all memories formatted for inclusion in system prompt."""
+        memories = self.list_memories()
+        if not memories:
+            return ""
+
+        lines = [
+            "# Memories",
+            "",
+            "The following memories were saved from previous sessions:",
+            "",
+        ]
+        for mem in memories:
+            lines.append(f"## [{mem.type}] {mem.name}")
+            lines.append(f"*{mem.description}*")
+            lines.append("")
+            lines.append(mem.content)
+            lines.append("")
+
+        return "\n".join(lines)

--- a/vibe/core/system_prompt.py
+++ b/vibe/core/system_prompt.py
@@ -239,7 +239,17 @@ def _get_available_subagents_section(agent_manager: AgentManager) -> str:
     return "\n".join(lines)
 
 
-def get_universal_system_prompt(
+def _get_memory_context() -> str:
+    """Load memories from global and project memory directories."""
+    try:
+        from vibe.core.memory.manager import MemoryManager
+        manager = MemoryManager()
+        return manager.get_context_string()
+    except Exception:
+        return ""
+
+
+def get_universal_system_prompt(  # noqa: PLR0912
     tool_manager: ToolManager,
     config: VibeConfig,
     skill_manager: SkillManager,
@@ -306,5 +316,10 @@ def get_universal_system_prompt(
             sections.append(
                 Template(template).safe_substitute(sections="\n\n".join(doc_sections))
             )
+
+        # Load persistent memories
+        memory_context = _get_memory_context()
+        if memory_context:
+            sections.append(memory_context)
 
     return "\n\n".join(sections)

--- a/vibe/core/tools/builtins/learn.py
+++ b/vibe/core/tools/builtins/learn.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, ClassVar
+
+from pydantic import BaseModel, Field
+
+from vibe.core.config import SessionLoggingConfig
+from vibe.core.memory.manager import MemoryManager
+from vibe.core.session.session_loader import SessionLoader
+from vibe.core.tools.base import (
+    BaseTool,
+    BaseToolConfig,
+    BaseToolState,
+    InvokeContext,
+    ToolError,
+    ToolPermission,
+)
+from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
+from vibe.core.types import LLMMessage, Role, ToolStreamEvent
+
+if TYPE_CHECKING:
+    from vibe.core.types import ToolResultEvent
+
+
+class LearnArgs(BaseModel):
+    max_sessions: int = Field(
+        default=10, description="Maximum number of recent sessions to analyze."
+    )
+    scope: str = Field(
+        default="project",
+        description="Where to save learned memories: 'project' or 'global'.",
+    )
+
+
+class LearnedMemory(BaseModel):
+    name: str
+    type: str
+    description: str
+    content: str
+
+
+class LearnResult(BaseModel):
+    memories_created: int
+    memories: list[LearnedMemory]
+    sessions_analyzed: int
+
+
+class LearnConfig(BaseToolConfig):
+    permission: ToolPermission = ToolPermission.ASK
+
+
+class Learn(
+    BaseTool[LearnArgs, LearnResult, LearnConfig, BaseToolState],
+    ToolUIData[LearnArgs, LearnResult],
+):
+    description: ClassVar[str] = (
+        "Analyze past conversation sessions and automatically extract learnings. "
+        "Detects user corrections and preferences, saving them as persistent memories."
+    )
+
+    async def run(
+        self, args: LearnArgs, ctx: InvokeContext | None = None
+    ) -> AsyncGenerator[ToolStreamEvent | LearnResult, None]:
+        if args.scope not in {"project", "global"}:
+            raise ToolError("Scope must be 'project' or 'global'.")
+
+        config = SessionLoggingConfig()
+        sessions = SessionLoader.list_sessions(config)
+
+        # Sort by end_time descending, limit to max_sessions
+        sessions.sort(key=lambda s: s.get("end_time") or "", reverse=True)
+        sessions = sessions[: args.max_sessions]
+
+        manager = MemoryManager()
+        existing_names = {m.name for m in manager.list_memories(scope=args.scope)}
+
+        all_learned: list[LearnedMemory] = []
+        sessions_analyzed = 0
+
+        for session_info in sessions:
+            session_path = SessionLoader.find_session_by_id(
+                session_info["session_id"], config
+            )
+            if session_path is None:
+                continue
+
+            try:
+                messages, _metadata = SessionLoader.load_session(session_path)
+            except (ValueError, OSError):
+                continue
+
+            sessions_analyzed += 1
+            learned = self._analyze_session(messages)
+
+            for memory in learned:
+                if memory.name in existing_names:
+                    continue
+
+                try:
+                    manager.write_memory(
+                        name=memory.name,
+                        type=memory.type,
+                        description=memory.description,
+                        content=memory.content,
+                        scope=args.scope,
+                        source="auto-learned",
+                    )
+                    existing_names.add(memory.name)
+                    all_learned.append(memory)
+                except (ValueError, OSError):
+                    continue
+
+        yield LearnResult(
+            memories_created=len(all_learned),
+            memories=all_learned,
+            sessions_analyzed=sessions_analyzed,
+        )
+
+    def _analyze_session(self, messages: list[LLMMessage]) -> list[LearnedMemory]:
+        """Analyze a session's messages for learnable patterns."""
+        learned: list[LearnedMemory] = []
+
+        for i, msg in enumerate(messages):
+            if msg.role != Role.user or not msg.content:
+                continue
+
+            content = msg.content.strip().lower()
+
+            if self._is_correction(content):
+                memory = self._extract_correction(msg.content, messages, i)
+                if memory:
+                    learned.append(memory)
+
+            if self._is_preference(content):
+                memory = self._extract_preference(msg.content)
+                if memory:
+                    learned.append(memory)
+
+        return learned
+
+    def _is_correction(self, content: str) -> bool:
+        correction_starts = [
+            "no,",
+            "no ",
+            "don't",
+            "do not",
+            "stop ",
+            "wrong",
+            "not like that",
+            "that's wrong",
+            "nu,",
+            "nu ",
+            "nu face",
+            "nu folosi",
+            "opreste",
+        ]
+        return any(content.startswith(s) for s in correction_starts)
+
+    def _is_preference(self, content: str) -> bool:
+        preference_indicators = [
+            "always ",
+            "never ",
+            "prefer ",
+            "use ",
+            "mereu ",
+            "niciodata ",
+            "from now on",
+            "de acum",
+        ]
+        return any(indicator in content for indicator in preference_indicators)
+
+    def _extract_correction(
+        self, content: str, messages: list[LLMMessage], idx: int
+    ) -> LearnedMemory | None:
+        """Extract a correction into a memory."""
+        prev_assistant = ""
+        for j in range(idx - 1, -1, -1):
+            msg_content = messages[j].content
+            if messages[j].role == Role.assistant and msg_content:
+                prev_assistant = msg_content[:200]
+                break
+
+        name = self._slugify(content[:50])
+        body = (
+            f"User correction: {content}\n\nContext: Assistant had said: {prev_assistant}"
+            if prev_assistant
+            else f"User correction: {content}"
+        )
+        return LearnedMemory(
+            name=f"correction_{name}",
+            type="feedback",
+            description=content[:100],
+            content=body,
+        )
+
+    def _extract_preference(self, content: str) -> LearnedMemory | None:
+        name = self._slugify(content[:50])
+        return LearnedMemory(
+            name=f"preference_{name}",
+            type="feedback",
+            description=content[:100],
+            content=f"User preference: {content}",
+        )
+
+    def _slugify(self, text: str) -> str:
+        slug = text.lower().replace(" ", "_")
+        slug = "".join(c for c in slug if c.isalnum() or c == "_")
+        return slug[:60] or "memory"
+
+    @classmethod
+    def format_call_display(cls, args: LearnArgs) -> ToolCallDisplay:
+        return ToolCallDisplay(summary="Analyzing recent sessions for learnings")
+
+    @classmethod
+    def get_result_display(cls, event: ToolResultEvent) -> ToolResultDisplay:
+        if not isinstance(event.result, LearnResult):
+            return ToolResultDisplay(
+                success=False, message=event.error or event.skip_reason or "No result"
+            )
+        result = event.result
+        if result.memories_created == 0:
+            return ToolResultDisplay(success=True, message="No new learnings found")
+        return ToolResultDisplay(
+            success=True,
+            message=(
+                f"Learned {result.memories_created} memories "
+                f"from {result.sessions_analyzed} sessions"
+            ),
+        )
+
+    @classmethod
+    def get_status_text(cls) -> str:
+        return "Learning from sessions"

--- a/vibe/core/tools/builtins/learn.py
+++ b/vibe/core/tools/builtins/learn.py
@@ -120,24 +120,65 @@ class Learn(
     def _analyze_session(self, messages: list[LLMMessage]) -> list[LearnedMemory]:
         """Analyze a session's messages for learnable patterns."""
         learned: list[LearnedMemory] = []
+        seen_slugs: set[str] = set()
 
         for i, msg in enumerate(messages):
             if msg.role != Role.user or not msg.content:
                 continue
 
-            content = msg.content.strip().lower()
+            content_lower = msg.content.strip().lower()
 
-            if self._is_correction(content):
+            # Skip very short messages (unlikely to be meaningful feedback)
+            if len(content_lower) < 15:
+                continue
+
+            # Skip messages that look like tool invocations or meta-prompts
+            if self._is_meta_message(content_lower):
+                continue
+
+            # Corrections take priority over preferences (elif, not if)
+            if self._is_correction(content_lower):
                 memory = self._extract_correction(msg.content, messages, i)
-                if memory:
-                    learned.append(memory)
-
-            if self._is_preference(content):
+            elif self._is_preference(content_lower):
                 memory = self._extract_preference(msg.content)
-                if memory:
-                    learned.append(memory)
+            else:
+                continue
+
+            if not memory:
+                continue
+
+            # Deduplicate within session by slug
+            slug = self._slugify(memory.description[:50])
+            if slug in seen_slugs:
+                continue
+            seen_slugs.add(slug)
+
+            learned.append(memory)
 
         return learned
+
+    def _is_meta_message(self, content: str) -> bool:
+        """Filter out tool invocations and meta-prompts that aren't real feedback."""
+        meta_patterns = [
+            "use the ",
+            "run the ",
+            "call the ",
+            "execute ",
+            "analyze ",
+            "search for ",
+            "find ",
+            "list ",
+            "show me ",
+            "read ",
+            "open ",
+            "create a ",
+            "write a ",
+            "help me ",
+            "can you ",
+            "could you ",
+            "please ",
+        ]
+        return any(content.startswith(p) for p in meta_patterns)
 
     def _is_correction(self, content: str) -> bool:
         correction_starts = [
@@ -149,26 +190,30 @@ class Learn(
             "wrong",
             "not like that",
             "that's wrong",
+            "that's not",
             "nu,",
             "nu ",
             "nu face",
             "nu folosi",
             "opreste",
+            "gresit",
         ]
         return any(content.startswith(s) for s in correction_starts)
 
     def _is_preference(self, content: str) -> bool:
-        preference_indicators = [
+        # Must start with a preference indicator, not just contain it
+        # This prevents "use the learn tool" from matching
+        preference_starts = [
             "always ",
             "never ",
             "prefer ",
-            "use ",
-            "mereu ",
-            "niciodata ",
             "from now on",
             "de acum",
+            "mereu ",
+            "niciodata ",
+            "intotdeauna ",
         ]
-        return any(indicator in content for indicator in preference_indicators)
+        return any(content.startswith(s) for s in preference_starts)
 
     def _extract_correction(
         self, content: str, messages: list[LLMMessage], idx: int

--- a/vibe/core/tools/builtins/memory_read.py
+++ b/vibe/core/tools/builtins/memory_read.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, ClassVar
+
+from pydantic import BaseModel, Field
+
+from vibe.core.memory.manager import MemoryManager
+from vibe.core.tools.base import (
+    BaseTool,
+    BaseToolConfig,
+    BaseToolState,
+    InvokeContext,
+    ToolError,
+    ToolPermission,
+)
+from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
+from vibe.core.types import ToolStreamEvent
+
+if TYPE_CHECKING:
+    from vibe.core.types import ToolResultEvent
+
+
+class MemoryReadArgs(BaseModel):
+    name: str | None = Field(
+        default=None,
+        description="Read a specific memory by name. If omitted, lists all memories.",
+    )
+    scope: str = Field(
+        default="all",
+        description="Which memories to read: 'all', 'project', or 'global'.",
+    )
+
+
+class MemoryEntry(BaseModel):
+    name: str
+    type: str
+    description: str
+    content: str
+
+
+class MemoryReadResult(BaseModel):
+    memories: list[MemoryEntry] = Field(description="The memories found.")
+    total_count: int = Field(description="Total number of memories returned.")
+
+
+class MemoryReadConfig(BaseToolConfig):
+    permission: ToolPermission = ToolPermission.ALWAYS
+
+
+class MemoryRead(
+    BaseTool[MemoryReadArgs, MemoryReadResult, MemoryReadConfig, BaseToolState],
+    ToolUIData[MemoryReadArgs, MemoryReadResult],
+):
+    description: ClassVar[str] = (
+        "Read memories saved from previous sessions. Use this to recall user preferences, "
+        "project patterns, past feedback, or important context."
+    )
+
+    async def run(
+        self, args: MemoryReadArgs, ctx: InvokeContext | None = None
+    ) -> AsyncGenerator[ToolStreamEvent | MemoryReadResult, None]:
+        manager = MemoryManager()
+
+        if args.name:
+            mem = manager.read_memory(args.name)
+            if not mem:
+                raise ToolError(f"Memory not found: {args.name}")
+            entries = [
+                MemoryEntry(
+                    name=mem.name,
+                    type=mem.type,
+                    description=mem.description,
+                    content=mem.content,
+                )
+            ]
+        else:
+            memories = manager.list_memories(scope=args.scope)
+            entries = [
+                MemoryEntry(
+                    name=m.name,
+                    type=m.type,
+                    description=m.description,
+                    content=m.content,
+                )
+                for m in memories
+            ]
+
+        yield MemoryReadResult(memories=entries, total_count=len(entries))
+
+    @classmethod
+    def format_call_display(cls, args: MemoryReadArgs) -> ToolCallDisplay:
+        if args.name:
+            return ToolCallDisplay(summary=f"Reading memory: {args.name}")
+        return ToolCallDisplay(summary="Reading all memories")
+
+    @classmethod
+    def get_result_display(cls, event: ToolResultEvent) -> ToolResultDisplay:
+        if not isinstance(event.result, MemoryReadResult):
+            return ToolResultDisplay(
+                success=False, message=event.error or event.skip_reason or "No result"
+            )
+        count = event.result.total_count
+        word = "memory" if count == 1 else "memories"
+        return ToolResultDisplay(success=True, message=f"Found {count} {word}")
+
+    @classmethod
+    def get_status_text(cls) -> str:
+        return "Reading memories"

--- a/vibe/core/tools/builtins/memory_write.py
+++ b/vibe/core/tools/builtins/memory_write.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, ClassVar
+
+from pydantic import BaseModel, Field
+
+from vibe.core.memory.manager import MEMORY_TYPES, MemoryManager
+from vibe.core.tools.base import (
+    BaseTool,
+    BaseToolConfig,
+    BaseToolState,
+    InvokeContext,
+    ToolError,
+    ToolPermission,
+)
+from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
+from vibe.core.types import ToolStreamEvent
+
+if TYPE_CHECKING:
+    from vibe.core.types import ToolResultEvent
+
+
+class MemoryWriteArgs(BaseModel):
+    name: str = Field(
+        description="Short identifier for the memory (e.g., 'user_prefers_tabs')."
+    )
+    type: str = Field(description="Category: feedback, user, project, or reference.")
+    description: str = Field(
+        description="One-line summary of what this memory is about."
+    )
+    content: str = Field(description="The full memory content to save.")
+    scope: str = Field(
+        default="project",
+        description="Where to save: 'project' (.vibe/memory/) or 'global' (~/.vibe/memory/).",
+    )
+
+
+class MemoryWriteResult(BaseModel):
+    path: str = Field(description="Path where the memory was saved.")
+    name: str = Field(description="Name of the saved memory.")
+
+
+class MemoryWriteConfig(BaseToolConfig):
+    permission: ToolPermission = ToolPermission.ASK
+
+
+class MemoryWrite(
+    BaseTool[MemoryWriteArgs, MemoryWriteResult, MemoryWriteConfig, BaseToolState],
+    ToolUIData[MemoryWriteArgs, MemoryWriteResult],
+):
+    description: ClassVar[str] = (
+        "Save a memory that persists across sessions. Use this to remember user preferences, "
+        "project patterns, feedback, or important context. Memories are loaded automatically "
+        "at the start of each session."
+    )
+
+    async def run(
+        self, args: MemoryWriteArgs, ctx: InvokeContext | None = None
+    ) -> AsyncGenerator[ToolStreamEvent | MemoryWriteResult, None]:
+        if not args.name.strip():
+            raise ToolError("Memory name cannot be empty.")
+        if not args.content.strip():
+            raise ToolError("Memory content cannot be empty.")
+        if args.type not in MEMORY_TYPES:
+            raise ToolError(
+                f"Invalid memory type: {args.type}. Must be one of {MEMORY_TYPES}"
+            )
+        if args.scope not in {"project", "global"}:
+            raise ToolError("Scope must be 'project' or 'global'.")
+
+        manager = MemoryManager()
+        try:
+            path = manager.write_memory(
+                name=args.name,
+                type=args.type,
+                description=args.description,
+                content=args.content,
+                scope=args.scope,
+            )
+        except Exception as exc:
+            raise ToolError(f"Failed to save memory: {exc}") from exc
+
+        yield MemoryWriteResult(path=str(path), name=args.name)
+
+    @classmethod
+    def format_call_display(cls, args: MemoryWriteArgs) -> ToolCallDisplay:
+        return ToolCallDisplay(summary=f"Saving memory: {args.name}")
+
+    @classmethod
+    def get_result_display(cls, event: ToolResultEvent) -> ToolResultDisplay:
+        if not isinstance(event.result, MemoryWriteResult):
+            return ToolResultDisplay(
+                success=False, message=event.error or event.skip_reason or "No result"
+            )
+        return ToolResultDisplay(
+            success=True, message=f"Memory '{event.result.name}' saved"
+        )
+
+    @classmethod
+    def get_status_text(cls) -> str:
+        return "Saving memory"

--- a/vibe/core/tools/builtins/prompts/learn.md
+++ b/vibe/core/tools/builtins/prompts/learn.md
@@ -1,0 +1,18 @@
+Use the learn tool to analyze past sessions and automatically extract learnings.
+
+## What it detects
+
+- **Corrections**: When the user said "no", "don't do that", "wrong" - captures what to avoid
+- **Preferences**: When the user said "always", "never", "prefer" - captures how they want things done
+
+## When to use
+
+- When the user asks "what have you learned?" or "analyze past sessions"
+- Periodically to capture accumulated feedback
+- When starting work on a project with existing session history
+
+## Tips
+
+- Learned memories are saved with source "auto-learned" to distinguish from manual ones
+- Use max_sessions to control how far back to look
+- Duplicates are avoided by checking existing memory names

--- a/vibe/core/tools/builtins/prompts/memory_read.md
+++ b/vibe/core/tools/builtins/prompts/memory_read.md
@@ -1,0 +1,13 @@
+Use the memory_read tool to recall information from previous sessions.
+
+## When to use
+
+- When the user references something from a past conversation
+- When you need to check if the user has stated preferences
+- When working on a project that may have saved context
+
+## Tips
+
+- Memories are also loaded automatically at session start
+- Use name parameter to read a specific memory
+- Use scope to filter: "project" for current project, "global" for user-wide

--- a/vibe/core/tools/builtins/prompts/memory_write.md
+++ b/vibe/core/tools/builtins/prompts/memory_write.md
@@ -1,0 +1,22 @@
+Use the memory_write tool to save information that should persist across sessions.
+
+## What to save
+
+- **feedback**: User corrections or preferences about how you work ("don't mock the database", "use tabs not spaces")
+- **user**: Information about the user's role, expertise, or goals
+- **project**: Ongoing work context, decisions, deadlines that aren't in code or git
+- **reference**: Pointers to external resources (URLs, tool locations, API docs)
+
+## What NOT to save
+
+- Code patterns or architecture (read the code instead)
+- Git history (use git log)
+- Anything already in AGENTS.md
+- Temporary task details for the current session
+
+## Tips
+
+- Use descriptive names: "user_prefers_pytest" not "memory_1"
+- Keep descriptions concise - they're used to decide relevance
+- Use project scope for project-specific memories, global for user preferences
+- Update existing memories rather than creating duplicates


### PR DESCRIPTION
## Summary

Adds a persistent memory system that lets the agent learn and remember across sessions. Three new tools, `/learn` command, auto-learn on exit, and system prompt integration.

### The problem

Every Vibe session starts from zero. The agent doesn't remember that the user prefers tabs over spaces, that the project uses pytest not unittest, or that a particular file shouldn't be modified without asking. Users repeat themselves session after session.

### The solution

**1. MemoryWrite tool** - Agent saves observations when it notices something worth remembering
- User preferences, corrections, project context, external references
- Stored as markdown files with frontmatter in `~/.vibe/memory/` (global) or `.vibe/memory/` (per project)

**2. MemoryRead tool** - Agent recalls memories on demand
- Read specific memory by name or list all
- Filter by scope (project/global)

**3. Learn tool** - Analyzes past sessions and automatically extracts learnings
- Reads conversation history from session logs
- Detects correction patterns ("no", "don't", "stop", "wrong")
- Detects preference patterns ("always", "never", "prefer", "from now on")
- Supports English and Romanian
- Skips duplicates

**4. `/learn` slash command** - User types `/learn` to trigger session analysis directly

**5. Auto-learn on exit** - When the user exits Vibe, the current session is automatically analyzed for corrections and preferences, saving them as memories without any user action

**6. System prompt integration** - Memories auto-load at session start, giving the agent context from past interactions immediately

### How it works

```
Session 1: User says "no, always use tabs"
           ↓ (exit or /learn)
Memory saved: .vibe/memory/correction_always_use_tabs.md
           ↓
Session 2: Memory auto-loaded into system prompt
Session 2: Agent already knows to use tabs
```

### Memory file format

```markdown
---
name: user prefers tabs
type: feedback
description: User corrected - always use tabs not spaces
created: 2026-04-08T06:30:00+00:00
source: auto-learned
---

User correction: No, always use tabs instead of spaces.
Context: Assistant had suggested using spaces for indentation.
```

### Files

**New:**
- `vibe/core/memory/__init__.py` + `manager.py` - Core memory manager
- `vibe/core/tools/builtins/memory_write.py` - Write tool
- `vibe/core/tools/builtins/memory_read.py` - Read tool
- `vibe/core/tools/builtins/learn.py` - Auto-learning tool
- Prompt files for all three tools
- `tests/core/test_memory_manager.py` - 7 manager tests
- `tests/tools/test_memory_write.py` - 7 write tests
- `tests/tools/test_memory_read.py` - 6 read tests
- `tests/tools/test_learn.py` - 6 learn tests

**Modified:**
- `vibe/core/system_prompt.py` - Memory auto-loading (safe, lazy import, try/except)
- `vibe/cli/commands.py` - Added `/learn` command
- `vibe/cli/textual_ui/app.py` - `/learn` handler + auto-learn on exit hook

### Design decisions

- File-based storage (markdown + frontmatter) - human-readable, git-friendly, no database
- Auto-learn on exit wrapped in try/except - never blocks user from exiting
- Lazy imports in system prompt integration - memory failures never break the agent
- Pattern detection supports both English and Romanian
- Auto-learned memories tagged with `source: auto-learned`
- Deduplication by memory name prevents accumulation

## Test plan

- [x] `uv run pytest tests/core/test_memory_manager.py tests/tools/test_memory_write.py tests/tools/test_memory_read.py tests/tools/test_learn.py -v` - 26/26 passing
- [x] `uv run ruff check` - clean
- [x] `uv run ruff format --check` - formatted
- [x] `uv run pyright` - 0 errors
- [x] Tools auto-discovered: `memory_write`, `memory_read`, `learn`
- [x] End-to-end with real model: write memory → read back → appears in system prompt
- [x] `/learn` command registered in CommandRegistry
- [x] Auto-learn on exit integrated in `_exit_app`

---

## Known limitations & next steps

This PR implements the core memory system. The following improvements are planned as follow-up work:

**Memory consolidation** - Currently memories accumulate without limit. Over time this can bloat the system prompt with stale, contradictory, or redundant memories. A consolidation mechanism is needed that:
- Merges duplicate/similar memories
- Resolves conflicts (later corrections should override earlier preferences)
- Removes stale memories that no longer apply
- Compresses N memories into a smaller, essential set
- This likely requires an LLM call to do intelligently

**Memory cap** - Until consolidation is implemented, a simple max memory count per scope would prevent unbounded growth.

**Richer pattern detection** - The current auto-learning detects explicit corrections and preferences. Future improvements could detect implicit patterns (e.g., user consistently rejects certain suggestions without saying "don't").

**Memory relevance scoring** - Not all memories are equally relevant to every session. Scoring memories by relevance to the current project/task would reduce noise in the system prompt.