### PR TITLE
fix(skills): notify user when a SKILL.md fails to parse

### DIFF
--- a/tests/skills/test_manager.py
+++ b/tests/skills/test_manager.py
@@ -170,6 +170,32 @@ class TestSkillManagerParsing:
         assert "valid-skill" in skills
         assert "invalid-skill" not in skills
 
+    def test_records_issue_for_malformed_yaml_frontmatter(
+        self, skills_dir: Path
+    ) -> None:
+        # Unquoted ': ' inside a YAML scalar is parsed as a nested mapping,
+        # which fails with "mapping values are not allowed here".
+        bad_skill_dir = skills_dir / "bad-skill"
+        bad_skill_dir.mkdir()
+        (bad_skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: bad-skill\n"
+            "description: A description with a colon: followed by space.\n"
+            "---\n"
+        )
+
+        config = build_test_vibe_config(
+            system_prompt_id="tests",
+            include_project_context=False,
+            skill_paths=[skills_dir],
+        )
+        manager = SkillManager(lambda: config)
+
+        assert "bad-skill" not in manager.available_skills
+        assert len(manager.issues) == 1
+        assert manager.issues[0].file == bad_skill_dir / "SKILL.md"
+        assert "Failed to parse" in manager.issues[0].message
+
     def test_skips_skill_with_missing_required_fields(self, skills_dir: Path) -> None:
         # Create skill missing description
         missing_desc_dir = skills_dir / "missing-desc"

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -511,6 +511,7 @@ class VibeApp(App):  # noqa: PLR0904
 
         self.call_after_refresh(self._refresh_banner)
         self._show_hook_config_issues_once()
+        self._show_skill_load_issues_once()
 
         self.run_worker(self._watch_init_completion(), exclusive=False)
 
@@ -524,6 +525,15 @@ class VibeApp(App):  # noqa: PLR0904
 
     def _show_hook_config_issues_once(self) -> None:
         for issue in self.agent_loop.hook_config_issues:
+            self.notify(
+                f"{issue.file}\n{issue.message}",
+                severity="warning",
+                markup=False,
+                timeout=10,
+            )
+
+    def _show_skill_load_issues_once(self) -> None:
+        for issue in self.agent_loop.skill_manager.issues:
             self.notify(
                 f"{issue.file}\n{issue.message}",
                 severity="warning",

--- a/vibe/core/skills/manager.py
+++ b/vibe/core/skills/manager.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING
 from vibe.core.config.harness_files import get_harness_files_manager
 from vibe.core.logger import logger
 from vibe.core.skills.builtins import BUILTIN_SKILLS
-from vibe.core.skills.models import ParsedSkillCommand, SkillInfo, SkillMetadata
+from vibe.core.skills.models import (
+    ParsedSkillCommand,
+    SkillInfo,
+    SkillLoadIssue,
+    SkillMetadata,
+)
 from vibe.core.skills.parser import SkillParseError, parse_skill_markdown
 from vibe.core.utils import name_matches
 from vibe.core.utils.io import read_safe
@@ -21,6 +26,7 @@ class SkillManager:
     def __init__(self, config_getter: Callable[[], VibeConfig]) -> None:
         self._config_getter = config_getter
         self._search_paths = self._compute_search_paths(self._config)
+        self.issues: list[SkillLoadIssue] = []
         self.available_skills: Mapping[str, SkillInfo] = MappingProxyType(
             self._apply_filters(self._discover_skills())
         )
@@ -120,6 +126,9 @@ class SkillManager:
         try:
             skill_info = self._parse_skill_file(skill_file)
         except Exception as e:
+            self.issues.append(
+                SkillLoadIssue(file=skill_file, message=f"Failed to parse: {e}")
+            )
             logger.warning("Failed to parse skill at %s: %s", skill_file, e)
             return None
         return skill_info

--- a/vibe/core/skills/models.py
+++ b/vibe/core/skills/models.py
@@ -102,3 +102,8 @@ class ParsedSkillCommand(BaseModel):
     name: str
     content: str
     extra_instructions: str | None = None
+
+
+class SkillLoadIssue(BaseModel):
+    file: Path
+    message: str


### PR DESCRIPTION
Closes #672.

A `SKILL.md` whose YAML frontmatter fails to parse is currently skipped without any on-screen warning; only `~/.vibe/logs/vibe.log` records the failure. This mirrors the existing hook-config-issue pattern (`HookConfigIssue` + `_show_hook_config_issues_once`): introduce `SkillLoadIssue`, collect parse failures on `SkillManager` during discovery, and surface them once at TUI startup via `self.notify(... severity="warning")`. The existing `logger.warning` is preserved for the on-disk log trail.

Test added in `tests/skills/test_manager.py` covering the unquoted `": "` reproducer from the issue.