### PR TITLE
fix: replace hardcoded 'textual-ansi' theme with 'textual-dark' to support textual 8.2.5+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "requests>=2.20.0",
     "rich>=14.0.0",
     "sounddevice>=0.5.1",
-    "textual==8.2.4",
+    "textual>=8.2.1",
     "textual-speedups>=0.2.1",
     "tomli-w>=1.2.0",
     "tree-sitter>=0.25.2",

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -458,7 +458,7 @@ class VibeApp(App):  # noqa: PLR0904
             yield ContextProgress()
 
     async def on_mount(self) -> None:
-        self.theme = "textual-ansi"
+        self.theme = "textual-dark"
         self._terminal_notifier.restore()
 
         self._cached_messages_area = self.query_one("#messages")

--- a/vibe/setup/onboarding/__init__.py
+++ b/vibe/setup/onboarding/__init__.py
@@ -21,7 +21,7 @@ class OnboardingApp(App[str | None]):
         self._entrypoint_metadata = entrypoint_metadata
 
     def on_mount(self) -> None:
-        self.theme = "textual-ansi"
+        self.theme = "textual-dark"
 
         self.install_screen(WelcomeScreen(), "welcome")
         self.install_screen(

--- a/vibe/setup/trusted_folders/trust_folder_dialog.py
+++ b/vibe/setup/trusted_folders/trust_folder_dialog.py
@@ -187,7 +187,7 @@ class TrustFolderApp(App):
         self._quit_without_saving = False
 
     def on_mount(self) -> None:
-        self.theme = "textual-ansi"
+        self.theme = "textual-dark"
 
     def compose(self) -> ComposeResult:
         yield TrustFolderDialog(self.folder_path, self.detected_files)


### PR DESCRIPTION
Fresh installs were pulling textual 8.2.5+ which removed the `textual-ansi` theme, causing an `InvalidThemeError` crash on startup. Three files hardcoded `self.theme = "textual-ansi"` in their `on_mount` handlers: `vibe/cli/textual_ui/app.py`, `vibe/setup/onboarding/__init__.py`, and `vibe/setup/trusted_folders/trust_folder_dialog.py`.

The hotfix in v2.9.3 pinned `textual==8.2.4` to work around the crash, but left the broken theme name in place. This change replaces all three `textual-ansi` references with `textual-dark` (a built-in theme present in all relevant textual versions) and relaxes the textual pin back to `>=8.2.1` so future textual releases can be adopted without needing a new pin.

Fixes #651
