### PR TITLE
feat(cli): add /copy command to copy the last agent answer to the clipboard

### DIFF
--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -44,6 +44,11 @@ class CommandRegistry:
                 description="Clear conversation history",
                 handler="_clear_history",
             ),
+            "copy": Command(
+                aliases=frozenset(["/copy"]),
+                description="Copy the last assistant answer to the clipboard",
+                handler="_copy_last_answer",
+            ),
             "log": Command(
                 aliases=frozenset(["/log"]),
                 description="Show path to current interaction log file",

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -25,7 +25,7 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from vibe import __version__ as CORE_VERSION
-from vibe.cli.clipboard import copy_selection_to_clipboard
+from vibe.cli.clipboard import _copy_to_clipboard, copy_selection_to_clipboard
 from vibe.cli.commands import CommandRegistry
 from vibe.cli.narrator_manager import (
     NarratorManager,
@@ -1750,6 +1750,43 @@ class VibeApp(App):  # noqa: PLR0904
                     f"Failed to get log path: {e}", collapsed=self._tools_collapsed
                 )
             )
+
+    async def _copy_last_answer(self, **kwargs: Any) -> None:
+        last_assistant = next(
+            (
+                m
+                for m in reversed(self.agent_loop.messages)
+                if m.role == Role.assistant and m.content
+            ),
+            None,
+        )
+        if last_assistant is None or not last_assistant.content:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    "No assistant answer available yet.",
+                    collapsed=self._tools_collapsed,
+                )
+            )
+            return
+
+        text = last_assistant.content
+        try:
+            _copy_to_clipboard(text)
+        except Exception as exc:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    f"Failed to copy to clipboard: {exc}",
+                    collapsed=self._tools_collapsed,
+                )
+            )
+            return
+
+        self.notify(
+            f"Copied last answer ({len(text)} chars) to clipboard",
+            severity="information",
+            timeout=2,
+            markup=False,
+        )
 
     async def _compact_history(self, **kwargs: Any) -> None:
         if self._agent_running:


### PR DESCRIPTION
## Summary

Adds a new slash command `/copy` to the Vibe CLI that copies the most recent
assistant answer from the conversation to the system clipboard.

- Registers `copy` (alias `/copy`) in `CommandRegistry` with a short
  user-facing description.
- Implements `_copy_last_answer` in `VibeApp`, which walks `agent_loop.messages`
  in reverse, finds the latest non-empty `Role.assistant` message, and writes
  its content to the clipboard via the existing `_copy_to_clipboard` helper in
  `vibe.cli.clipboard` — so no new clipboard backend is introduced and platform
  behavior is unchanged.
- Surfaces clear feedback to the user:
  - Success: a toast notification `Copied last answer (<N> chars) to clipboard`.
  - Empty conversation / no assistant reply yet: a rendered `ErrorMessage`
    ("No assistant answer available yet.").
  - Clipboard failure: a rendered `ErrorMessage` with the underlying exception,
    so failures are visible instead of silent.

## Motivation

Copying assistant answers is a very common action, and today the only way to
do it is mouse-selecting the text in the terminal UI. That is awkward and, in
practice, not reliable:

- Long answers span many screen heights and wrap across lines, so drag-select
  frequently grabs the wrong range, the prompt border, line numbers, or
  trailing whitespace.
- Code blocks, diffs, and multi-paragraph explanations are exactly the content
  users most want to copy — and exactly where mouse selection is worst.
- Users on tiling window managers, SSH sessions, or tmux panes often don't
  have a working mouse-select-to-clipboard path at all.
- Keyboard-driven workflows (which the rest of the slash-command surface
  optimizes for) currently break at this final step.

`/copy` makes copying the last answer a single, deterministic keystroke,
independent of terminal/mouse/tmux quirks. It's a small addition that
noticeably improves the day-to-day ergonomics of using Vibe.

## Changes

- `vibe/cli/commands.py`: register the `copy` command.
- `vibe/cli/textual_ui/app.py`: import `_copy_to_clipboard` and implement
  `VibeApp._copy_last_answer`.

No changes to dependencies, configuration, storage, or public APIs.

## Test Plan

- [x] Manual: ran the CLI, issued `/copy` after various assistant turns, and
  verified the clipboard contents matched the last assistant message
  exactly (including multi-line / code-block answers).
- [x] Regression: `uv run pytest tests/cli/*` → **279 passed**.
- [x] Lint: `uv run ruff check` → **passes** with no new findings.
