### PR TITLE
fix: stop showing feedback survey after user has already responded (#716)

### DIFF
--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -945,6 +945,7 @@ class VibeApp(App):  # noqa: PLR0904
         self.agent_loop.telemetry_client.send_user_rating_feedback(
             rating=message.rating, model=self.config.active_model
         )
+        self._feedback_bar_manager.record_feedback_given()
 
     async def _remove_loading_widget(self) -> None:
         if self._loading_widget and self._loading_widget.parent:

--- a/vibe/cli/textual_ui/widgets/feedback_bar_manager.py
+++ b/vibe/cli/textual_ui/widgets/feedback_bar_manager.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from vibe.core.agent_loop import AgentLoop
-from vibe.core.feedback import record_feedback_asked, should_show_feedback
+from vibe.core.feedback import (
+    record_feedback_asked,
+    record_feedback_given,
+    should_show_feedback,
+)
 from vibe.core.types import Role
 
 
@@ -21,3 +25,6 @@ class FeedbackBarManager:
 
     def record_feedback_asked(self) -> None:
         record_feedback_asked()
+
+    def record_feedback_given(self) -> None:
+        record_feedback_given()

--- a/vibe/core/feedback.py
+++ b/vibe/core/feedback.py
@@ -11,6 +11,7 @@ FEEDBACK_COOLDOWN_SECONDS = 3600
 MIN_USER_MESSAGES_FOR_FEEDBACK = 3
 _CACHE_SECTION = "user_feedback"
 _LAST_SHOWN_KEY = "last_shown_at"
+_RESPONDED_KEY = "responded"
 
 
 def should_show_feedback(
@@ -23,9 +24,11 @@ def should_show_feedback(
     if user_message_count < MIN_USER_MESSAGES_FOR_FEEDBACK:
         return False
 
-    last_ts = (
-        read_cache(CACHE_FILE.path).get(_CACHE_SECTION, {}).get(_LAST_SHOWN_KEY, 0)
-    )
+    section = read_cache(CACHE_FILE.path).get(_CACHE_SECTION, {})
+    if section.get(_RESPONDED_KEY):
+        return False
+
+    last_ts = section.get(_LAST_SHOWN_KEY, 0)
     if not isinstance(last_ts, int):
         return False
 
@@ -37,3 +40,7 @@ def should_show_feedback(
 
 def record_feedback_asked() -> None:
     write_cache(CACHE_FILE.path, _CACHE_SECTION, {_LAST_SHOWN_KEY: int(time.time())})
+
+
+def record_feedback_given() -> None:
+    write_cache(CACHE_FILE.path, _CACHE_SECTION, {_RESPONDED_KEY: True})


### PR DESCRIPTION
## Problem

`should_show_feedback` only checks `last_shown_at` (a 1-hour cooldown since the survey was last *displayed*). It never records whether the user actually *responded*. After the cooldown expires, the survey can appear again with 20% probability, even if the user already gave a rating. Users who respond see the prompt again after ~1 hour.

## Fix

Add a `responded` boolean flag to the cache section. `record_feedback_given()` sets it to `True` when the user submits a rating. `should_show_feedback` returns `False` immediately if this flag is present. Once the user has responded, the survey is never shown again.

## Files changed

- `vibe/core/feedback.py` — `_RESPONDED_KEY` constant; `record_feedback_given()`; early-return in `should_show_feedback`
- `vibe/cli/textual_ui/widgets/feedback_bar_manager.py` — `record_feedback_given()` wrapper
- `vibe/cli/textual_ui/app.py` — call `record_feedback_given()` in `on_feedback_bar_feedback_given`

Fixes #716.