### PR TITLE
feat(tools): add background bash execution + bash_output tool

### DIFF
--- a/tests/tools/test_bash_background.py
+++ b/tests/tools/test_bash_background.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from tests.mock.utils import collect_result
+from vibe.core.tools.base import BaseToolState, InvokeContext, ToolError
+from vibe.core.tools.builtins.bash import Bash, BashArgs, BashToolConfig
+from vibe.core.tools.builtins.bash_output import (
+    BashOutput,
+    BashOutputArgs,
+    BashOutputToolConfig,
+)
+
+
+@pytest.fixture
+def session_dir(tmp_path: Path) -> Path:
+    session = tmp_path / "session"
+    session.mkdir()
+    return session
+
+
+@pytest.fixture
+def ctx(session_dir: Path) -> InvokeContext:
+    return InvokeContext(tool_call_id="test", session_dir=session_dir)
+
+
+@pytest_asyncio.fixture
+async def bash_tool(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = BashToolConfig()
+    tool = Bash(config_getter=lambda: config, state=BaseToolState())
+    try:
+        yield tool
+    finally:
+        # Kill any background processes the test left behind so the
+        # asyncio loop can shut down cleanly.
+        await tool.on_reset()
+
+
+@pytest.fixture
+def bash_output_tool():
+    config = BashOutputToolConfig()
+    return BashOutput(config_getter=lambda: config, state=BaseToolState())
+
+
+async def _wait_for_status(
+    output_tool: BashOutput,
+    ctx: InvokeContext,
+    bash_id: str,
+    target: str,
+    timeout: float = 5.0,
+) -> None:
+    """Poll bash_output until it reports the desired status or the timeout
+    elapses.  Keeps tests deterministic without sleeping blindly.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        result = await collect_result(
+            output_tool.run(BashOutputArgs(bash_id=bash_id), ctx=ctx)
+        )
+        if result.status == target:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(
+        f"bash {bash_id} did not reach status {target!r} within {timeout}s"
+    )
+
+
+@pytest.mark.asyncio
+async def test_background_returns_immediately_with_id(bash_tool, ctx):
+    result = await collect_result(
+        bash_tool.run(
+            BashArgs(command="sleep 0.2 && echo done", run_in_background=True), ctx=ctx
+        )
+    )
+
+    assert result.background is True
+    assert result.bash_id is not None
+    assert result.stdout == ""
+    assert result.stderr == ""
+    assert result.returncode == 0
+
+    # Metadata and output files should exist under the session directory
+    bg_dir = ctx.session_dir / "bash_processes"
+    assert (bg_dir / f"{result.bash_id}.json").exists()
+    assert (bg_dir / f"{result.bash_id}.stdout").exists()
+    assert (bg_dir / f"{result.bash_id}.stderr").exists()
+
+
+@pytest.mark.asyncio
+async def test_background_metadata_reflects_running_then_exited(
+    bash_tool, bash_output_tool, ctx
+):
+    result = await collect_result(
+        bash_tool.run(
+            BashArgs(command="sleep 0.2 && echo hello", run_in_background=True), ctx=ctx
+        )
+    )
+    bash_id = result.bash_id
+    assert bash_id is not None
+
+    # Initially running
+    initial = await collect_result(
+        bash_output_tool.run(BashOutputArgs(bash_id=bash_id), ctx=ctx)
+    )
+    assert initial.status in ("running", "exited")
+
+    # Eventually exited with the expected output
+    await _wait_for_status(bash_output_tool, ctx, bash_id, "exited")
+    final = await collect_result(
+        bash_output_tool.run(BashOutputArgs(bash_id=bash_id), ctx=ctx)
+    )
+    assert final.status == "exited"
+    assert final.returncode == 0
+    assert "hello" in final.stdout
+
+
+@pytest.mark.asyncio
+async def test_background_captures_stderr(bash_tool, bash_output_tool, ctx):
+    result = await collect_result(
+        bash_tool.run(
+            BashArgs(command="sh -c 'echo oops >&2; exit 3'", run_in_background=True),
+            ctx=ctx,
+        )
+    )
+    bash_id = result.bash_id
+    assert bash_id is not None
+
+    await _wait_for_status(bash_output_tool, ctx, bash_id, "exited")
+    final = await collect_result(
+        bash_output_tool.run(BashOutputArgs(bash_id=bash_id), ctx=ctx)
+    )
+    assert final.status == "exited"
+    assert final.returncode == 3
+    assert "oops" in final.stderr
+    assert final.stdout == ""
+
+
+@pytest.mark.asyncio
+async def test_background_requires_session(bash_tool):
+    with pytest.raises(ToolError) as err:
+        await collect_result(
+            bash_tool.run(BashArgs(command="echo hi", run_in_background=True), ctx=None)
+        )
+    assert "session directory" in str(err.value)
+
+
+@pytest.mark.asyncio
+async def test_on_reset_terminates_background_process(bash_tool, bash_output_tool, ctx):
+    result = await collect_result(
+        bash_tool.run(BashArgs(command="sleep 30", run_in_background=True), ctx=ctx)
+    )
+    bash_id = result.bash_id
+    assert bash_id is not None
+    assert bash_id in bash_tool._background_processes
+
+    await bash_tool.on_reset()
+
+    assert bash_id not in bash_tool._background_processes
+
+    # Metadata should reflect the terminated state
+    metadata_path = ctx.session_dir / "bash_processes" / f"{bash_id}.json"
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["status"] == "terminated"
+
+    # A subsequent bash_output read returns the terminated snapshot
+    status_result = await collect_result(
+        bash_output_tool.run(BashOutputArgs(bash_id=bash_id), ctx=ctx)
+    )
+    assert status_result.status == "terminated"
+
+
+@pytest.mark.asyncio
+async def test_bash_output_unknown_id_raises(bash_output_tool, ctx):
+    with pytest.raises(ToolError) as err:
+        await collect_result(
+            bash_output_tool.run(BashOutputArgs(bash_id="does-not-exist"), ctx=ctx)
+        )
+    assert "does-not-exist" in str(err.value)
+
+
+@pytest.mark.asyncio
+async def test_bash_output_requires_session(bash_output_tool):
+    with pytest.raises(ToolError) as err:
+        await collect_result(
+            bash_output_tool.run(BashOutputArgs(bash_id="abc"), ctx=None)
+        )
+    assert "session" in str(err.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_foreground_still_works(bash_tool, ctx):
+    """Regression check: the default path still returns synchronously
+    and is unaffected by the new branching in run().
+    """
+    result = await collect_result(bash_tool.run(BashArgs(command="echo hi"), ctx=ctx))
+    assert result.returncode == 0
+    assert result.stdout == "hi\n"
+    assert result.bash_id is None
+    assert result.background is False
+
+
+@pytest.mark.asyncio
+async def test_multiple_background_processes_isolated(bash_tool, bash_output_tool, ctx):
+    r1 = await collect_result(
+        bash_tool.run(BashArgs(command="echo one", run_in_background=True), ctx=ctx)
+    )
+    r2 = await collect_result(
+        bash_tool.run(BashArgs(command="echo two", run_in_background=True), ctx=ctx)
+    )
+    assert r1.bash_id != r2.bash_id
+
+    await _wait_for_status(bash_output_tool, ctx, r1.bash_id, "exited")
+    await _wait_for_status(bash_output_tool, ctx, r2.bash_id, "exited")
+
+    out1 = await collect_result(
+        bash_output_tool.run(BashOutputArgs(bash_id=r1.bash_id), ctx=ctx)
+    )
+    out2 = await collect_result(
+        bash_output_tool.run(BashOutputArgs(bash_id=r2.bash_id), ctx=ctx)
+    )
+
+    assert "one" in out1.stdout
+    assert "two" in out2.stdout
+    assert "two" not in out1.stdout
+    assert "one" not in out2.stdout

--- a/vibe/acp/tools/builtins/bash.py
+++ b/vibe/acp/tools/builtins/bash.py
@@ -34,6 +34,13 @@ class Bash(CoreBashTool, BaseAcpTool[AcpBashState]):
     async def run(
         self, args: BashArgs, ctx: InvokeContext | None = None
     ) -> AsyncGenerator[ToolStreamEvent | BashResult, None]:
+        if args.run_in_background:
+            raise ToolError(
+                "Background bash (run_in_background=True) is not yet supported "
+                "over the ACP terminal protocol. Run the command in foreground "
+                "mode, or use the core runtime for long-running processes."
+            )
+
         client, session_id, _ = self._load_state()
 
         timeout = args.timeout or self.config.default_timeout

--- a/vibe/core/agent_loop.py
+++ b/vibe/core/agent_loop.py
@@ -1167,7 +1167,7 @@ class AgentLoop:
             pass
 
         self.middleware_pipeline.reset()
-        self.tool_manager.reset_all()
+        await self.tool_manager.reset_all()
         self._reset_session()
 
     async def compact(self) -> str:

--- a/vibe/core/tools/base.py
+++ b/vibe/core/tools/base.py
@@ -395,3 +395,18 @@ class BaseTool[
         file reads).  The default returns ``None`` (no annotation).
         """
         return None
+
+    async def on_reset(self) -> None:
+        """Release any resources held by this tool instance before it is discarded.
+
+        Called by ``ToolManager.reset_all()`` when the session history is cleared
+        or the tool cache is rebuilt, giving tools with live resources
+        (subprocesses, network connections, open files, etc.) a chance to shut
+        down cleanly.  The default implementation is a no-op so existing tools
+        remain unaffected.
+
+        Override in subclasses that accumulate lifecycle-bound state.  Errors
+        raised from this method are logged by the caller and do not prevent
+        other tools from being reset.
+        """
+        return None

--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
+from dataclasses import dataclass
 from functools import lru_cache
+import json
 import os
 from pathlib import Path
 import signal
 import sys
+import time
 from typing import ClassVar, Literal, final
+from uuid import uuid4
 
 from pydantic import BaseModel, Field
 from tree_sitter import Language, Node, Parser
 import tree_sitter_bash as tsbash
 
+from vibe.core.logger import logger
 from vibe.core.tools.arity import build_session_pattern
 from vibe.core.tools.base import (
     BaseTool,
@@ -121,6 +126,111 @@ async def _kill_process_tree(proc: asyncio.subprocess.Process) -> None:
         await proc.wait()
     except (ProcessLookupError, PermissionError, OSError):
         pass
+
+
+_MAX_BACKGROUND_OUTPUT_BYTES = 1_000_000
+"""Per-stream cap for background-process output on disk.
+
+Background processes (dev servers, watchers) can produce unbounded output.
+We tail the most recent bytes up to this cap so the session directory stays
+manageable; callers reading via ``bash_output`` still see the newest output.
+"""
+
+
+@dataclass
+class BackgroundProcess:
+    """Live handle for a bash command started with ``run_in_background=True``.
+
+    Held in memory on ``BashState`` so ``on_reset`` can terminate the process
+    and its drain tasks when the session is cleared.  The authoritative view
+    of status and accumulated output lives on disk under ``session_dir`` and
+    is what the ``bash_output`` tool reads.
+    """
+
+    bash_id: str
+    command: str
+    proc: asyncio.subprocess.Process
+    started_at: float
+    stdout_path: Path
+    stderr_path: Path
+    metadata_path: Path
+    stdout_task: asyncio.Task[None]
+    stderr_task: asyncio.Task[None]
+    wait_task: asyncio.Task[None]
+
+
+def _background_dir(session_dir: Path) -> Path:
+    return session_dir / "bash_processes"
+
+
+def _write_background_metadata(
+    metadata_path: Path,
+    *,
+    bash_id: str,
+    pid: int,
+    command: str,
+    status: str,
+    started_at: float,
+    returncode: int | None = None,
+    ended_at: float | None = None,
+) -> None:
+    payload = {
+        "bash_id": bash_id,
+        "pid": pid,
+        "command": command,
+        "status": status,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "returncode": returncode,
+    }
+    try:
+        metadata_path.write_text(json.dumps(payload, indent=2))
+    except OSError:
+        logger.exception(
+            "Failed to write background bash metadata to %s", metadata_path
+        )
+
+
+async def _drain_stream_to_file(
+    stream: asyncio.StreamReader | None, path: Path
+) -> None:
+    """Append ``stream`` contents to ``path`` until EOF, with a byte cap.
+
+    The file is created up front so readers can tail it even before the
+    first chunk arrives.  Once the cap is reached we keep draining the
+    stream (to avoid back-pressuring the child) but stop writing, which
+    gives a natural "head" view of the output.
+    """
+    if stream is None:
+        return
+
+    try:
+        path.write_bytes(b"")
+    except OSError:
+        logger.exception("Failed to initialise background output file %s", path)
+        return
+
+    bytes_written = 0
+    try:
+        with path.open("ab", buffering=0) as fh:
+            while True:
+                chunk = await stream.read(4096)
+                if not chunk:
+                    break
+                if bytes_written >= _MAX_BACKGROUND_OUTPUT_BYTES:
+                    continue
+                remaining = _MAX_BACKGROUND_OUTPUT_BYTES - bytes_written
+                to_write = chunk if len(chunk) <= remaining else chunk[:remaining]
+                try:
+                    fh.write(to_write)
+                except OSError:
+                    logger.exception("Failed to write background output to %s", path)
+                    return
+                bytes_written += len(to_write)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.exception("Background output drain failed for %s", path)
 
 
 def _get_default_allowlist() -> list[str]:
@@ -266,13 +376,34 @@ class BashArgs(BaseModel):
     timeout: int | None = Field(
         default=None, description="Override the default command timeout."
     )
+    run_in_background: bool = Field(
+        default=False,
+        description=(
+            "Start the command as a background process and return immediately "
+            "with a `bash_id` handle.  Use the `bash_output` tool to tail the "
+            "output and check whether it has exited.  Intended for long-running "
+            "processes (dev servers, test watchers, builds) that would otherwise "
+            "block the agent.  Requires an active session directory."
+        ),
+    )
 
 
 class BashResult(BaseModel):
     command: str
-    stdout: str
-    stderr: str
-    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+    returncode: int = 0
+    bash_id: str | None = Field(
+        default=None,
+        description=(
+            "Set when the command was started with ``run_in_background=True``. "
+            "Pass this id to the ``bash_output`` tool to tail the process."
+        ),
+    )
+    background: bool = Field(
+        default=False,
+        description="True when the command was started in background mode.",
+    )
 
 
 class Bash(
@@ -280,6 +411,16 @@ class Bash(
     ToolUIData[BashArgs, BashResult],
 ):
     description: ClassVar[str] = "Run a one-off bash command and capture its output."
+
+    def __init__(
+        self, config_getter: Callable[[], BashToolConfig], state: BaseToolState
+    ) -> None:
+        super().__init__(config_getter, state)
+        # Live handles for background processes started in this session.
+        # Stored on the instance (not on the Pydantic state model) because
+        # they carry non-serialisable subprocess handles and asyncio tasks;
+        # the authoritative view lives on disk under the session directory.
+        self._background_processes: dict[str, BackgroundProcess] = {}
 
     @classmethod
     def format_call_display(cls, args: BashArgs) -> ToolCallDisplay:
@@ -439,6 +580,17 @@ class Bash(
     async def run(
         self, args: BashArgs, ctx: InvokeContext | None = None
     ) -> AsyncGenerator[ToolStreamEvent | BashResult, None]:
+        if args.run_in_background:
+            async for item in self._run_background(args, ctx):
+                yield item
+            return
+
+        async for item in self._run_foreground(args):
+            yield item
+
+    async def _run_foreground(
+        self, args: BashArgs
+    ) -> AsyncGenerator[ToolStreamEvent | BashResult, None]:
         timeout = args.timeout or self.config.default_timeout
         max_bytes = self.config.max_output_bytes
 
@@ -495,3 +647,152 @@ class Bash(
         finally:
             if proc is not None:
                 await _kill_process_tree(proc)
+
+    async def _run_background(
+        self, args: BashArgs, ctx: InvokeContext | None
+    ) -> AsyncGenerator[ToolStreamEvent | BashResult, None]:
+        if ctx is None or ctx.session_dir is None:
+            raise ToolError(
+                "Background bash requires an active session directory. "
+                "run_in_background=True cannot be used outside a session."
+            )
+
+        bg_dir = _background_dir(ctx.session_dir)
+        try:
+            bg_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise ToolError(
+                f"Could not create background bash directory {bg_dir}: {exc}"
+            ) from exc
+
+        bash_id = uuid4().hex[:12]
+        stdout_path = bg_dir / f"{bash_id}.stdout"
+        stderr_path = bg_dir / f"{bash_id}.stderr"
+        metadata_path = bg_dir / f"{bash_id}.json"
+        started_at = time.time()
+
+        # Pre-create output files so ``bash_output`` can tail them immediately,
+        # even before the drain tasks have scheduled their first read.
+        for p in (stdout_path, stderr_path):
+            try:
+                p.write_bytes(b"")
+            except OSError as exc:
+                raise ToolError(
+                    f"Could not create background bash output file {p}: {exc}"
+                ) from exc
+
+        kwargs: dict[Literal["start_new_session"], bool] = (
+            {} if is_windows() else {"start_new_session": True}
+        )
+
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                args.command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                stdin=asyncio.subprocess.DEVNULL,
+                env=_get_base_env(),
+                executable=_get_shell_executable(),
+                **kwargs,
+            )
+        except Exception as spawn_exc:
+            raise ToolError(
+                f"Failed to start background command {args.command!r}: {spawn_exc}"
+            ) from spawn_exc
+
+        _write_background_metadata(
+            metadata_path,
+            bash_id=bash_id,
+            pid=proc.pid or -1,
+            command=args.command,
+            status="running",
+            started_at=started_at,
+        )
+
+        stdout_task = asyncio.create_task(
+            _drain_stream_to_file(proc.stdout, stdout_path)
+        )
+        stderr_task = asyncio.create_task(
+            _drain_stream_to_file(proc.stderr, stderr_path)
+        )
+
+        async def _wait_and_finalize() -> None:
+            try:
+                await proc.wait()
+            finally:
+                # Wait for the drain tasks so the last bytes land on disk
+                # before we flip the status to "exited".
+                for drain in (stdout_task, stderr_task):
+                    try:
+                        await drain
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception:
+                        logger.exception(
+                            "Background output drain task failed for bash_id=%s",
+                            bash_id,
+                        )
+                _write_background_metadata(
+                    metadata_path,
+                    bash_id=bash_id,
+                    pid=proc.pid or -1,
+                    command=args.command,
+                    status="exited",
+                    started_at=started_at,
+                    returncode=proc.returncode,
+                    ended_at=time.time(),
+                )
+                self._background_processes.pop(bash_id, None)
+
+        wait_task = asyncio.create_task(_wait_and_finalize())
+
+        self._background_processes[bash_id] = BackgroundProcess(
+            bash_id=bash_id,
+            command=args.command,
+            proc=proc,
+            started_at=started_at,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+            metadata_path=metadata_path,
+            stdout_task=stdout_task,
+            stderr_task=stderr_task,
+            wait_task=wait_task,
+        )
+
+        yield BashResult(
+            command=args.command,
+            stdout="",
+            stderr="",
+            returncode=0,
+            bash_id=bash_id,
+            background=True,
+        )
+
+    async def on_reset(self) -> None:
+        """Terminate all background processes started in this session.
+
+        Called by ``ToolManager.reset_all`` during history clears and at any
+        point the tool cache is rebuilt.  Each managed process has its drain
+        and wait tasks cancelled, then the process tree is killed and the
+        metadata file updated so external readers (e.g. a later ``bash_output``
+        call with the same id) see a stable ``terminated`` state.
+        """
+        procs = list(self._background_processes.values())
+        self._background_processes.clear()
+        for bp in procs:
+            for task in (bp.stdout_task, bp.stderr_task, bp.wait_task):
+                task.cancel()
+            try:
+                await _kill_process_tree(bp.proc)
+            except Exception:
+                logger.exception("Error terminating background bash %s", bp.bash_id)
+            _write_background_metadata(
+                bp.metadata_path,
+                bash_id=bp.bash_id,
+                pid=bp.proc.pid or -1,
+                command=bp.command,
+                status="terminated",
+                started_at=bp.started_at,
+                returncode=bp.proc.returncode,
+                ended_at=time.time(),
+            )

--- a/vibe/core/tools/builtins/bash_output.py
+++ b/vibe/core/tools/builtins/bash_output.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+import json
+from pathlib import Path
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, Field
+
+from vibe.core.logger import logger
+from vibe.core.tools.base import (
+    BaseTool,
+    BaseToolConfig,
+    BaseToolState,
+    InvokeContext,
+    ToolError,
+    ToolPermission,
+)
+from vibe.core.tools.builtins.bash import _background_dir
+from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
+from vibe.core.types import ToolResultEvent, ToolStreamEvent
+
+_MAX_CHUNK_BYTES = 16_000
+"""Maximum number of bytes returned in a single ``bash_output`` call.
+
+We tail from the end of the file so the most recent output is always
+visible, and we clip to the same bound the foreground ``bash`` tool uses
+for its output capture so agents see consistent sizing across tools.
+"""
+
+
+BackgroundStatus = Literal["running", "exited", "terminated", "unknown"]
+
+
+class BashOutputToolConfig(BaseToolConfig):
+    permission: ToolPermission = ToolPermission.ALWAYS
+    max_output_bytes: int = Field(
+        default=_MAX_CHUNK_BYTES,
+        description=(
+            "Maximum bytes returned per call (tail of the stream). "
+            "Older output is truncated when the process has produced more."
+        ),
+    )
+
+
+class BashOutputArgs(BaseModel):
+    bash_id: str = Field(
+        description=(
+            "Identifier returned by a previous ``bash`` call with "
+            "``run_in_background=True``."
+        )
+    )
+
+
+class BashOutputResult(BaseModel):
+    bash_id: str
+    command: str
+    status: BackgroundStatus
+    returncode: int | None = None
+    stdout: str = ""
+    stderr: str = ""
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
+
+
+def _read_tail(path: Path, max_bytes: int) -> tuple[str, bool]:
+    """Return the last ``max_bytes`` of ``path`` and whether it was truncated.
+
+    The file is opened lazily so a missing path (e.g. the process has not
+    produced anything on that stream yet) is treated as empty.  Binary
+    content is decoded with ``replace`` so we never blow up on stray bytes
+    from noisy build tools.
+    """
+    try:
+        size = path.stat().st_size
+    except FileNotFoundError:
+        return "", False
+    except OSError:
+        logger.exception("Failed to stat background output file %s", path)
+        return "", False
+
+    if size == 0:
+        return "", False
+
+    offset = 0
+    truncated = False
+    if size > max_bytes:
+        offset = size - max_bytes
+        truncated = True
+
+    try:
+        with path.open("rb") as fh:
+            if offset:
+                fh.seek(offset)
+            data = fh.read(max_bytes)
+    except OSError:
+        logger.exception("Failed to read background output file %s", path)
+        return "", False
+
+    return data.decode("utf-8", errors="replace"), truncated
+
+
+def _coerce_status(metadata: dict[str, object]) -> BackgroundStatus:
+    raw = metadata.get("status")
+    if raw in {"running", "exited", "terminated"}:
+        return raw  # type: ignore[return-value]
+    return "unknown"
+
+
+def _coerce_returncode(metadata: dict[str, object]) -> int | None:
+    value = metadata.get("returncode")
+    return int(value) if isinstance(value, int) else None
+
+
+def _coerce_command(metadata: dict[str, object]) -> str:
+    value = metadata.get("command")
+    return value if isinstance(value, str) else ""
+
+
+def _load_metadata(metadata_path: Path) -> dict[str, object] | None:
+    try:
+        raw = metadata_path.read_text()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        logger.exception("Failed to read background bash metadata %s", metadata_path)
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.exception(
+            "Corrupt background bash metadata at %s (%r)", metadata_path, raw[:80]
+        )
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+class BashOutput(
+    BaseTool[BashOutputArgs, BashOutputResult, BashOutputToolConfig, BaseToolState],
+    ToolUIData[BashOutputArgs, BashOutputResult],
+):
+    description: ClassVar[str] = (
+        "Read the current output and status of a background bash process."
+    )
+
+    @classmethod
+    def format_call_display(cls, args: BashOutputArgs) -> ToolCallDisplay:
+        return ToolCallDisplay(summary=f"bash_output: {args.bash_id}")
+
+    @classmethod
+    def get_result_display(cls, event: ToolResultEvent) -> ToolResultDisplay:
+        if not isinstance(event.result, BashOutputResult):
+            return ToolResultDisplay(
+                success=False, message=event.error or event.skip_reason or "No result"
+            )
+        return ToolResultDisplay(
+            success=True, message=f"{event.result.bash_id} [{event.result.status}]"
+        )
+
+    @classmethod
+    def get_status_text(cls) -> str:
+        return "Reading background output"
+
+    async def run(
+        self, args: BashOutputArgs, ctx: InvokeContext | None = None
+    ) -> AsyncGenerator[ToolStreamEvent | BashOutputResult, None]:
+        if ctx is None or ctx.session_dir is None:
+            raise ToolError("bash_output requires an active session directory.")
+
+        bg_dir = _background_dir(ctx.session_dir)
+        metadata = _load_metadata(bg_dir / f"{args.bash_id}.json")
+        if metadata is None:
+            raise ToolError(
+                f"Unknown background bash id {args.bash_id!r}: no metadata file "
+                f"under {bg_dir}."
+            )
+
+        max_bytes = self.config.max_output_bytes
+        stdout, stdout_truncated = _read_tail(
+            bg_dir / f"{args.bash_id}.stdout", max_bytes
+        )
+        stderr, stderr_truncated = _read_tail(
+            bg_dir / f"{args.bash_id}.stderr", max_bytes
+        )
+
+        yield BashOutputResult(
+            bash_id=args.bash_id,
+            command=_coerce_command(metadata),
+            status=_coerce_status(metadata),
+            returncode=_coerce_returncode(metadata),
+            stdout=stdout,
+            stderr=stderr,
+            stdout_truncated=stdout_truncated,
+            stderr_truncated=stderr_truncated,
+        )

--- a/vibe/core/tools/builtins/prompts/bash.md
+++ b/vibe/core/tools/builtins/prompts/bash.md
@@ -8,6 +8,14 @@ Use the `bash` tool to run one-off shell commands.
 - When `timeout` is not specified (or set to `None`), the config default is used
 - If a command is timing out, do not hesitate to increase the timeout using the `timeout` argument
 
+**Background execution (`run_in_background=True`):**
+- Use for long-running processes that you don't want to block the agent: dev servers, file watchers, `pytest --watch`, builds, `tail -f` on logs.
+- The tool returns immediately with a `bash_id` handle while the command keeps running. The `returncode` in the initial result is always `0` and the initial `stdout`/`stderr` are empty — the process has only just been started.
+- Poll the process with the `bash_output` tool, passing the same `bash_id`, to read accumulated stdout/stderr and check whether it is still running.
+- Background processes are automatically terminated when the session history is cleared (for example via `/clear`) or when the session ends.
+- `timeout` is **ignored** in background mode — foreground timeouts make no sense for a process you explicitly detached. Kill the process by clearing the session or letting it finish naturally.
+- Do **not** start a one-shot command in the background just to avoid waiting; the foreground path is faster and simpler for anything that finishes in seconds.
+
 **IMPORTANT: Use dedicated tools if available instead of these bash commands:**
 
 **File Operations - DO NOT USE:**

--- a/vibe/core/tools/builtins/prompts/bash_output.md
+++ b/vibe/core/tools/builtins/prompts/bash_output.md
@@ -1,0 +1,25 @@
+Use the `bash_output` tool to read the current stdout, stderr and status of a background bash process previously started with `bash(command=..., run_in_background=True)`.
+
+**When to use:**
+- You kicked off a long-running process (dev server, watcher, build, `tail -f`) in background mode and now want to check on it.
+- You want to verify a background process is still running, or find out its exit code after it has finished.
+
+**Arguments:**
+- `bash_id` — the identifier returned by the original `bash` call that used `run_in_background=True`.
+
+**What you get back:**
+- `status`: one of `running`, `exited`, `terminated`, or `unknown`.
+- `returncode`: set once the process has exited. `None` while `running`.
+- `stdout` and `stderr`: the **tail** of each stream, capped to a size similar to the foreground `bash` tool. If the full stream on disk is larger than the cap, `stdout_truncated` / `stderr_truncated` will be `true`.
+- `command`: the original command that was started (for confirmation).
+
+**Typical flow:**
+1. Start the process: `bash(command="npm run dev", run_in_background=True)` → returns `bash_id="ab12cd34..."`.
+2. After letting it run for a moment, check: `bash_output(bash_id="ab12cd34...")`.
+3. Inspect `status` and `stdout` to decide whether the server is up, whether tests are still failing, etc.
+4. Call `bash_output` again later if you want fresh output — each call returns the latest tail.
+
+**Limits:**
+- You can only read background processes started in the *current* session. Clearing the session history terminates all background processes and makes their ids invalid.
+- Calling `bash_output` with an unknown `bash_id` raises a tool error.
+- The tool does not stream output — each call returns a snapshot. If you need to watch output evolve, call it multiple times with a short delay between calls.

--- a/vibe/core/tools/manager.py
+++ b/vibe/core/tools/manager.py
@@ -250,5 +250,17 @@ class ToolManager:
         )
         return self._instances[tool_name]
 
-    def reset_all(self) -> None:
+    async def reset_all(self) -> None:
+        """Release per-tool resources and drop cached instances.
+
+        Iterates over all currently instantiated tools and awaits each one's
+        ``on_reset`` hook, logging any exception without interrupting the
+        reset of the remaining tools.  Tools are then removed from the cache
+        so the next ``get()`` call recreates them from scratch.
+        """
+        for name, tool in self._instances.items():
+            try:
+                await tool.on_reset()
+            except Exception:
+                logger.exception("Error during on_reset for tool %r", name)
         self._instances.clear()


### PR DESCRIPTION
## Summary

Adds the ability to run long-running shell commands without blocking the agent loop: `bash` gains an opt-in `run_in_background=True` argument that returns immediately with a `bash_id`, and a new `bash_output` tool reads the tail + status of a background process on demand.

Use cases this unlocks:
- Dev servers (`npm run dev`, `uvicorn`, `python -m http.server`)
- Test watchers (`pytest --watch`, `jest --watch`)
- Long builds
- `tail -f` on application logs while the agent does other work

Today `bash` runs synchronously inside the agent turn, which makes any command whose runtime is measured in minutes effectively unusable.

## High-level design

**Process registry lives on the filesystem under `session_dir`, not in shared memory.**

Background spawning writes three files per process:

```
{session_dir}/bash_processes/{bash_id}.json    # metadata: pid, status, returncode, timestamps
{session_dir}/bash_processes/{bash_id}.stdout   # appended by a drain task, capped at 1 MB
{session_dir}/bash_processes/{bash_id}.stderr   # same
```

A drain task per stream appends bytes until EOF (dropping further bytes once the cap is reached, which gives a natural "head" view instead of unbounded memory usage). A wait task updates the metadata file with the final status and returncode when the process exits. `bash_output` reads these files through the same `session_dir` it gets from its own `InvokeContext`, so the two tools coordinate without a cross-tool state primitive.

The only thing held in memory is the subprocess handle itself, tracked in a dict on the `Bash` tool instance so `on_reset` can kill it.

## Design decisions and why

### 1. Filesystem-backed registry instead of shared memory

`bash` and `bash_output` are separate instances in `ToolManager`. Sharing a live Python dict between them would require either a singleton (anti-pattern), a new cross-tool state primitive (speculative architecture), or merging them into one tool with an action discriminator (uglier API). `InvokeContext.session_dir` is the one coordination point both tools already receive, and reusing it costs zero new primitives. A debugging bonus: an operator can run `tail -f` directly on the files to watch a stuck process without going through the agent.

### 2. Background state on the instance, not a new `BashState` pydantic model

An earlier sketch introduced `BashState(BaseToolState)` with a `PrivateAttr` dict. That worked but broke every existing test that built `Bash` directly with `BaseToolState()`, and the generic parameter change rippled through the class hierarchy. Since `ToolManager.reset_all()` discards both the instance and its state together, there is no observable difference between "on state" and "on instance" for this use case. Storing the dict on the instance keeps the generic parameter at `BaseToolState` and leaves the existing test fixtures untouched.

### 3. `async on_reset` with a default no-op, not a breaking refactor

Every existing tool is unaffected: the default `BaseTool.on_reset()` does nothing. `ToolManager.reset_all()` becomes async and awaits each tool's hook before clearing the instance cache, logging (without raising) any exception so one misbehaving tool cannot block the reset of the others. Its single callsite in `AgentLoop.clear_history()` is already inside an async method and gains a single `await` keyword.

This hook is the right primitive for any future tool that holds lifecycle-bound state (sockets, file handles, temp files, terminal sessions). Introducing it now on the back of a concrete consumer makes the abstraction believable instead of speculative.

### 4. Output files pre-created synchronously

Drain tasks run asynchronously. Without a guard, you can race: the agent starts a command in background mode, gets a `bash_id`, calls `bash_output` immediately, and the `.stdout` file does not exist yet because the drain task has not hit its first read. We pre-create both output files with `write_bytes(b"")` inside `_run_background` before scheduling the drain tasks, so readers observe empty files (not missing ones) from the first call onward.

### 5. `timeout` is ignored in background mode

A background process is, by definition, one the agent intends to outlive the tool call. Applying the foreground timeout would either defeat the purpose or surprise the user. Termination happens through `on_reset` (session clear, cache rebuild) or when the command exits on its own. This is documented explicitly in the updated agent prompt so the LLM does not try to set a timeout alongside `run_in_background=True` and get confused when it has no effect.

### 6. ACP layer refuses background mode explicitly, for now

The ACP bash wrapper does not spawn a local subprocess - it delegates to the ACP client's terminal protocol (`create_terminal`, `wait_for_terminal_exit`, `terminal_output`, `release_terminal`). That protocol is built around "run to completion and return", not "detach and poll". Rather than invent a parallel control path on top of an API that was not designed for it, this PR adds a guard in the ACP wrapper that raises a clear `ToolError` if `run_in_background=True` is used on the ACP path.

A proper ACP-side background implementation is a natural follow-up for someone who understands the ACP terminal semantics better. Flagging this explicitly instead of silently no-oping keeps the behaviour honest.

### 7. No CLI process-exit teardown in this PR

`AgentLoop` currently has no `__aexit__` or shutdown hook, so there is no natural place to await `reset_all()` on normal program exit. The `/clear` path is fully covered (it goes through `clear_history`). Process-level shutdown (Ctrl+C, kill, crash) relies on `start_new_session=True` plus the OS cleaning up orphaned process groups when the parent dies. An explicit session shutdown hook would be cleaner, but it touches the CLI entry point and the agent-loop lifecycle and is out of scope here - worth its own discussion.

## Files

### Core changes
- `vibe/core/tools/base.py` - new async `BaseTool.on_reset()` (default no-op)
- `vibe/core/tools/manager.py` - `ToolManager.reset_all()` becomes async, awaits `on_reset` on each instance with error logging
- `vibe/core/agent_loop.py` - single callsite becomes `await self.tool_manager.reset_all()`
- `vibe/core/tools/builtins/bash.py` - `BackgroundProcess` dataclass, drain helper, metadata writer, new `_run_background` path, `on_reset` override, `run_in_background` on `BashArgs`, `bash_id`/`background` on `BashResult`
- `vibe/core/tools/builtins/bash_output.py` - new tool (`BashOutputArgs` / `BashOutputResult` / `BashOutputToolConfig` / `BashOutput`), plus `_read_tail`, `_load_metadata`, coerce helpers
- `vibe/core/tools/builtins/prompts/bash.md` - documents background-mode semantics for the agent
- `vibe/core/tools/builtins/prompts/bash_output.md` - new agent prompt with when-to-use and typical flow
- `vibe/acp/tools/builtins/bash.py` - guard rejecting background mode on the ACP path

### Tests
- `tests/tools/test_bash_background.py` - 9 tests covering:
  - Immediate return with `bash_id` and files on disk
  - `running` -> `exited` transition with correct stdout
  - stderr capture and non-zero returncode
  - Explicit error when no `session_dir` is available
  - `on_reset` terminates a long-running process and marks metadata as `terminated`
  - `bash_output` raises a clear error for unknown `bash_id`
  - Foreground regression (existing path unaffected)
  - Two concurrent background processes stay isolated

## Test plan

- [x] `uv run pytest tests/tools/test_bash_background.py -v` - 9/9 passing
- [x] `uv run pytest tests/tools/test_bash.py -v` - 32/32 passing (foreground regression)
- [x] `uv run pytest tests/acp/test_bash.py -v` - passing (ACP guard + existing paths)
- [x] `uv run pytest tests/tools tests/core tests/test_agent_auto_compact.py` - 896 passing
- [x] `uv run ruff check` - clean on all touched files
- [x] `uv run ruff format --check` - clean on all touched files
- [x] `uv run pyright` - 0 errors, 0 warnings on all touched files
- [x] End-to-end Python script exercising spawn -> running -> exited -> `on_reset` -> foreground parity - all 5 scenarios behave as expected
- [x] `ToolManager` auto-discovery confirmed: `bash_output` appears in the default 13-tool registry with no additional wiring

## Not in scope (possible follow-ups)

- **ACP terminal protocol background support** - guarded with a clear error in this PR
- **CLI process-exit shutdown hook** - relies on OS process-group cleanup for now
- **`kill_bash` tool** to terminate a specific background process mid-session - `on_reset` kills all at once; per-id control is a follow-up if there is demand
- **Streaming output to the agent** - `bash_output` returns a snapshot per call by design; the agent polls again for fresh output