### PR TITLE
fix: replace LC_ALL with LC_CTYPE in bash tool environment

### DIFF
--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -82,7 +82,7 @@ def _get_base_env() -> dict[str, str]:
         base_env["GIT_PAGER"] = "cat"
         base_env["PAGER"] = "cat"
         base_env["LESS"] = "-FX"
-        base_env["LC_ALL"] = "en_US.UTF-8"
+        base_env["LC_CTYPE"] = "en_US.UTF-8"
 
     return base_env
 


### PR DESCRIPTION
## Problem

The bash tool forces `LC_ALL=en_US.UTF-8` for all subprocess executions.
`LC_ALL` overrides **every** locale category — `LC_MESSAGES`, `LC_TIME`,
`LC_NUMERIC`, `LC_COLLATE` — and that setting propagates to all child processes.

Concrete impact on non-English systems:
- GUI processes restarted through the bash tool (e.g. KDE Plasma via `kstart5 plasmashell`) switch to English because they inherit the forced locale
- `date` output, number formatting, and sort order all switch to US conventions
- Users in non-English locales cannot reproduce consistent behaviour between running commands in the terminal vs. through Vibe

Reported in #659.

## Fix

Replace `LC_ALL` with `LC_CTYPE`:

```python
# before
base_env["LC_ALL"] = "en_US.UTF-8"

# after
base_env["LC_CTYPE"] = "en_US.UTF-8"
```

`LC_CTYPE` only controls character classification and encoding, which is what we actually need (reliable UTF-8 output from subprocesses). It does not affect language, date format, or number formatting.

## Testing

All 39 existing bash tool tests pass unchanged.