### PR TITLE
Fix SSE event handling for keep alive of old connection.

### DIFF
--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -417,7 +417,7 @@ class GenericBackend:
                 await response.aread()
             response.raise_for_status()
             async for line in response.aiter_lines():
-                if line.strip() == "":
+                if line.strip() == "" or line.strip().startswith(":"):
                     continue
 
                 DELIM_CHAR = ":"


### PR DESCRIPTION
Llama.cpp sends: ':' to keep alive long HTTP connections during prompt processing. Vibe threats it as error and drops prompt processing which is disrupting long conversations.

Fixes bug: https://github.com/mistralai/mistral-vibe/issues/762#issue-4629629273