### PR TITLE
perf: combine git subprocess calls in SessionLogger

### DIFF
--- a/tests/session/test_session_logger.py
+++ b/tests/session/test_session_logger.py
@@ -114,16 +114,12 @@ class TestSessionLoggerMetadata:
         self, mock_getuser, mock_subprocess, session_config: SessionLoggingConfig
     ) -> None:
         """Test that session metadata is correctly initialized."""
-        # Mock git commands
-        git_commit_mock = MagicMock()
-        git_commit_mock.returncode = 0
-        git_commit_mock.stdout = "abc123\n"
+        # Mock combined git command
+        git_mock = MagicMock()
+        git_mock.returncode = 0
+        git_mock.stdout = "abc123\nmain\n"
 
-        git_branch_mock = MagicMock()
-        git_branch_mock.returncode = 0
-        git_branch_mock.stdout = "main\n"
-
-        mock_subprocess.side_effect = [git_commit_mock, git_branch_mock]
+        mock_subprocess.return_value = git_mock
         mock_getuser.return_value = "testuser"
 
         session_id = "test-session-123"
@@ -149,7 +145,7 @@ class TestSessionLoggerMetadata:
         self, mock_getuser, mock_subprocess, session_config: SessionLoggingConfig
     ) -> None:
         """Test that session metadata handles git command errors gracefully."""
-        # Mock git commands to fail
+        # Mock combined git command to fail
         mock_subprocess.side_effect = FileNotFoundError("git not found")
         mock_getuser.return_value = "testuser"
 

--- a/vibe/core/session/session_logger.py
+++ b/vibe/core/session/session_logger.py
@@ -94,37 +94,32 @@ class SessionLogger:
             )
         return self.session_dir / MESSAGES_FILENAME
 
-    @property
-    def git_commit(self) -> str | None:
+    def _fetch_git_metadata(self) -> tuple[str | None, str | None]:
+        """Fetch git commit and branch in a single subprocess call."""
         try:
             result = subprocess.run(
-                ["git", "rev-parse", "HEAD"],
+                ["git", "rev-parse", "HEAD", "--abbrev-ref", "HEAD"],
                 capture_output=True,
                 stdin=subprocess.DEVNULL if is_windows() else None,
                 text=True,
                 timeout=5.0,
             )
             if result.returncode == 0 and result.stdout:
-                return result.stdout.strip()
+                lines = result.stdout.strip().splitlines()
+                commit = lines[0] if len(lines) > 0 else None
+                branch = lines[1] if len(lines) > 1 else None
+                return commit, branch
         except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
             pass
-        return None
+        return None, None
+
+    @property
+    def git_commit(self) -> str | None:
+        return self._fetch_git_metadata()[0]
 
     @property
     def git_branch(self) -> str | None:
-        try:
-            result = subprocess.run(
-                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-                capture_output=True,
-                stdin=subprocess.DEVNULL if is_windows() else None,
-                text=True,
-                timeout=5.0,
-            )
-            if result.returncode == 0 and result.stdout:
-                return result.stdout.strip()
-        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-            pass
-        return None
+        return self._fetch_git_metadata()[1]
 
     @property
     def username(self) -> str:
@@ -134,8 +129,7 @@ class SessionLogger:
             return "unknown"
 
     def _initialize_session_metadata(self) -> SessionMetadata:
-        git_commit = self.git_commit
-        git_branch = self.git_branch
+        git_commit, git_branch = self._fetch_git_metadata()
         user_name = self.username
 
         return SessionMetadata(


### PR DESCRIPTION
Hey @mistralai team!

I picked up issue #102 — the sequential git subprocess calls adding 100-300ms to startup.

## What changed

Merged the two separate `git rev-parse` calls (`HEAD` and `--abbrev-ref HEAD`) into a single `_fetch_git_metadata()` method that runs one subprocess and parses both values from its output. Also updated `_initialize_session_metadata()` to call this directly instead of going through the properties, avoiding any redundant spawns.

**Before:** 2 sequential subprocess calls (~100-300ms)
**After:** 1 subprocess call (~50-150ms)

## Changes
- `vibe/core/session/session_logger.py` — new `_fetch_git_metadata()` method, properties delegate to it
- `tests/session/test_session_logger.py` — updated mocks to match single-call behavior

Net -10 lines. All existing error handling preserved.

Fixes #102