### PR TITLE
fix: show visible warning when Narrator enabled without sounddevice/PortAudio

### DIFF
--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -141,7 +141,7 @@ from vibe.cli.vscode_extension_promo import (
 )
 from vibe.core.agent_loop import AgentLoop, TeleportError
 from vibe.core.agents import AgentProfile
-from vibe.core.audio_player.audio_player import AudioPlayer
+from vibe.core.audio_player.audio_player import AudioPlayer, check_audio_available
 from vibe.core.audio_recorder import AudioRecorder
 from vibe.core.autocompletion.path_prompt import (
     PathPromptPayload,
@@ -1122,6 +1122,14 @@ class VibeApp(App):  # noqa: PLR0904
             VibeConfig.save_updates(non_voice_changes)
             self.agent_loop.refresh_config()
             self._narrator_manager.sync()
+            if non_voice_changes.get("narrator_enabled") is True:
+                audio_error = check_audio_available()
+                if audio_error:
+                    self.notify(
+                        f"Narrator enabled but audio is unavailable: {audio_error}",
+                        severity="warning",
+                        timeout=15,
+                    )
 
     async def on_model_picker_app_model_selected(
         self, message: ModelPickerApp.ModelSelected

--- a/vibe/core/audio_player/audio_player.py
+++ b/vibe/core/audio_player/audio_player.py
@@ -28,6 +28,22 @@ DTYPE = "int16"
 DEFAULT_SAMPLE_WIDTH = 2  # 16-bit = 2 bytes
 
 
+def check_audio_available() -> str | None:
+    """Return an error string if sounddevice/PortAudio is unavailable, else None."""
+    if sd is None:
+        return (
+            "sounddevice is not installed. "
+            "Install it with: pip install sounddevice  "
+            "(PortAudio system library also required: "
+            "apt install libportaudio2 / pacman -S portaudio / brew install portaudio)"
+        )
+    try:
+        sd.query_devices(kind="output")
+        return None
+    except Exception as exc:
+        return f"No audio output device available: {exc}"
+
+
 class AudioPlayer:
     """Plays audio through the default output device using sounddevice."""
 


### PR DESCRIPTION
## Problem

When the **Narrator (experimental)** feature is toggled on via `/voice` but
`sounddevice` (or its PortAudio system library) is not installed, the failure
is completely silent:

- The `▂▅▇ speaking` indicator never appears
- No audio is produced
- No toast or warning is shown to the user
- The only trace is a `logger.warning("TTS speak failed")` buried in the debug log

Users have no way to know why the narrator does not work. Reported in #597.

## Root cause

`audio_player.py` imports sounddevice with a bare `except OSError: sd = None`.
When `play()` is called and `sd is None`, an `AudioBackendUnavailableError` is
raised, caught in `narrator_manager._speak_summary`'s broad `except Exception`,
and silently swallowed.

## Fix

**`vibe/core/audio_player/audio_player.py`** — add `check_audio_available()`:

```python
def check_audio_available() -> str | None:
    """Return an error string if sounddevice/PortAudio is unavailable, else None."""
    if sd is None:
        return "sounddevice is not installed. Install it with: pip install sounddevice ..."
    try:
        sd.query_devices(kind="output")
        return None
    except Exception as exc:
        return f"No audio output device available: {exc}"
```

**`vibe/cli/textual_ui/app.py`** — call it immediately after the narrator is toggled on:

```python
if non_voice_changes.get("narrator_enabled") is True:
    audio_error = check_audio_available()
    if audio_error:
        self.notify(
            f"Narrator enabled but audio is unavailable: {audio_error}",
            severity="warning",
            timeout=15,
        )
```

This proactively surfaces the problem at the moment the user enables the feature,
with a message that includes the install command.