### PR TITLE
fix: add configurable cost_currency display setting (closes #736)

### DIFF
--- a/vibe/acp/acp_agent_loop.py
+++ b/vibe/acp/acp_agent_loop.py
@@ -854,8 +854,9 @@ class VibeAcpAgentLoop(AcpAgent):
     def _build_usage_update(self, session: AcpSessionLoop) -> UsageUpdate:
         stats = session.agent_loop.stats
         active_model = session.agent_loop.config.get_active_model()
+        currency = session.agent_loop.config.cost_currency.upper()
         cost = (
-            Cost(amount=stats.session_cost, currency="USD")
+            Cost(amount=stats.session_cost, currency=currency)
             if stats.input_price_per_million > 0 or stats.output_price_per_million > 0
             else None
         )

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -213,6 +213,7 @@ from vibe.core.utils import (
     get_user_cancellation_message,
     is_dangerous_directory,
 )
+from vibe.core.utils.display import format_cost
 
 _VSCODE_FAMILY_TERMINALS = {Terminal.VSCODE, Terminal.VSCODE_INSIDERS, Terminal.CURSOR}
 
@@ -2112,7 +2113,7 @@ class VibeApp(App):  # noqa: PLR0904
 - **Session Completion Tokens**: {stats.session_completion_tokens:,}
 - **Session Total LLM Tokens**: {stats.session_total_llm_tokens:,}
 - **Last Turn Tokens**: {stats.last_turn_total_tokens:,}
-- **Cost**: ${stats.session_cost:.4f}
+- **Cost**: {format_cost(stats.session_cost, self.config.cost_currency)}
 """
         await self._mount_and_scroll(UserCommandMessage(status_text))
 

--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -612,6 +612,7 @@ class VibeConfig(BaseSettings):
     enable_update_checks: bool = True
     enable_notifications: bool = True
     enable_system_trust_store: bool = False
+    cost_currency: str = "USD"
     api_timeout: float = DEFAULT_API_TIMEOUT
     auto_compact_threshold: int = DEFAULT_AUTO_COMPACT_THRESHOLD
 

--- a/vibe/core/config/vibe_schema.py
+++ b/vibe/core/config/vibe_schema.py
@@ -227,6 +227,7 @@ class VibeConfigSchema(ConfigSchema):
     enable_auto_update: Annotated[bool, WithReplaceMerge()] = True
     enable_notifications: Annotated[bool, WithReplaceMerge()] = True
     enable_system_trust_store: Annotated[bool, WithReplaceMerge()] = False
+    cost_currency: Annotated[str, WithReplaceMerge()] = "USD"
     api_timeout: Annotated[float, WithReplaceMerge()] = DEFAULT_API_TIMEOUT
     vibe_base_url: Annotated[str, WithReplaceMerge()] = DEFAULT_VIBE_BASE_URL
     vibe_code_sessions_base_url: Annotated[str, WithReplaceMerge()] = (

--- a/vibe/core/utils/display.py
+++ b/vibe/core/utils/display.py
@@ -2,6 +2,21 @@ from __future__ import annotations
 
 from vibe.core.session.session_id import shorten_session_id
 
+_CURRENCY_SYMBOLS: dict[str, str] = {
+    "USD": "$",
+    "EUR": "€",
+    "GBP": "£",
+    "JPY": "¥",
+    "CAD": "CA$",
+    "AUD": "A$",
+    "CHF": "Fr",
+}
+
+
+def format_cost(amount: float, currency: str = "USD") -> str:
+    symbol = _CURRENCY_SYMBOLS.get(currency.upper(), f"{currency.upper()} ")
+    return f"{symbol}{amount:.4f}"
+
 
 def compact_complete_display(
     old_session_id: str | None = None, new_session_id: str | None = None


### PR DESCRIPTION
## Summary

Fixes #736 — cost is hardcoded to USD in both the TUI `/stats` command and the ACP layer that feeds the VS Code extension.

- Adds a `cost_currency` config option (default `"USD"`) to `VibeConfig` and `VibeConfigSchema`
- Adds a `format_cost(amount, currency)` helper in `vibe/core/utils/display.py` with a symbol map for common currencies (USD, EUR, GBP, JPY, CAD, AUD, CHF); unknown codes fall back to the ISO code as prefix
- Wires `cost_currency` into the `/stats` TUI command (`app.py`) and the ACP usage update (`acp_agent_loop.py`) that the VS Code extension consumes

## Usage

```toml
# ~/.vibe/config.toml
cost_currency = "EUR"
```

The cost display changes from `$0.0042` to `€0.0042`.

> **Note:** Mistral API pricing is denominated in USD. This setting controls the display label only — no currency conversion is applied.

## Test plan

- [x] `uv run pyright` — 0 errors
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest` — 72/72 passed