### PR TITLE
fix: prevent TUI crash and show actionable error when active model is missing

### DIFF
--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -659,8 +659,9 @@ class VibeApp(App):  # noqa: PLR0904
         context_progress = self.query_one(ContextProgress)
 
         def update_context_progress(stats: AgentStats) -> None:
+            active_model = self._active_model_or_none()
             context_progress.tokens = TokenState(
-                max_tokens=self.config.get_active_model().auto_compact_threshold,
+                max_tokens=active_model.auto_compact_threshold if active_model else 0,
                 current_tokens=stats.context_tokens,
             )
 
@@ -699,6 +700,15 @@ class VibeApp(App):  # noqa: PLR0904
         gc.freeze()
 
     def _show_config_issues(self) -> None:
+        if self._active_model_or_none() is None:
+            self.notify(
+                f"Active model '{self.config.active_model}' not found. "
+                "Use /model to select a different model "
+                "or update 'active_model' in your config.",
+                severity="error",
+                timeout=20,
+                markup=False,
+            )
         for issue in (
             *self.agent_loop.hook_config_issues,
             *self.agent_loop.skill_manager.config_issues,


### PR DESCRIPTION
## Problem

When `active_model` in `config.toml` refers to an alias that does not exist
in the `models` list (e.g. after manually editing the config or removing a
custom model), `get_active_model()` raises `ValueError`. In `on_mount` this
was called directly inside the `update_context_progress` stats listener,
propagating an unhandled exception that crashes the TUI before the user sees
anything useful.

Reported in #632.

## Root cause

```python
# on_mount — crashes if active_model alias is not found
def update_context_progress(stats: AgentStats) -> None:
    context_progress.tokens = TokenState(
        max_tokens=self.config.get_active_model().auto_compact_threshold,  # ValueError!
        current_tokens=stats.context_tokens,
    )
```

## Fix

**Two changes in `app.py`:**

1. Use `_active_model_or_none()` (already exists, wraps the ValueError) inside
   `update_context_progress` so a missing model yields a zero threshold instead
   of an unhandled exception:

```python
def update_context_progress(stats: AgentStats) -> None:
    active_model = self._active_model_or_none()
    context_progress.tokens = TokenState(
        max_tokens=active_model.auto_compact_threshold if active_model else 0,
        current_tokens=stats.context_tokens,
    )
```

2. In `_show_config_issues()` (called on every startup and config reload), detect a
   missing active model and surface an error-severity toast with clear instructions:

```python
if self._active_model_or_none() is None:
    self.notify(
        f"Active model '{self.config.active_model}' not found in configuration. "
        "Use /model to pick a different model or update 'active_model' in your config.",
        severity="error",
        timeout=20,
        markup=False,
    )
```

The TUI now starts correctly and the user immediately sees what is wrong and how to fix it.