### PR TITLE
fix: anchor completion popup to input box top to stop overlaying prompt text

### DIFF
--- a/vibe/cli/textual_ui/widgets/chat_input/container.py
+++ b/vibe/cli/textual_ui/widgets/chat_input/container.py
@@ -182,11 +182,16 @@ class ChatInputContainer(Vertical):
         widget = self.input_widget
         if not widget:
             return
-        cursor = widget.cursor_screen_offset
         my_region = self.region
-        # Place popup bottom edge just above the cursor row
         popup_height = self._compute_line_count(suggestions) + 2  # +2 for solid border
-        offset = (cursor.x - my_region.x, cursor.y - popup_height - my_region.y)
+        # Anchor the popup bottom to the top of the input box so multi-line
+        # text above the cursor is never obscured.
+        try:
+            input_box = self.get_widget_by_id(self.ID_INPUT_BOX)
+            anchor_y = input_box.region.y
+        except Exception:
+            anchor_y = widget.cursor_screen_offset.y
+        offset = (0, anchor_y - popup_height - my_region.y)
         popup.styles.offset = offset
 
     def _format_insertion(self, replacement: str, suffix: str) -> str:


### PR DESCRIPTION
## Problem

When typing a slash command after already having text in the prompt,
the completion popup is positioned at the cursor row and extends upward.
On a multi-line input this causes the popup to cover the lines typed
above the cursor, hiding text the user has already written.

Additionally, since the horizontal offset is set to `cursor.x`, the popup
can extend off-screen to the right when the cursor is near the terminal edge.

Reported in #722.

## Root cause

`_position_popup` in `container.py` computes the popup's Y offset relative
to `cursor.y`. For a single-line input this is fine, but the moment the input
wraps to multiple lines the popup covers those earlier lines.

## Fix

Anchor the popup's bottom edge to the **top of the input box widget** rather
than the cursor row. This guarantees the popup never overlaps any part of the
input text, regardless of how many lines have been typed.

Also pin the horizontal offset to `0` (left-aligned to the container) so the
popup is always fully visible.

```python
# before
cursor = widget.cursor_screen_offset
offset = (cursor.x - my_region.x, cursor.y - popup_height - my_region.y)

# after
input_box = self.get_widget_by_id(self.ID_INPUT_BOX)
anchor_y = input_box.region.y
offset = (0, anchor_y - popup_height - my_region.y)
```