### PR TITLE
fix: don't discard stdin content when /dev/tty is unavailable (#573)

### DIFF
--- a/vibe/cli/cli.py
+++ b/vibe/cli/cli.py
@@ -58,14 +58,15 @@ def get_prompt_from_stdin() -> str | None:
     if sys.stdin.isatty():
         return None
     try:
-        if content := sys.stdin.read().strip():
-            sys.stdin = sys.__stdin__ = open("/dev/tty")
-            return content
+        content = sys.stdin.read().strip()
     except KeyboardInterrupt:
-        pass
-    except OSError:
         return None
-
+    if content:
+        try:
+            sys.stdin = sys.__stdin__ = open("/dev/tty")
+        except OSError:
+            pass
+        return content
     return None
 
 


### PR DESCRIPTION
## Problem

`get_prompt_from_stdin()` reads stdin content and then tries to reopen `/dev/tty` to restore the terminal. In headless/container environments (CI, subprocesses, Docker), `/dev/tty` does not exist, so `open("/dev/tty")` raises `OSError`. Because the read and the reopen share the same `try` block, the `except OSError: return None` clause discards the already-read content and returns `None`.

Result: `vibe -p` invoked via subprocess with piped stdin always fails with `"Error: No prompt provided for programmatic mode"`, even when the prompt was successfully read.

## Fix

Separate the stdin read and the `/dev/tty` reopen into independent `try/except` blocks. The reopen failure is silently ignored — not having a TTY is perfectly valid in programmatic mode — while the content is returned regardless.

## Files changed

- `vibe/cli/cli.py` — `get_prompt_from_stdin()` restructured

Fixes #573.