### PR TITLE
fix(generic): default delta.role to 'assistant' for streaming chunks

### DIFF
--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -137,6 +137,10 @@ class OpenAIAdapter(APIAdapter):
                 return LLMMessage.model_validate(msg_dict)
             if "delta" in choice:
                 msg_dict = self._reasoning_from_api(choice["delta"], field_name)
+                # Streaming chunks 2+ have delta.role=None per OpenAI spec.
+                # Default to assistant since that's the only role a model returns.
+                if msg_dict.get("role") is None:
+                    msg_dict["role"] = "assistant"
                 return LLMMessage.model_validate(msg_dict)
             raise ValueError("Invalid response data: missing message or delta")
 
@@ -145,6 +149,8 @@ class OpenAIAdapter(APIAdapter):
             return LLMMessage.model_validate(msg_dict)
         if "delta" in data:
             msg_dict = self._reasoning_from_api(data["delta"], field_name)
+            if msg_dict.get("role") is None:
+                msg_dict["role"] = "assistant"
             return LLMMessage.model_validate(msg_dict)
 
         return None


### PR DESCRIPTION
## Summary

OpenAIAdapter._parse_message rejects streaming chunks 2+ because `delta.role` is `null` per OpenAI spec, but `LLMMessage.role` is a required `Role` enum without a default. The TUI fails on every multi-chunk streaming response (which is every real response).

Closes https://github.com/mistralai/mistral-vibe/issues/665

## Change

Three lines at each of the two delta-handling branches: default `role` to `\"assistant\"` when `None`. Only `assistant` is a valid role for a model-emitted streaming chunk, so the default is semantically safe.

## Test plan

- [x] Reproduced bug on fresh `uv tool install mistral-vibe` against SGLang Mistral Small 4
- [x] Verified raw streaming chunks: first has `delta.role=\"assistant\"`, subsequent have `delta.role: null` (OpenAI spec)
- [x] Applied fix locally, TUI now takes prompts cleanly across multi-turn sessions
- [x] Programmatic mode (`vibe -p`) unaffected (already used non-streaming `choice.message` path)
- [ ] Maintainer to consider whether a cleaner upstream form is making `LLMMessage.role` Optional with default `Role.assistant` (not done in this PR to keep the diff minimal)

## Detailed reproduction context

Diagnosis sequence (including two falsified hypotheses before the actual root cause was traced) and full SGLang chunk dump: https://sovgrid.org/blog/fixes-vibe-400-badrequest-fix/