### PR TITLE
fix: forward Alt+↑↓ and Ctrl+P/N from rewind overlay to app navigation (#550)

### DIFF
--- a/vibe/cli/textual_ui/widgets/rewind_app.py
+++ b/vibe/cli/textual_ui/widgets/rewind_app.py
@@ -143,5 +143,13 @@ class RewindApp(Container):
             case _RewindAction.EDIT_ONLY:
                 self.post_message(self.RewindWithoutRestore())
 
+    def on_key(self, event: events.Key) -> None:
+        if event.key in {"alt+up", "ctrl+p"}:
+            event.prevent_default()
+            self.app.call_next(self.app.action_rewind_prev)
+        elif event.key in {"alt+down", "ctrl+n"}:
+            event.prevent_default()
+            self.app.call_next(self.app.action_rewind_next)
+
     def on_blur(self, event: events.Blur) -> None:
         self.call_after_refresh(self.focus)


### PR DESCRIPTION
## Problem

When the rewind overlay (`RewindApp`) has focus, the message-navigation keys `Alt+↑`, `Alt+↓`, `Ctrl+P`, `Ctrl+N` have no effect. The overlay receives keyboard events but does not handle these combos, and `priority=True` bindings in `VibeApp` are not reliably fired while the overlay is focused (observed on Windows/PowerShell and reproduced on other platforms).

The root cause: `RewindApp` has `on_blur` that immediately steals focus back via `call_after_refresh(self.focus)`. Combined with focus routing, the app-level priority bindings for `alt+up`/`ctrl+p`/`alt+down`/`ctrl+n` are swallowed without triggering navigation.

## Fix

Add an `on_key` handler in `RewindApp` that explicitly intercepts the four navigation combos and delegates them to the corresponding app actions via `self.app.call_next(...)`. This is explicit and does not rely on Textual's priority-binding routing.

The `↑`/`↓` bindings remain in `RewindApp` for navigating between rewind options; only the `Alt+`/`Ctrl+` variants are forwarded.

## Files changed

- `vibe/cli/textual_ui/widgets/rewind_app.py` — `on_key` handler added

Fixes #550.