### PR TITLE
fix: surface MCP server connection errors in the TUI

### DIFF
--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -718,6 +718,13 @@ class VibeApp(App):  # noqa: PLR0904
                 await self._ensure_loading_widget("Initializing", show_hint=False)
                 init_widget = self._loading_widget
             await self.agent_loop.wait_until_ready()
+            for srv_name, err in self.agent_loop.tool_manager.pop_mcp_errors().items():
+                self.notify(
+                    f"MCP server '{srv_name}' failed to connect: {err}",
+                    severity="warning",
+                    markup=False,
+                    timeout=10,
+                )
         except Exception as e:
             await self._mount_and_scroll(
                 ErrorMessage(

--- a/vibe/core/tools/manager.py
+++ b/vibe/core/tools/manager.py
@@ -451,5 +451,9 @@ class ToolManager:
         )
         return self._instances[tool_name]
 
+    def pop_mcp_errors(self) -> dict[str, str]:
+        """Return and clear pending MCP discovery errors (server name → error message)."""
+        return self._mcp_registry.pop_failed()
+
     def reset_all(self) -> None:
         self._instances.clear()

--- a/vibe/core/tools/mcp/registry.py
+++ b/vibe/core/tools/mcp/registry.py
@@ -28,6 +28,7 @@ class MCPRegistry:
 
     def __init__(self) -> None:
         self._cache: dict[str, dict[str, type[BaseTool]]] = {}
+        self._failed: dict[str, str] = {}
 
     @staticmethod
     def _server_key(srv: MCPServer) -> str:
@@ -70,6 +71,7 @@ class MCPRegistry:
                 logger.warning(
                     "MCP discovery failed for server %r: %s", srv.name, result
                 )
+                self._failed[srv.name] = str(result)
                 continue
             if result is None:
                 continue
@@ -177,6 +179,12 @@ class MCPRegistry:
                     exc,
                 )
         return tools
+
+    def pop_failed(self) -> dict[str, str]:
+        """Return and clear the per-server discovery errors accumulated so far."""
+        errors = dict(self._failed)
+        self._failed.clear()
+        return errors
 
     def count_loaded(self, servers: list[MCPServer]) -> int:
         """Return how many of *servers* were successfully discovered (cached)."""


### PR DESCRIPTION
Closes #649

## Problem

When an MCP server fails to connect (SSL certificate error, timeout, network unreachable), the error is logged via `logger.warning` and silently swallowed. Users running `vibe` without `--debug` have no idea why their MCP tools are missing — they just see an empty tool list with no feedback.

## Solution

- `MCPRegistry._discover_all` now stores per-server errors in `self._failed: dict[str, str]` when `asyncio.gather` returns an exception for a server.
- New `MCPRegistry.pop_failed() -> dict[str, str]` returns and clears the accumulated errors.
- `ToolManager.pop_mcp_errors()` delegates to the registry, giving callers a single entry point.
- `VibeApp._watch_init_completion` calls `pop_mcp_errors()` after `wait_until_ready()` and displays one Textual `notify()` toast per failing server (severity=warning, 10 s timeout).

## What changes

- `vibe/core/tools/mcp/registry.py` — `_failed` dict + `pop_failed()`
- `vibe/core/tools/manager.py` — `pop_mcp_errors()`
- `vibe/cli/textual_ui/app.py` — toast loop in `_watch_init_completion`