### PR TITLE
feat: Add additional Mistral models to default config

### DIFF
--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -385,6 +385,7 @@ DEFAULT_PROVIDERS = [
 ]
 
 DEFAULT_MODELS = [
+    # Devstral models (optimized for coding/tool use)
     ModelConfig(
         name="mistral-vibe-cli-latest",
         provider="mistral",
@@ -399,6 +400,36 @@ DEFAULT_MODELS = [
         input_price=0.1,
         output_price=0.3,
     ),
+    # General Mistral models
+    ModelConfig(
+        name="mistral-large-latest",
+        provider="mistral",
+        alias="mistral-large",
+        input_price=2.0,
+        output_price=6.0,
+    ),
+    ModelConfig(
+        name="mistral-small-latest",
+        provider="mistral",
+        alias="mistral-small",
+        input_price=0.2,
+        output_price=0.6,
+    ),
+    ModelConfig(
+        name="mistral-large-2512",
+        provider="mistral",
+        alias="mistral-large-2512",
+        input_price=2.0,
+        output_price=6.0,
+    ),
+    ModelConfig(
+        name="mistral-small-2603",
+        provider="mistral",
+        alias="mistral-small-2603",
+        input_price=0.2,
+        output_price=0.6,
+    ),
+    # Local/self-hosted
     ModelConfig(
         name="devstral",
         provider="llamacpp",


### PR DESCRIPTION
This PR expands the available models in Vibe CLI to include more Mistral options beyond the current devstral variants.

## Added Models

| Alias | Model | Input Price | Output Price |
|-------|-------|-------------|--------------|
| mistral-large | mistral-large-latest | $2.00 | $6.00 |
| mistral-small | mistral-small-latest | $0.20 | $0.60 |
| mistral-large-2512 | mistral-large-2512 | $2.00 | $6.00 |
| mistral-small-2603 | mistral-small-2603 | $0.20 | $0.60 |

## Notable Findings

🔥 **mistral-small-2603** shows strong performance for coding and agentic tasks while maintaining the low latency and cost benefits of the small model family. It serves as a good middle-ground option between devstral-small and the larger models.

## Changes

- Added 4 new ModelConfig entries to DEFAULT_MODELS in _settings.py
- Organized models by category (Devstral vs General Mistral)
- Maintained existing devstral-2 as default