### PR TITLE
fix(config): respect active_model overrides from project level config

### DIFF
--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -28,6 +28,7 @@ import tomli_w
 
 from vibe.core.agents.models import BuiltinAgentName
 from vibe.core.config.harness_files import get_harness_files_manager
+from vibe.core.config.schema import WithReplaceMerge
 from vibe.core.logger import logger
 from vibe.core.paths import GLOBAL_ENV_FILE, SESSION_LOG_DIR
 from vibe.core.prompts import UtilityPrompt, load_prompt, load_system_prompt
@@ -497,7 +498,7 @@ DEFAULT_THEME = "ansi-dark"
 
 
 class VibeConfig(BaseSettings):
-    active_model: str = DEFAULT_ACTIVE_MODEL
+    active_model: Annotated[str, WithReplaceMerge()] = DEFAULT_ACTIVE_MODEL
     vim_keybindings: bool = False
     theme: str = DEFAULT_THEME
     disable_welcome_banner_animation: bool = False


### PR DESCRIPTION
Fixes #657.

### Bug
Previously, the `active_model` setting in `VibeConfig` was lacking the `WithReplaceMerge()` Pydantic annotation. This caused the configuration builder to ignore custom `active_model` string values specified in the project's `.vibe/config.toml` and fall back to the global default.

### Fix
Adding `Annotated[str, WithReplaceMerge()]` ensures that the project-level alias configuration correctly overrides the global settings, so commands like `vibe -p "What model am I using?"` will correctly use the locally requested custom model alias.

Bounty Wallet: 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp (Solana) / Algora