### PR TITLE
Honor model max output token config

### DIFF
--- a/tests/stubs/fake_backend.py
+++ b/tests/stubs/fake_backend.py
@@ -35,6 +35,7 @@ class FakeBackend:
         self._requests_messages: list[list[LLMMessage]] = []
         self._requests_extra_headers: list[dict[str, str] | None] = []
         self._requests_metadata: list[dict[str, str] | None] = []
+        self._requests_max_tokens: list[int | None] = []
         self._exception_to_raise = exception_to_raise
 
         self._streams: list[list[LLMChunk]]
@@ -67,6 +68,10 @@ class FakeBackend:
     def requests_metadata(self) -> list[dict[str, str] | None]:
         return self._requests_metadata
 
+    @property
+    def requests_max_tokens(self) -> list[int | None]:
+        return self._requests_max_tokens
+
     async def __aenter__(self):
         return self
 
@@ -91,6 +96,7 @@ class FakeBackend:
         self._requests_messages.append(list(messages))
         self._requests_extra_headers.append(extra_headers)
         self._requests_metadata.append(metadata)
+        self._requests_max_tokens.append(max_tokens)
 
         if self._streams:
             stream = self._streams.pop(0)
@@ -119,6 +125,7 @@ class FakeBackend:
         self._requests_messages.append(list(messages))
         self._requests_extra_headers.append(extra_headers)
         self._requests_metadata.append(metadata)
+        self._requests_max_tokens.append(max_tokens)
 
         if self._streams:
             stream = list(self._streams.pop(0))

--- a/tests/test_agent_backend.py
+++ b/tests/test_agent_backend.py
@@ -119,6 +119,25 @@ async def test_updates_tokens_stats_based_on_backend_response_streaming(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("enable_streaming", [False, True])
+async def test_uses_model_max_output_tokens_for_assistant_turn(
+    enable_streaming: bool,
+) -> None:
+    model = ModelConfig(
+        name="test-model", provider="mistral", alias="test", max_output_tokens=123
+    )
+    config = build_test_vibe_config(models=[model])
+    backend = FakeBackend([mock_llm_chunk(content="Response")])
+    agent = build_test_agent_loop(
+        config=config, backend=backend, enable_streaming=enable_streaming
+    )
+
+    [_ async for _ in agent.act("Hello")]
+
+    assert backend.requests_max_tokens == [123]
+
+
+@pytest.mark.asyncio
 async def test_passes_session_id_to_backend(vibe_config: VibeConfig):
     backend = FakeBackend([mock_llm_chunk(content="Response")])
     agent = build_test_agent_loop(config=vibe_config, backend=backend)

--- a/vibe/core/agent_loop.py
+++ b/vibe/core/agent_loop.py
@@ -1362,6 +1362,9 @@ class AgentLoop:  # noqa: PLR0904
 
         available_tools = self.format_handler.get_available_tools(self.tool_manager)
         tool_choice = self.format_handler.get_tool_choice()
+        request_max_tokens = (
+            max_tokens if max_tokens is not None else active_model.max_output_tokens
+        )
 
         last_user_message = self._last_user_message()
         self.telemetry_client.send_request_sent(
@@ -1384,7 +1387,7 @@ class AgentLoop:  # noqa: PLR0904
                 tools=available_tools,
                 tool_choice=tool_choice,
                 extra_headers=self._get_extra_headers(provider),
-                max_tokens=max_tokens,
+                max_tokens=request_max_tokens,
                 metadata=backend_metadata.model_dump(exclude_none=True),
             )
             end_time = time.perf_counter()
@@ -1425,6 +1428,9 @@ class AgentLoop:  # noqa: PLR0904
 
         available_tools = self.format_handler.get_available_tools(self.tool_manager)
         tool_choice = self.format_handler.get_tool_choice()
+        request_max_tokens = (
+            max_tokens if max_tokens is not None else active_model.max_output_tokens
+        )
 
         last_user_message = self._last_user_message()
         self.telemetry_client.send_request_sent(
@@ -1449,7 +1455,7 @@ class AgentLoop:  # noqa: PLR0904
                 tools=available_tools,
                 tool_choice=tool_choice,
                 extra_headers=self._get_extra_headers(),
-                max_tokens=max_tokens,
+                max_tokens=request_max_tokens,
                 metadata=backend_metadata.model_dump(exclude_none=True),
             ):
                 if chunk.correlation_id:

--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -381,6 +381,7 @@ class ModelConfig(BaseModel):
     thinking: ThinkingLevel = "off"
     supports_images: bool = False
     auto_compact_threshold: int = DEFAULT_AUTO_COMPACT_THRESHOLD
+    max_output_tokens: int | None = None
     _default_alias_to_name = model_validator(mode="before")(_default_alias_to_name)
 
 

--- a/vibe/core/skills/builtins/vibe.py
+++ b/vibe/core/skills/builtins/vibe.py
@@ -126,6 +126,7 @@ input_price = 1.5
 output_price = 7.5
 thinking = "high"                 # "off", "low", "medium", "high", "max"
 auto_compact_threshold = 200000
+max_output_tokens = 49152         # optional cap for each model response
 supports_images = true            # vision-capable; allows @-mentioned images
 
 [[models]]

--- a/vibe/core/skills/builtins/vibe.py
+++ b/vibe/core/skills/builtins/vibe.py
@@ -126,7 +126,6 @@ input_price = 1.5
 output_price = 7.5
 thinking = "high"                 # "off", "low", "medium", "high", "max"
 auto_compact_threshold = 200000
-max_output_tokens = 49152         # optional cap for each model response
 supports_images = true            # vision-capable; allows @-mentioned images
 
 [[models]]


### PR DESCRIPTION
## Summary

Adds a model-level `max_output_tokens` config field and uses it as the default `max_tokens` for normal assistant turns when set. The field remains unset by default. Explicit `max_tokens` passed by call sites still takes precedence, so special paths such as compaction can keep their own limits.

This lets callers configure a Vibe response cap in `config.toml` instead of clamping requests in downstream runtime/server plumbing. Companion Orchestral PR: https://github.com/mistralai/mistral/pull/18131.

## Reviewer Guide

- `vibe/core/config/_settings.py`: adds optional `ModelConfig.max_output_tokens`.
- `vibe/core/agent_loop.py`: applies the model config value when `_chat()` / `_chat_streaming()` are called without an explicit `max_tokens`.
- `tests/stubs/fake_backend.py`: records requested `max_tokens` so tests can assert the value propagated.
- `tests/test_agent_backend.py`: covers streaming and non-streaming assistant turns using the model-level cap.

No default cap is added to built-in skills or default config. The value is only honored when the caller explicitly sets it in the model config.

## End-to-End Validation

Validated together with companion Orchestral PR #18131, which writes task `max_gen_toks` into `.vibe/config.toml` as `max_output_tokens`.

- SLURM job `1746883` completed successfully (`COMPLETED 0:0`) in 5m56s on QoS `dev`.
- Output dir: `/mnt/vast/runs/faruk.ahmed/vibe_cap_e2e_live_260608_0p6b_cap128_dev`.
- Task: `skillsbench_vibe[max_steps=1|max_gen_toks=128|vibe_version=git+https://github.com/farukahmed-mistral/mistral-vibe.git@faruk.ahmed/vibe-max-output-tokens-config]` against local vLLM `rafale` served from `/mnt/vast/ci/models/241121_mistral-draft-0.6b-2504/consolidated`.
- `jobs/1746883/slurm.out` shows this Vibe git branch installed, the generated Vibe config, and `max_output_tokens = 128`.
- `results/skillsbench_vibe/747ac992/logs/3d-scan-calc/records.log` line 1 is the actual Vibe-agent model request/response: request `max_tokens=128`, response model `rafale`, `completion_tokens=29`, `finish_reason=stop`, `errors=[]`.
- `results/skillsbench_vibe/747ac992/logs/eval.log` shows the instance finished 1 step, scoring ran, and scored generations were saved.

Caveat: the vLLM server was launched with `--no-enable-log-requests`, so the per-request cap is visible in the saved Thunderdome/Orchestral request record rather than in vLLM access logs.

## Test Plan

- `uv run pytest tests/test_agent_backend.py tests/core/test_config_resolution.py -q`
- `uv run pytest tests/test_agent_backend.py::test_uses_model_max_output_tokens_for_assistant_turn -q`
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pyright`
- End-to-end live run with companion Orchestral PR #18131: SLURM job `1746883`, output dir `/mnt/vast/runs/faruk.ahmed/vibe_cap_e2e_live_260608_0p6b_cap128_dev`, completed `COMPLETED 0:0` and recorded a real Vibe-agent request with `max_tokens=128`.
