### PR TITLE
fix: strip UTF-8 BOM from SKILL.md before parsing frontmatter

### DIFF
--- a/vibe/core/skills/parser.py
+++ b/vibe/core/skills/parser.py
@@ -16,6 +16,7 @@ FM_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)
 
 
 def parse_skill_markdown(content: str) -> tuple[dict[str, Any], str]:
+    content = content.lstrip("﻿")
     splits = FM_BOUNDARY.split(content, 2)
     if len(splits) < 3 or splits[0].strip():  # noqa: PLR2004
         raise SkillParseError(


### PR DESCRIPTION
## Problem

On Windows, text editors often save files with a UTF-8 BOM (Byte Order Mark, `﻿`) prepended.
When a SKILL.md is created or edited on Windows and then loaded by Vibe, the leading BOM character
prevents the YAML frontmatter regex from matching, raising a `SkillParseError` or silently
skipping the skill entirely.

Reported in #701.

## Fix

Strip the BOM at the top of `parse_skill_markdown()` before any regex split:

```python
content = content.lstrip("﻿")
```

This is a one-liner that has no effect on files without a BOM.

## Testing

- Files without BOM: unchanged behaviour
- Files with UTF-8 BOM: frontmatter now parsed correctly