### PR TITLE
fix: add missing syrupy to dev dependencies (#646)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ dev = [
     "pytest>=8.3.5",
     "pytest-asyncio>=1.2.0",
     "pytest-textual-snapshot>=1.1.0",
+    "syrupy>=4.0.0",
     "pytest-timeout>=2.4.0",
     "pytest-xdist>=3.8.0",
     "respx>=0.22.0",


### PR DESCRIPTION
## Problem

`syrupy` is used as a snapshot-testing library in several test files (`tests/test_agent_observer_streaming.py`, `tests/core/test_config_layer.py`, `tests/core/test_rewind_*.py`, `tests/core/test_user_config_layer.py`) but is not declared in `[dependency-groups] dev` in `pyproject.toml`. Running the test suite in a fresh environment fails at import time before any test executes.

## Fix

Add `"syrupy>=4.0.0"` to the `dev` dependency group, alongside the other pytest-related packages.

## Files changed

- `pyproject.toml` — one line added in `[dependency-groups] dev`

Fixes #646.