### PR TITLE
fix: Set include_commit_signature and enable_telemetry defaults to false for GDPR compliance

### DIFF
--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -508,9 +508,9 @@ class VibeConfig(BaseSettings):
     active_transcribe_model: str = "voxtral-realtime"
     active_tts_model: str = "voxtral-tts"
     bypass_tool_permissions: bool = False
-    enable_telemetry: bool = True
+    enable_telemetry: bool = False
     system_prompt_id: str = "cli"
-    include_commit_signature: bool = True
+    include_commit_signature: bool = False
     include_model_info: bool = True
     include_project_context: bool = True
     include_prompt_detail: bool = True


### PR DESCRIPTION
This addresses issue #679 where the default values for `include_commit_signature` and `enable_telemetry` were true, which violates GDPR Article 25 (Data Protection by Design and by Default).

## Changes
- Changed `enable_telemetry` default from True to False
- Changed `include_commit_signature` default from True to False

## Rationale
The original defaults caused PII (commit author name, email, GPG signature) and usage telemetry to be collected by default without explicit user consent. This violates GDPR Article 25 which requires that data collection be minimised by default and only data strictly necessary for the stated purpose be processed.

With these changes, users must explicitly opt-in to share their commit signature and telemetry data, aligning with privacy-first principles and GDPR compliance.

## Related Issue
Fixes #679