### PR TITLE
fix: respect auto-approve flag in exit_plan_mode when using --prompt

### DIFF
--- a/vibe/core/agent_loop.py
+++ b/vibe/core/agent_loop.py
@@ -862,6 +862,7 @@ class AgentLoop:
                     plan_file_path=self._plan_session.plan_file_path,
                     switch_agent_callback=self.switch_agent,
                     skill_manager=self.skill_manager,
+                    auto_approve=self.auto_approve,
                 ),
                 **tool_call.args_dict,
             ):

--- a/vibe/core/tools/base.py
+++ b/vibe/core/tools/base.py
@@ -57,6 +57,7 @@ class InvokeContext:
     plan_file_path: Path | None = field(default=None)
     switch_agent_callback: SwitchAgentCallback | None = field(default=None)
     skill_manager: SkillManager | None = field(default=None)
+    auto_approve: bool = field(default=False)
 
 
 class ToolError(Exception):

--- a/vibe/core/tools/builtins/exit_plan_mode.py
+++ b/vibe/core/tools/builtins/exit_plan_mode.py
@@ -69,6 +69,17 @@ class ExitPlanMode(
         if ctx.agent_manager.active_profile.name != BuiltinAgentName.PLAN:
             raise ToolError("ExitPlanMode can only be used in plan mode.")
 
+        if ctx.auto_approve:
+            if ctx.switch_agent_callback:
+                await ctx.switch_agent_callback(BuiltinAgentName.AUTO_APPROVE)
+            else:
+                ctx.agent_manager.switch_profile(BuiltinAgentName.AUTO_APPROVE)
+            yield ExitPlanModeResult(
+                switched=True,
+                message="Switched to auto-approve mode. Proceeding with implementation.",
+            )
+            return
+
         if ctx.user_input_callback is None:
             raise ToolError("ExitPlanMode requires an interactive UI.")
 


### PR DESCRIPTION
When running with `--prompt` in programmatic mode, the tool correctly uses the `auto-approve` profile by default. However, if the model invokes `exit_plan_mode` (for example when `--plan` is specified or plan mode is triggered), the tool unconditionally calls `ctx.user_input_callback` for confirmation. In programmatic mode `user_input_callback` is always `None`, so the tool raises `ToolError("ExitPlanMode requires an interactive UI.")` instead of proceeding automatically.

The root cause is that `InvokeContext` had no way to convey the `auto_approve` flag to individual tools, so `exit_plan_mode` could not distinguish a programmatic/auto-approve invocation from a headless one without a UI.

The fix adds an `auto_approve: bool` field to `InvokeContext` in `vibe/core/tools/base.py`, passes `self.auto_approve` when building the context in `vibe/core/agent_loop.py`, and updates `exit_plan_mode.py` to skip the user confirmation prompt and immediately switch to `auto-approve` mode when `ctx.auto_approve` is `True`.

Fixes #605