### PR TITLE
fix: ignore SSE comment/keep-alive lines in streaming response (#762)

### DIFF
--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -421,6 +421,9 @@ class GenericBackend:
                 if line.strip() == "":
                     continue
 
+                if line.startswith(":"):
+                    continue
+
                 DELIM_CHAR = ":"
                 if f"{DELIM_CHAR} " not in line:
                     raise ValueError(


### PR DESCRIPTION
## Problem

Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), lines beginning with `:` are comments and must be ignored. llama.cpp uses these as keep-alive heartbeats during long prompt-processing phases (e.g. reloading a 20k-token context). The current parser reaches the delimiter check before filtering comment lines, so `": " not in ":"` evaluates to `True` and raises:

```
Error: API error from llm: Stream chunk improperly formatted.
Expected `key: value`, received `:`
```

This aborts the HTTP connection and the request fails.

## Fix

Add `if line.startswith(";"): continue` immediately after the empty-line guard, before the delimiter validation. This aligns with the SSE spec and is consistent with the existing comment for non-`data` keys ("might be the case with openrouter, so we just ignore it").

## Files changed

- `vibe/core/llm/backend/generic.py` — three lines added in `_make_streaming_request`

Fixes #762.