### PR TITLE
fix: default delta.role to assistant when null in streaming chunks (#665)

### DIFF
--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -158,6 +158,8 @@ class OpenAIAdapter(APIAdapter):
                 return LLMMessage.model_validate(msg_dict)
             if "delta" in choice:
                 msg_dict = self._reasoning_from_api(choice["delta"], field_name)
+                if msg_dict.get("role") is None:
+                    msg_dict["role"] = Role.assistant
                 return LLMMessage.model_validate(msg_dict)
             raise ValueError("Invalid response data: missing message or delta")
 
@@ -166,6 +168,8 @@ class OpenAIAdapter(APIAdapter):
             return LLMMessage.model_validate(msg_dict)
         if "delta" in data:
             msg_dict = self._reasoning_from_api(data["delta"], field_name)
+            if msg_dict.get("role") is None:
+                msg_dict["role"] = Role.assistant
             return LLMMessage.model_validate(msg_dict)
 
         return None


### PR DESCRIPTION
## Problem

Per the OpenAI streaming spec, only the first SSE chunk carries `delta.role: "assistant"`. All subsequent chunks send `delta.role: null`. `_parse_message` passes the raw `msg_dict` directly to `LLMMessage.model_validate()`, which rejects `null` for the required `role` enum field:

```
1 validation error for LLMMessage
role
  Input should be 'system', 'user', 'assistant' or 'tool'
  [type=enum, input_value=None, input_type=NoneType]
```

The TUI fails on the very first prompt when connected to any spec-conforming provider (SGLang, vllm, etc.). The non-streaming path (`-p`) is unaffected because `choice.message.role` is always present in non-streaming responses.

## Fix

In both delta-handling branches of `_parse_message`, set `msg_dict["role"] = Role.assistant` when the field is `None` before validating. A model can only stream `assistant` deltas, so the default is unambiguous.

## Files changed

- `vibe/core/llm/backend/generic.py` — 4 lines added in `_parse_message`

Fixes #665.