### PR TITLE
fix: increase ask_user_question header max_length from 12 to 20

### DIFF
--- a/vibe/core/tools/builtins/ask_user_question.py
+++ b/vibe/core/tools/builtins/ask_user_question.py
@@ -29,8 +29,8 @@ class Question(BaseModel):
     question: str = Field(description="The question text")
     header: str = Field(
         default="",
-        description="Short header for the question (1-2 words, e.g. 'Auth', 'Database')",
-        max_length=12,
+        description="Short chip/tag label for the question (max 20 chars)",
+        max_length=20,
     )
     options: list[Choice] = Field(
         description="Available options (2-4, not including 'Other'). An 'Other' option for free text is automatically added.",


### PR DESCRIPTION
## Problem

The `header` field of `ask_user_question` has a `max_length=12` constraint.
Common two-word labels like `"Backend Setup"` (13 chars), `"Auth Method"` (11 chars)
or `"File Format"` (11 chars) sit right at or above the limit. When the model
generates a header that exceeds 12 characters the tool call fails with a Pydantic
validation error mid-conversation:

```
ask_user_question: Invalid arguments: 1 validation error for AskUserQuestionArgs
questions.0.header
  String should have at most 12 characters [type=string_too_long, ...]
```

Reported in #584.

## Fix

Raise `max_length` from `12` to `20` and update the field description with
realistic examples that reflect the actual range of useful labels.

```python
# before
header: str = Field(
    default="",
    description="Short header for the question (1-2 words, e.g. 'Auth', 'Database')",
    max_length=12,
)

# after
header: str = Field(
    default="",
    description="Short label for the question displayed as a chip/tag (max 20 chars, e.g. 'Auth method', 'Library', 'Approach')",
    max_length=20,
)
```

The constraint is kept (20 chars still prevents runaway headers) while covering
the natural range of short descriptive two-word labels.