### PR TITLE
tui: polish banner layout and bash output collapsing

### DIFF
--- a/vibe/cli/textual_ui/app.tcss
+++ b/vibe/cli/textual_ui/app.tcss
@@ -568,9 +568,41 @@ Markdown {
     }
 }
 
+.bash-output-body {
+    width: 1fr;
+    height: auto;
+}
+
 .bash-output {
     width: 1fr;
     height: auto;
+}
+
+.bash-output-toggle {
+    width: auto;
+    height: auto;
+    margin-top: 0;
+}
+
+.bash-output-triangle {
+    width: auto;
+    height: auto;
+    color: $text-muted;
+    margin-right: 1;
+
+    &:ansi {
+        text-style: dim;
+    }
+}
+
+.bash-output-toggle-label {
+    width: auto;
+    height: auto;
+    color: $text-muted;
+
+    &:ansi {
+        text-style: dim;
+    }
 }
 
 .unknown-event {
@@ -1161,7 +1193,7 @@ NarratorStatus {
 }
 
 #banner-container {
-    align: left middle;
+    align: left top;
     padding: 1 1 0 0;
     width: auto;
 }
@@ -1173,8 +1205,8 @@ NarratorStatus {
 #banner-info {
     width: auto;
     height: auto;
-    margin-left: 2;
-    content-align: left middle;
+    margin-top: 1;
+    content-align: left top;
 }
 
 .banner-line {

--- a/vibe/cli/textual_ui/widgets/banner/banner.py
+++ b/vibe/cli/textual_ui/widgets/banner/banner.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalGroup
 from textual.reactive import reactive
 from textual.widgets import Static
 
@@ -54,7 +54,7 @@ class Banner(Static):
         self._animated = not config.disable_welcome_banner_animation
 
     def compose(self) -> ComposeResult:
-        with Horizontal(id="banner-container"):
+        with VerticalGroup(id="banner-container"):
             yield PetitChat(animate=self._animated)
 
             with Vertical(id="banner-info"):

--- a/vibe/cli/textual_ui/widgets/messages.py
+++ b/vibe/cli/textual_ui/widgets/messages.py
@@ -238,6 +238,11 @@ class ReasoningMessage(SpinnerMixin, StreamingMessageBase):
     def on_resize(self) -> None:
         self.refresh_spinner()
 
+    def stop_spinning(self, success: bool = True) -> None:
+        super().stop_spinning(success)
+        if self._indicator_widget:
+            self._indicator_widget.update("■")
+
     async def on_click(self) -> None:
         await self._toggle_collapsed()
 
@@ -324,6 +329,7 @@ class InterruptMessage(Static):
 
 class BashOutputMessage(SpinnerMixin, Static):
     SPINNER_TYPE = SpinnerType.PULSE
+    _PREVIEW_LINES = 3
 
     def __init__(
         self,
@@ -342,10 +348,38 @@ class BashOutputMessage(SpinnerMixin, Static):
         self._output = output.rstrip("\n")
         self._exit_code = exit_code
         self._pending = pending
+        self._collapsed = True
         self._output_widget: NoMarkupStatic | None = None
+        self._overflow_widget: NoMarkupStatic | None = None
+        self._toggle_widget: Horizontal | None = None
+        self._toggle_triangle: NonSelectableStatic | None = None
+        self._toggle_label: NoMarkupStatic | None = None
         self._output_container: Horizontal | None = None
         self._prompt_widget: NonSelectableStatic | None = None
         self._indicator_widget: Static | None = None
+
+    def _preview_text(self) -> str:
+        return "\n".join(self._output.splitlines()[:self._PREVIEW_LINES])
+
+    def _overflow_text(self) -> str:
+        return "\n".join(self._output.splitlines()[self._PREVIEW_LINES:])
+
+    def _overflow_count(self) -> int:
+        return max(0, len(self._output.splitlines()) - self._PREVIEW_LINES)
+
+    def _refresh_output_widgets(self) -> None:
+        count = self._overflow_count()
+        if self._output_widget:
+            self._output_widget.update(self._preview_text())
+        if self._overflow_widget:
+            self._overflow_widget.update(self._overflow_text())
+            self._overflow_widget.display = not self._collapsed and count > 0
+        if self._toggle_widget:
+            self._toggle_widget.display = count > 0
+        if self._toggle_label:
+            self._toggle_label.update(f"+{count} more lines")
+        if self._toggle_triangle:
+            self._toggle_triangle.update("▼" if not self._collapsed else "▶")
 
     def _update_spinner_frame(self) -> None:
         if not self._is_spinning or not self._prompt_widget:
@@ -372,21 +406,53 @@ class BashOutputMessage(SpinnerMixin, Static):
             yield self._prompt_widget
             yield NoMarkupStatic(self._command, classes="bash-command")
         if not self._pending:
+            count = self._overflow_count()
+            self._output_widget = NoMarkupStatic(self._preview_text(), classes="bash-output")
+            self._overflow_widget = NoMarkupStatic(self._overflow_text(), classes="bash-output")
+            self._overflow_widget.display = False
+            self._toggle_triangle = NonSelectableStatic("▶", classes="bash-output-triangle")
+            self._toggle_label = NoMarkupStatic(f"+{count} more lines", classes="bash-output-toggle-label")
+            self._toggle_widget = Horizontal(
+                self._toggle_triangle,
+                self._toggle_label,
+                classes="bash-output-toggle",
+            )
+            self._toggle_widget.display = count > 0
             self._output_container = Horizontal(classes="bash-output-container")
             with self._output_container:
                 yield ExpandingBorder(classes="bash-output-border")
-                self._output_widget = NoMarkupStatic(
-                    self._output, classes="bash-output"
-                )
-                yield self._output_widget
+                with Vertical(classes="bash-output-body"):
+                    yield self._output_widget
+                    yield self._overflow_widget
+                    yield self._toggle_widget
+
+    async def on_click(self) -> None:
+        if self._overflow_count() > 0:
+            self._collapsed = not self._collapsed
+            self._refresh_output_widgets()
 
     async def _ensure_output_container(self) -> None:
         if self._output_container is not None:
             return
         self._output_widget = NoMarkupStatic("", classes="bash-output")
+        self._overflow_widget = NoMarkupStatic("", classes="bash-output")
+        self._overflow_widget.display = False
+        self._toggle_triangle = NonSelectableStatic("▶", classes="bash-output-triangle")
+        self._toggle_label = NoMarkupStatic("+0 more lines", classes="bash-output-toggle-label")
+        self._toggle_widget = Horizontal(
+            self._toggle_triangle,
+            self._toggle_label,
+            classes="bash-output-toggle",
+        )
+        self._toggle_widget.display = False
         self._output_container = Horizontal(
             ExpandingBorder(classes="bash-output-border"),
-            self._output_widget,
+            Vertical(
+                self._output_widget,
+                self._overflow_widget,
+                self._toggle_widget,
+                classes="bash-output-body",
+            ),
             classes="bash-output-container",
         )
         await self.mount(self._output_container)
@@ -394,8 +460,7 @@ class BashOutputMessage(SpinnerMixin, Static):
     async def append_output(self, text: str) -> None:
         await self._ensure_output_container()
         self._output += text
-        if self._output_widget:
-            self._output_widget.update(self._output.rstrip("\n"))
+        self._refresh_output_widgets()
 
     async def finish(self, exit_code: int, *, interrupted: bool = False) -> None:
         self._exit_code = exit_code
@@ -424,8 +489,7 @@ class BashOutputMessage(SpinnerMixin, Static):
         if not self._output:
             self._output = "(no output)"
         await self._ensure_output_container()
-        if self._output_widget:
-            self._output_widget.update(self._output.rstrip("\n"))
+        self._refresh_output_widgets()
 
 
 class ErrorMessage(Static):

--- a/vibe/cli/textual_ui/widgets/tool_widgets.py
+++ b/vibe/cli/textual_ui/widgets/tool_widgets.py
@@ -5,9 +5,10 @@ from pathlib import Path
 
 from pydantic import BaseModel
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.widgets import Markdown, Static
 
+from vibe.cli.textual_ui.widgets.messages import NonSelectableStatic
 from vibe.cli.textual_ui.widgets.no_markup_static import NoMarkupStatic
 from vibe.core.tools.builtins.ask_user_question import AskUserQuestionResult
 from vibe.core.tools.builtins.bash import BashArgs, BashResult
@@ -130,18 +131,42 @@ class BashApprovalWidget(ToolApprovalWidget[BashArgs]):
 
 
 class BashResultWidget(ToolResultWidget[BashResult]):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._inner_collapsed = True
+        self._overflow_widget: NoMarkupStatic | None = None
+        self._toggle_triangle: NonSelectableStatic | None = None
+        self._toggle_label: NoMarkupStatic | None = None
+        self._toggle_row: Horizontal | None = None
+
     def compose(self) -> ComposeResult:
         if not self.result:
             yield from self._footer()
             return
         if self.collapsed:
-            truncation_info = None
             if self.result.stdout:
-                content, truncation_info = _truncate_lines(self.result.stdout, 10)
-                yield NoMarkupStatic(content, classes="tool-result-detail")
+                lines = self.result.stdout.strip("\n").split("\n")
+                self._overflow_widget = NoMarkupStatic(
+                    "\n".join(lines), classes="tool-result-detail"
+                )
+                self._overflow_widget.display = False
+                yield self._overflow_widget
+                self._toggle_triangle = NonSelectableStatic(
+                    "▶", classes="bash-output-triangle"
+                )
+                self._toggle_label = NoMarkupStatic(
+                    f"{len(lines)} lines",
+                    classes="bash-output-toggle-label",
+                )
+                self._toggle_row = Horizontal(
+                    self._toggle_triangle,
+                    self._toggle_label,
+                    classes="bash-output-toggle",
+                )
+                yield self._toggle_row
             else:
                 yield NoMarkupStatic("(no content)", classes="tool-result-detail")
-            yield from self._footer(truncation_info)
+            yield from self._footer()
             return
         yield NoMarkupStatic(
             f"returncode: {self.result.returncode}", classes="tool-result-detail"
@@ -157,6 +182,16 @@ class BashResultWidget(ToolResultWidget[BashResult]):
                 f"stderr:{sep}{self.result.stderr}", classes="tool-result-detail"
             )
         yield from self._footer()
+
+    async def on_click(self) -> None:
+        if self._overflow_widget is None:
+            return
+        self._inner_collapsed = not self._inner_collapsed
+        self._overflow_widget.display = not self._inner_collapsed
+        if self._toggle_triangle:
+            self._toggle_triangle.update("▼" if not self._inner_collapsed else "▶")
+        if self._inner_collapsed and self._toggle_row:
+            self._toggle_row.scroll_visible()
 
 
 class WriteFileApprovalWidget(ToolApprovalWidget[WriteFileArgs]):


### PR DESCRIPTION
## Summary

- **Banner**: moved the PetitChat cat animation above the info text (was side-by-side) by swapping the outer `Horizontal` container to `VerticalGroup`
- **Agent bash results**: replaced the old 10-line truncation hint with a `▶ N lines` collapsed toggle — clicking expands all stdout inline; clicking again collapses and scrolls the toggle back into view
- **User `!command` output**: same expandable toggle pattern with a 3-line preview and `▶ +N more lines` overflow row
- **Reasoning indicator**: shows `■` on completion instead of `✓`, matching the pulse spinner's in-progress character for visual consistency

## Test plan

- [ ] Launch vibe and confirm cat appears above banner text, not beside it
- [ ] Run an agent bash command with >1 line of output — confirm `▶ N lines` is shown collapsed by default
- [ ] Click the collapsed bash result to expand, click again to collapse and verify viewport snaps back to the toggle row
- [ ] Type `! ls -la` and confirm the 3-line preview + overflow toggle works for user commands
- [ ] Trigger a thinking/reasoning step and confirm the indicator shows `■` after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)