### PR TITLE
fix: pass reasoning_effort in OpenAI-compatible backend payload

### DIFF
--- a/tests/backend/test_backend.py
+++ b/tests/backend/test_backend.py
@@ -38,7 +38,7 @@ from tests.backend.data.mistral import (
 )
 from vibe.core.config import ModelConfig, ProviderConfig
 from vibe.core.llm.backend.factory import BACKEND_FACTORY
-from vibe.core.llm.backend.generic import GenericBackend
+from vibe.core.llm.backend.generic import GenericBackend, OpenAIAdapter
 from vibe.core.llm.backend.mistral import MistralBackend, MistralMapper
 from vibe.core.llm.exceptions import BackendError, BackendErrorBuilder
 from vibe.core.llm.types import BackendLike
@@ -581,6 +581,39 @@ class TestMistralMapperPrepareMessage:
         msg = LLMMessage(role=Role.assistant, content="Hello!")
         result = mapper.prepare_message(msg)
         assert result.content == "Hello!"
+
+
+class TestGenericBackendReasoningEffort:
+    """Tests that GenericBackend includes reasoning_effort in the HTTP payload."""
+
+    @pytest.mark.parametrize(
+        ("thinking", "expect_in_payload"),
+        [
+            ("off", False),
+            ("low", True),
+            ("medium", True),
+            ("high", True),
+        ],
+    )
+    def test_build_payload_reasoning_effort(
+        self,
+        thinking: str,
+        expect_in_payload: bool,
+    ) -> None:
+        adapter = OpenAIAdapter()
+        payload = adapter.build_payload(
+            model_name="test-model",
+            converted_messages=[{"role": "user", "content": "hi"}],
+            temperature=0.7,
+            tools=None,
+            max_tokens=None,
+            tool_choice=None,
+            thinking=thinking,
+        )
+        if expect_in_payload:
+            assert payload["reasoning_effort"] == thinking
+        else:
+            assert "reasoning_effort" not in payload
 
 
 class TestMistralBackendReasoningEffort:

--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -41,6 +41,7 @@ class OpenAIAdapter(APIAdapter):
         tools: list[AvailableTool] | None,
         max_tokens: int | None,
         tool_choice: StrToolChoice | AvailableTool | None,
+        thinking: str = "off",
     ) -> dict[str, Any]:
         payload = {
             "model": model_name,
@@ -48,6 +49,8 @@ class OpenAIAdapter(APIAdapter):
             "temperature": temperature,
         }
 
+        if thinking != "off":
+            payload["reasoning_effort"] = thinking
         if tools:
             payload["tools"] = [tool.model_dump(exclude_none=True) for tool in tools]
         if tool_choice:
@@ -133,7 +136,13 @@ class OpenAIAdapter(APIAdapter):
         ]
 
         payload = self.build_payload(
-            model_name, converted_messages, temperature, tools, max_tokens, tool_choice
+            model_name,
+            converted_messages,
+            temperature,
+            tools,
+            max_tokens,
+            tool_choice,
+            thinking,
         )
 
         if enable_streaming:


### PR DESCRIPTION
## Problem

When using a provider with `api_style = "openai"` and a model configured with
`thinking = "low"` / `"medium"` / `"high"`, the `reasoning_effort` field is
**never included** in the outgoing HTTP payload.

As a result, the model responds without activating reasoning and no
`reasoning_content` is returned — even when the endpoint fully supports it
(verified by direct `curl` with `"reasoning_effort": "high"` returning
`reasoning_content` correctly).

Reported in #560.

## Root cause

`OpenAIAdapter.prepare_request()` receives `thinking` as a parameter but never
forwards it to `build_payload()`, which also has no `thinking` parameter:

```python
# before — thinking is silently dropped
payload = self.build_payload(
    model_name, converted_messages, temperature, tools, max_tokens, tool_choice
)
```

## Fix

Add `thinking: str = "off"` to `build_payload()` and set `reasoning_effort`
in the payload when `thinking != "off"`. Forward `thinking` from
`prepare_request()`.

```python
# build_payload — new parameter + conditional field
def build_payload(self, ..., thinking: str = "off") -> dict[str, Any]:
    ...
    if thinking != "off":
        payload["reasoning_effort"] = thinking
    ...

# prepare_request — now forwards thinking
payload = self.build_payload(
    model_name, converted_messages, temperature, tools, max_tokens, tool_choice,
    thinking,
)
```

## Tests

Added `TestGenericBackendReasoningEffort` with four parametrized cases
(`off` / `low` / `medium` / `high`) mirroring the existing
`TestMistralBackendReasoningEffort` suite. All 233 backend tests pass.