### PR TITLE
fix: strip whitespace from SSE [DONE] sentinel (#770)

### DIFF
--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -434,7 +434,7 @@ class GenericBackend:
                 if key != "data":
                     # This might be the case with openrouter, so we just ignore it
                     continue
-                if value == "[DONE]":
+                if value.strip() == "[DONE]":
                     return
                 yield json.loads(value.strip())
 


### PR DESCRIPTION
## Problem

With certain OpenAI-compatible servers (Ollama, some model backends), the SSE stream terminates with `data: [DONE]\r` or `data: [DONE] ` rather than `data: [DONE]`. The comparison `value == "[DONE]"` fails, causing `json.loads("[DONE]")` to raise `JSONDecodeError`, which propagates through the async generator and cuts the stream short. Users see only the first token or word of the response.

## Fix

Change `value == "[DONE]"` to `value.strip() == "[DONE]"` in `_make_streaming_request`. This is consistent with the `.strip()` already applied on the next line when parsing JSON chunks.

## Files changed

- `vibe/core/llm/backend/generic.py` — one-character fix in `_make_streaming_request`

Fixes #770.