### PR TITLE
fix: strip bracketed IPv6 entries from NO_PROXY to prevent startup crash

### DIFF
--- a/vibe/acp/entrypoint.py
+++ b/vibe/acp/entrypoint.py
@@ -81,11 +81,13 @@ def main() -> None:
 
     from vibe.acp.acp_agent_loop import run_acp_server
     from vibe.core.config import VibeConfig, load_dotenv_values
+    from vibe.core.proxy_setup import sanitize_no_proxy
     from vibe.core.tracing import setup_tracing
     from vibe.setup.onboarding import run_onboarding
 
     environ_before_dotenv_load = os.environ.copy()
     load_dotenv_values()
+    sanitize_no_proxy()
     bootstrap_config_files()
     args = parse_arguments()
     if args.setup:

--- a/vibe/cli/cli.py
+++ b/vibe/cli/cli.py
@@ -26,6 +26,7 @@ from vibe.core.hooks.config import HookConfigResult, load_hooks_from_fs
 from vibe.core.logger import logger
 from vibe.core.paths import HISTORY_FILE
 from vibe.core.programmatic import run_programmatic
+from vibe.core.proxy_setup import sanitize_no_proxy
 from vibe.core.session import last_session_pointer
 from vibe.core.session.session_loader import SessionLoader
 from vibe.core.telemetry.build_metadata import build_entrypoint_metadata
@@ -297,6 +298,7 @@ def _maybe_run_startup_update_prompt(
 
 def run_cli(args: argparse.Namespace) -> None:
     load_dotenv_values()
+    sanitize_no_proxy()
     bootstrap_config_files()
 
     if args.setup:

--- a/vibe/core/proxy_setup.py
+++ b/vibe/core/proxy_setup.py
@@ -1,8 +1,25 @@
 from __future__ import annotations
 
+import os
+import re
+
 from dotenv import dotenv_values, set_key, unset_key
 
 from vibe.core.paths import GLOBAL_ENV_FILE
+
+_BRACKETED_IPV6 = re.compile(r"^\[.*\]$")
+
+
+def sanitize_no_proxy() -> None:
+    for key in ("NO_PROXY", "no_proxy"):
+        value = os.environ.get(key)
+        if not value:
+            continue
+        cleaned = ",".join(
+            e for e in value.split(",") if not _BRACKETED_IPV6.match(e.strip())
+        )
+        os.environ[key] = cleaned
+
 
 SUPPORTED_PROXY_VARS: dict[str, str] = {
     "HTTP_PROXY": "Proxy URL for HTTP requests",


### PR DESCRIPTION
## Problem

In corporate environments it is common for `NO_PROXY` (or `no_proxy`) to contain
bracketed IPv6 addresses such as `[::1]` or `[fe80::1]`. `httpx` does not accept
this notation and raises an unhandled exception at startup, making the CLI
completely unusable on affected machines.

Reported in #759.

## Root cause

`httpx` expects bare IPv6 addresses (e.g. `::1`) in `NO_PROXY`, not the bracketed
form (`[::1]`) used by some tools and proxy configuration utilities.

## Fix

Add `sanitize_no_proxy()` in `vibe/core/proxy_setup.py` that strips any
comma-separated entry matching `[...]` before `httpx` reads the variable:

```python
_BRACKETED_IPV6 = re.compile(r"^\[.*\]$")

def sanitize_no_proxy() -> None:
    for key in ("NO_PROXY", "no_proxy"):
        value = os.environ.get(key)
        if not value:
            continue
        cleaned = ",".join(
            e for e in value.split(",") if not _BRACKETED_IPV6.match(e.strip())
        )
        os.environ[key] = cleaned
```

Call it immediately after `load_dotenv_values()` in both the CLI and ACP entrypoints.

## Notes

- Bare IPv6 addresses (e.g. `::1`) are left untouched
- Bracketed entries are silently removed; `httpx` will still use `HTTPS_PROXY`/`HTTP_PROXY` for those hosts, which is acceptable — the alternative is a hard crash