### PR TITLE
Add --upgrade flag to force upgrade check and update

### DIFF
--- a/tests/cli/test_upgrade_flag.py
+++ b/tests/cli/test_upgrade_flag.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import sys
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import build_test_vibe_config
+from vibe.cli.cli import _handle_forced_upgrade, run_cli
+from vibe.cli.entrypoint import parse_arguments
+from vibe.cli.update_notifier import FileSystemUpdateCacheRepository, UpdateCache
+from vibe.cli.update_notifier.update import UpdateAvailability
+
+
+class TestUpgradeFlagArgumentParsing:
+    def test_upgrade_flag_is_parsed_correctly(self) -> None:
+        args = parse_arguments(["--upgrade"])
+        assert args.upgrade is True
+
+    def test_upgrade_flag_defaults_to_false(self) -> None:
+        args = parse_arguments([])
+        assert args.upgrade is False
+
+    def test_upgrade_flag_with_other_args(self) -> None:
+        args = parse_arguments(["--upgrade", "--setup"])
+        assert args.upgrade is True
+        assert args.setup is True
+
+
+class TestHandleForcedUpgrade:
+    @pytest.fixture
+    def repository(self, tmp_path: Path) -> FileSystemUpdateCacheRepository:
+        return FileSystemUpdateCacheRepository(base_path=tmp_path)
+
+    def test_upgrade_when_already_up_to_date(
+        self, repository: FileSystemUpdateCacheRepository, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test that when no update is available, it prints up-to-date message and exits 0."""
+        with (
+            patch(
+                "vibe.cli.cli.get_update_if_available",
+                return_value=None,
+            ),
+            patch("vibe.cli.cli.__version__", "1.0.0"),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            _handle_forced_upgrade()
+
+        assert excinfo.value.code == 0
+        captured = capsys.readouterr()
+        assert "✔ Vibe is up to date (v1.0.0)" in captured.out
+
+    def test_upgrade_when_update_available_and_successful(
+        self, repository: FileSystemUpdateCacheRepository, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test that when update is available and successful, it prints success and exits 0."""
+        update_availability = UpdateAvailability(
+            latest_version="2.0.0", should_notify=True
+        )
+        with (
+            patch(
+                "vibe.cli.cli.get_update_if_available",
+                return_value=update_availability,
+            ),
+            patch("vibe.cli.cli.do_update", return_value=True),
+            patch("vibe.cli.cli.__version__", "1.0.0"),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            _handle_forced_upgrade()
+
+        assert excinfo.value.code == 0
+        captured = capsys.readouterr()
+        assert "New version available: 1.0.0 → 2.0.0" in captured.out
+        assert "✔ Vibe was updated from 1.0.0 to 2.0.0" in captured.out
+
+    def test_upgrade_when_update_available_but_fails(
+        self, repository: FileSystemUpdateCacheRepository, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test that when update is available but fails, it prints error and exits 1."""
+        update_availability = UpdateAvailability(
+            latest_version="2.0.0", should_notify=True
+        )
+        with (
+            patch(
+                "vibe.cli.cli.get_update_if_available",
+                return_value=update_availability,
+            ),
+            patch("vibe.cli.cli.do_update", return_value=False),
+            patch("vibe.cli.cli.__version__", "1.0.0"),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            _handle_forced_upgrade()
+
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "New version available: 1.0.0 → 2.0.0" in captured.out
+        assert "✗ Vibe could not be updated automatically" in captured.out
+
+    def test_upgrade_when_update_check_fails(
+        self, repository: FileSystemUpdateCacheRepository, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test that when update check fails, it prints error and exits 1."""
+        with (
+            patch(
+                "vibe.cli.cli.get_update_if_available",
+                side_effect=Exception("Network error"),
+            ),
+            patch("vibe.cli.cli.__version__", "1.0.0"),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            _handle_forced_upgrade()
+
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "✗ Failed to check for updates" in captured.out
+
+    def test_upgrade_when_update_fails_with_exception(
+        self, repository: FileSystemUpdateCacheRepository, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Test that when update process fails with exception, it prints error and exits 1."""
+        update_availability = UpdateAvailability(
+            latest_version="2.0.0", should_notify=True
+        )
+        with (
+            patch(
+                "vibe.cli.cli.get_update_if_available",
+                return_value=update_availability,
+            ),
+            patch("vibe.cli.cli.do_update", side_effect=Exception("Update failed")),
+            patch("vibe.cli.cli.__version__", "1.0.0"),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            _handle_forced_upgrade()
+
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "✗ Vibe could not be updated automatically" in captured.out
+
+
+class TestRunCliWithUpgradeFlag:
+    def test_run_cli_with_upgrade_flag_calls_handle_forced_upgrade(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that run_cli calls _handle_forced_upgrade when --upgrade flag is set."""
+        args = parse_arguments(["--upgrade"])
+        
+        with (
+            patch("vibe.cli.cli._handle_forced_upgrade") as mock_handle_upgrade,
+            patch("vibe.cli.cli.load_dotenv_values"),
+            patch("vibe.cli.cli.bootstrap_config_files"),
+            pytest.raises(SystemExit),
+        ):
+            run_cli(args)
+        
+        mock_handle_upgrade.assert_called_once()
+
+    def test_run_cli_without_upgrade_flag_does_not_call_handle_forced_upgrade(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that run_cli does not call _handle_forced_upgrade when --upgrade flag is not set."""
+        args = parse_arguments([])
+        
+        with (
+            patch("vibe.cli.cli._handle_forced_upgrade") as mock_handle_upgrade,
+            patch("vibe.cli.cli.load_dotenv_values"),
+            patch("vibe.cli.cli.bootstrap_config_files"),
+            patch("vibe.cli.cli.load_config_or_exit"),
+        ):
+            # This will fail due to missing config, but we just want to check that
+            # _handle_forced_upgrade is not called
+            try:
+                run_cli(args)
+            except:
+                pass
+        
+        mock_handle_upgrade.assert_not_called()

--- a/vibe/cli/cli.py
+++ b/vibe/cli/cli.py
@@ -19,6 +19,11 @@ from vibe.cli.update_notifier import (
     get_pending_update_from_cache,
     mark_update_as_dismissed,
 )
+from vibe.cli.update_notifier.update import (
+    get_update_if_available,
+    do_update,
+)
+from vibe.cli.update_notifier.adapters.pypi_update_gateway import PyPIUpdateGateway
 from vibe.core.agent_loop import AgentLoop, TeleportError
 from vibe.core.agents.models import BuiltinAgentName
 from vibe.core.config import MissingAPIKeyError, VibeConfig, load_dotenv_values
@@ -296,6 +301,50 @@ def _maybe_run_startup_update_prompt(
             sys.exit(1)
 
 
+def _handle_forced_upgrade() -> None:
+    """Handle the --upgrade flag: force check for updates and perform update if available."""
+    update_cache_repository = FileSystemUpdateCacheRepository()
+    update_gateway = PyPIUpdateGateway(project_name="mistral-vibe")
+
+    try:
+        # Force a fresh update check
+        update_availability = asyncio.run(
+            get_update_if_available(
+                update_gateway, __version__, update_cache_repository
+            )
+        )
+    except Exception as exc:
+        logger.debug("Failed to check for updates", exc_info=exc)
+        rprint("[red]✗ Failed to check for updates. Please try again later.[/]")
+        sys.exit(1)
+
+    if update_availability is None:
+        rprint(f"[green]✔ Vibe is up to date (v{__version__})[/]")
+        sys.exit(0)
+
+    latest_version = update_availability.latest_version
+    rprint(f"[green]New version available: {__version__} → {latest_version}[/]")
+
+    # Perform the update
+    try:
+        update_successful = asyncio.run(do_update())
+    except Exception as exc:
+        logger.debug("Update failed", exc_info=exc)
+        rprint("[red]✗ Vibe could not be updated automatically.[/]")
+        sys.exit(1)
+
+    if update_successful:
+        rprint(
+            f"[green]✔ Vibe was updated from {__version__} to "
+            f"{latest_version}.[/]\n  Run [bold]vibe[/] to start using the "
+            "new version."
+        )
+        sys.exit(0)
+    else:
+        rprint("[red]✗ Vibe could not be updated automatically.[/]")
+        sys.exit(1)
+
+
 def run_cli(args: argparse.Namespace) -> None:
     load_dotenv_values()
     bootstrap_config_files()
@@ -303,6 +352,11 @@ def run_cli(args: argparse.Namespace) -> None:
     if args.setup:
         run_onboarding(entrypoint_metadata=_build_cli_entrypoint_metadata())
         sys.exit(0)
+
+    if args.upgrade:
+        _handle_forced_upgrade()
+        # This function will sys.exit, so we never reach here
+        return
 
     try:
         is_interactive = args.prompt is None

--- a/vibe/cli/entrypoint.py
+++ b/vibe/cli/entrypoint.py
@@ -112,6 +112,11 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument("--setup", action="store_true", help="Setup API key and exit")
     parser.add_argument(
+        "--upgrade",
+        action="store_true",
+        help="Force upgrade check and update if available",
+    )
+    parser.add_argument(
         "--workdir",
         type=Path,
         metavar="DIR",


### PR DESCRIPTION
## Summary
- Add new `--upgrade` CLI flag to force Vibe to check for updates from PyPI
- When used, performs automatic update if a new version is available
- Provides appropriate feedback messages for success/failure cases
- Exits with appropriate status codes (0 for success, 1 for failure)

## Changes Made
- Added `--upgrade` argument to CLI argument parser in `entrypoint.py`
- Added `_handle_forced_upgrade()` function in `cli.py` to handle the upgrade logic
- Modified `run_cli()` to check for `--upgrade` flag and call the upgrade handler
- Added comprehensive tests for the new functionality in `test_upgrade_flag.py`

## Behavior
- `vibe --upgrade` forces a fresh update check (not just from cache)
- Shows current version status if up to date: `✔ Vibe is up to date (vX.X.X)`
- If update available: shows version info and performs automatic update
- On successful update: `✔ Vibe was updated from X.X.X to Y.Y.Y`
- On failure: `✗ Vibe could not be updated automatically`

## Testing
- Added tests for argument parsing
- Added tests for all upgrade scenarios (up-to-date, available+success, available+fail, check fail)
- Added tests for integration with run_cli function

This addresses the team request to have a way to force upgrade checks, similar to `uv tool upgrade mistral-vibe` but integrated into the Vibe CLI itself.