### PR TITLE
Add /init command: agent-authored AGENTS.md setup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,6 @@ Welcome to the Mistral Vibe documentation! For basic setup, see the [main README
 
 ## Available Documentation
 
+- **[AGENTS.md Guide](agents-md.md)** - Project-specific instructions similar to Claude Code's CLAUDE.md. Learn how to create AGENTS.md files to provide context and guidelines for AI agents working in your projects. Includes the `/init` command for automatic setup.
 - **[ACP Setup](acp-setup.md)** - Setup instructions for using Mistral Vibe with various editors and IDEs that support the Agent Client Protocol.
 - **[Proxy Setup](proxy-setup.md)** - Configure proxy and SSL certificate settings for corporate networks or firewalls.

--- a/docs/agents-md.md
+++ b/docs/agents-md.md
@@ -1,0 +1,441 @@
+# Project Instructions with AGENTS.md
+
+Mistral Vibe supports project-specific instructions through **AGENTS.md** files, similar to Claude Code's CLAUDE.md. These files provide context and guidelines to the AI agent when working within your project.
+
+## Quick Start
+
+Create an `AGENTS.md` file in your project root with instructions for the AI:
+
+```markdown
+# My Project Guidelines
+
+## Commands
+- `npm install` - Install dependencies
+- `npm run dev` - Start development server
+- `npm test` - Run tests
+
+## Project Structure
+- `src/` - Source code
+- `tests/` - Test files
+- `public/` - Static assets
+
+## Coding Standards
+- Use TypeScript
+- Follow ESLint rules
+- Prettier for formatting
+```
+
+Then start Vibe in your project directory. The agent will automatically read and follow these instructions.
+
+## Automatic Setup with `/init`
+
+Run the `/init` command to analyze your codebase and set up an AGENTS.md file:
+
+```
+> /init
+```
+
+`/init` runs as **a single agent turn**. The agent explores the repo with its
+own tools — reading the manifests (`package.json`, `pyproject.toml`,
+`Cargo.toml`, `go.mod`, `composer.json`, `Gemfile`, …), build config, CI
+workflows, and the key source directories — then writes (or improves an existing)
+AGENTS.md itself.
+
+Because the agent authors the file, the output is repo-aware rather than
+template-shaped: it confirms commands actually work, reads conventions from the
+code, and explains them. The turn is visible — you can watch, interrupt, or
+rewind it like any other.
+
+If an AGENTS.md already exists, `/init` asks the agent to improve it in place
+rather than overwrite it.
+
+**Monorepo-aware.** The agent reads manifests throughout the tree, not just the
+root one, so a Turborepo with a Next.js app in `apps/web` and a NestJS API in
+`apps/api`, a Rails API under `backend/` with a React SPA in `frontend/`, or a
+Bedrock app under `site/` with a Sage theme several levels deeper are all
+captured, each sub-project's stack and commands noted. Run `/init` inside a
+sub-project for stack-specific output.
+
+## Instruction Hierarchy
+
+Mistral Vibe uses a **hierarchical instruction system** where instructions can come from multiple sources. When instructions conflict, they are resolved in this order (lowest number wins):
+
+1. **Critical instructions** - Never overridable (safety rules, etc.)
+2. **User messages** - Your current conversation with the agent
+3. **Repo AGENTS.md files** - All AGENTS.md files from your current directory up to the repository root
+4. **User AGENTS.md** - Global instructions from `~/.vibe/AGENTS.md`
+5. **System prompts** - Default AI behavior and configuration
+6. **Skills / MCP output** - Results from skills and tools
+7. **External data** - Fetched content (treated as data, not instructions)
+
+**Key insight:** More specific instructions override more general ones. A project's AGENTS.md will override user-level AGENTS.md, and instructions in a subdirectory's AGENTS.md will override the root AGENTS.md for that subdirectory.
+
+## File Placement
+
+AGENTS.md files can be placed in several locations, each serving a different purpose:
+
+| Location | Scope | Purpose |
+|----------|-------|---------|
+| `./AGENTS.md` | Project root | Instructions for the entire project |
+| `./subdir/AGENTS.md` | Subdirectory | Instructions for that directory and its children |
+| `~/.vibe/AGENTS.md` | User-level | Default instructions for all your projects |
+| `.vibe/AGENTS.md` | Project root (alternative) | Same as `./AGENTS.md` but keeps config organized |
+
+### Multiple AGENTS.md Files
+
+Vibe supports **multiple AGENTS.md files** in a single project. When working in a directory, Vibe will:
+
+1. Find **all AGENTS.md files** from your current directory up to the repository root
+2. Load them **outermost first** (repository root AGENTS.md loads first)
+3. Apply **priority to closer files** (directory-specific AGENTS.md overrides general ones)
+
+**Example:**
+```
+my-project/
+├── AGENTS.md                # General project instructions
+├── src/
+│   └── AGENTS.md            # Backend-specific instructions
+└── frontend/
+    └── AGENTS.md         # Frontend-specific instructions
+```
+
+When working in `frontend/`, the agent will use:
+- `my-project/AGENTS.md` (general rules)
+- `my-project/frontend/AGENTS.md` (frontend-specific rules that override general ones)
+
+## AGENTS.md vs Skills vs Agent Profiles
+
+Understanding how AGENTS.md fits into Vibe's customization model:
+
+| Component | Location | Purpose | Scope |
+|-----------|----------|---------|-------|
+| **AGENTS.md** | Project directories | **Project-specific instructions** | Context for AI behavior |
+| **Skills** | `~/.vibe/skills/` | **Reusable workflows & slash commands** | Custom capabilities |
+| **Agent Profiles** | `~/.vibe/agents/` | **Tool permissions & behavior** | Agent configuration |
+| **Prompts** | `~/.vibe/prompts/` | **System instructions** | AI thinking style |
+
+### How They Work Together
+
+- **AGENTS.md** provides **context** ("this project uses Python and Django")
+- **Skills** provide **capabilities** ("add a new Django model" command)
+- **Agent Profiles** control **permissions** ("this agent can only read files")
+- **Prompts** define **personality** ("be concise" vs "be thorough")
+
+**For most users:** AGENTS.md is all you need to get started with project-specific customization.
+
+## What to Include in AGENTS.md
+
+### Essential Sections
+
+#### Project Overview
+```markdown
+# Project Name
+
+Brief description of what this project does.
+
+Version: 1.0.0
+```
+
+#### Commands
+```markdown
+## Commands
+
+### Build
+- `npm install` - Install dependencies
+- `npm run build` - Build for production
+
+### Test
+- `npm test` - Run all tests
+- `npm run test:unit` - Run unit tests only
+
+### Development
+- `npm run dev` - Start development server
+- `npm run lint` - Run linter
+```
+
+#### Project Structure
+```markdown
+## Project Structure
+
+- `src/` - Main source code
+- `src/api/` - API endpoints
+- `src/models/` - Data models
+- `tests/` - Test files
+- `public/` - Static assets
+- `config/` - Configuration files
+```
+
+#### Coding Standards
+```markdown
+## Coding Standards
+
+- Use TypeScript for all new code
+- Follow ESLint configuration in `.eslintrc.json`
+- Use Prettier for code formatting
+- All functions must have JSDoc comments
+- Tests required for all new features
+```
+
+#### Framework/Tool Specific
+```markdown
+## Django Project
+
+- Use Django REST Framework for API endpoints
+- Models go in `models.py` files within each app
+- Views go in `views.py` files
+- Serializers in `serializers.py`
+- Use `djangorestframework` for API views
+```
+
+#### Environment Setup
+```markdown
+## Environment Setup
+
+1. Copy `.env.example` to `.env`
+2. Install dependencies: `pip install -r requirements.txt`
+3. Run migrations: `python manage.py migrate`
+4. Start server: `python manage.py runserver`
+
+## Environment Variables
+
+- `DATABASE_URL` - Database connection string
+- `SECRET_KEY` - Django secret key
+- `DEBUG` - Set to "True" for development
+```
+
+#### AI Agent Guidelines
+```markdown
+## AI Agent Instructions
+
+When working with this codebase:
+
+- Follow existing code style and patterns
+- Add type hints for all Python functions
+- Write tests for new functionality
+- Use the project's build and test commands
+- Respect the project structure
+- Document new functions and classes
+```
+
+## Best Practices
+
+### Be Specific
+```markdown
+# Good ✅
+- Use `black .` for Python formatting
+- Run `pytest` before committing
+
+# Bad ❌
+- Format code nicely
+- Test your code
+```
+
+### Use Code Examples
+```markdown
+## API Development
+
+When creating new endpoints:
+
+```python
+# Good pattern
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = [IsAuthenticated]
+```
+```
+
+### Document Architectural Decisions
+```markdown
+## Architecture
+
+- **Event-driven architecture** - Use Redis for event publishing
+- **Service pattern** - Business logic in `services/` directory
+- **Repository pattern** - Database access through repository classes
+```
+
+### Include Common Workflows
+```markdown
+## Common Workflows
+
+### Adding a new feature
+1. Create migration: `python manage.py makemigrations`
+2. Apply migration: `python manage.py migrate`
+3. Add tests in `tests/` directory
+4. Update documentation
+
+### Debugging
+- Check logs: `tail -f logs/app.log`
+- Run tests: `pytest tests/test_feature.py -v`
+```
+
+## Advanced Usage
+
+### Multiple Projects
+
+For users working with multiple projects:
+
+1. **User-level AGENTS.md** (`~/.vibe/AGENTS.md`) - Instructions that apply to all your projects
+   ```markdown
+   # My Default Preferences
+   
+   - Use TypeScript when possible
+   - Prefer functional components in React
+   - Always add error handling
+   ```
+
+2. **Project-specific AGENTS.md** - Instructions specific to each project (overrides user-level)
+
+### Team Collaboration
+
+AGENTS.md files are perfect for team collaboration:
+
+- **Commit to version control** - Share project conventions with your team
+- **Onboard new developers** - Document project-specific workflows
+- **Maintain consistency** - Ensure all team members follow the same patterns
+
+**Example team AGENTS.md:**
+```markdown
+# Team Development Guidelines
+
+## Code Review Process
+- All PRs must pass CI checks
+- Require at least 2 approvals for merges
+- Use conventional commit messages
+
+## Branch Strategy
+- `main` - Production releases only
+- `develop` - Integration branch
+- `feature/*` - New features
+- `fix/*` - Bug fixes
+```
+
+## Migration from Claude Code
+
+If you're coming from Claude Code, here's how to migrate:
+
+| Claude Code | Mistral Vibe |
+|-------------|--------------|
+| `CLAUDE.md` | `AGENTS.md` |
+| Project root | Project root or `.vibe/AGENTS.md` |
+| Instructions apply to project | Same behavior |
+| Multiple CLAUDE.md files | Multiple AGENTS.md files supported |
+
+**Simple migration:**
+1. Rename `CLAUDE.md` to `AGENTS.md`
+2. Place in project root
+3. Start using Vibe - it will automatically pick up the instructions
+
+## Troubleshooting
+
+### AGENTS.md Not Working?
+
+1. **Check file location** - Must be in project root or a parent directory
+2. **Check file name** - Must be exactly `AGENTS.md` (case-sensitive)
+3. **Check file content** - Must have non-empty content
+4. **Check working directory** - Vibe loads AGENTS.md files from the current directory up to repo root
+
+### Verify AGENTS.md is Loaded
+
+Ask the agent:
+```
+What project instructions are you currently following?
+```
+
+The agent should summarize the instructions from your AGENTS.md files.
+
+### Common Issues
+
+- **File not found** - AGENTS.md must be in the current directory or a parent directory
+- **Permission issues** - Vibe can only read AGENTS.md files in trusted directories
+- **Empty content** - Empty AGENTS.md files are ignored
+- **Wrong encoding** - Use UTF-8 encoding for AGENTS.md files
+
+## Examples
+
+### Python Project
+```markdown
+# Python Data Analysis Project
+
+## Setup
+- Python 3.12+
+- `pip install -r requirements.txt`
+
+## Commands
+- `pytest` - Run tests
+- `ruff check .` - Lint code
+- `mypy .` - Type checking
+- `jupyter notebook` - Start notebook
+
+## Structure
+- `src/` - Main code
+- `tests/` - Tests
+- `notebooks/` - Jupyter notebooks
+- `data/` - Data files (in .gitignore)
+
+## Standards
+- Use type hints
+- Follow PEP 8
+- Use pandas for data manipulation
+- Type check with mypy
+```
+
+### Node.js Project
+```markdown
+# Full-Stack JavaScript Project
+
+## Tech Stack
+- Node.js 18+
+- Express.js backend
+- React frontend
+- PostgreSQL database
+
+## Commands
+- `npm install` - Install dependencies
+- `npm run dev` - Run both frontend and backend
+- `npm run build` - Production build
+- `npm test` - Run all tests
+
+## Structure
+- `backend/` - Express server
+- `frontend/` - React app
+- `database/` - Database schemas and migrations
+
+## Standards
+- Use ESLint and Prettier
+- TypeScript for new code
+- Jest for testing
+```
+
+### Go Project
+```markdown
+# Go Microservice
+
+## Setup
+- Go 1.21+
+- `go mod download` - Download dependencies
+
+## Commands
+- `go build` - Build binary
+- `go test ./...` - Run all tests
+- `golangci-lint run` - Lint code
+
+## Structure
+- `cmd/` - Entry points
+- `internal/` - Private code
+- `pkg/` - Library code
+- `api/` - API definitions
+
+## Standards
+- Use gofmt for formatting
+- Add proper error handling
+- Document exported functions
+```
+
+## Summary
+
+AGENTS.md files provide a **powerful, flexible way** to give Mistral Vibe project-specific context and instructions. They work similarly to Claude Code's CLAUDE.md files and are automatically loaded by the agent when working in your project.
+
+**For most users:** Creating an AGENTS.md file is the simplest way to get started with customizing Vibe's behavior for your specific project needs.
+
+**Use `/init` command** to automatically generate a comprehensive AGENTS.md file based on your codebase analysis.

--- a/tests/setup/test_init_prompt.py
+++ b/tests/setup/test_init_prompt.py
@@ -1,0 +1,64 @@
+"""Tests for the `/init` prompt builder.
+
+`/init` is a single agent turn: the builder only assembles instructions telling
+the agent to explore the repo and author AGENTS.md itself. These tests cover the
+two branches the prompt takes (create vs. improve) and confirm the builder never
+writes to disk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vibe.setup.init import build_init_prompt
+
+
+@pytest.mark.asyncio
+async def test_prompt_instructs_create_when_no_agents_md(tmp_path: Path) -> None:
+    prompt = await build_init_prompt(tmp_path)
+
+    assert "No AGENTS.md exists yet" in prompt
+    assert "already exists" not in prompt
+    # Tells the agent to explore and confirm rather than guess.
+    assert "Explore the repo" in prompt
+    assert "confirm" in prompt or "Confirm" in prompt
+
+
+@pytest.mark.asyncio
+async def test_prompt_uses_improve_branch_when_agents_md_exists(
+    tmp_path: Path,
+) -> None:
+    existing = "# Existing Guide\n\nRun `make test`.\n"
+    (tmp_path / "AGENTS.md").write_text(existing, encoding="utf-8")
+
+    prompt = await build_init_prompt(tmp_path)
+
+    assert "already exists" in prompt
+    assert "Do not rewrite it wholesale" in prompt
+    # The current file is embedded so the agent can improve it in place.
+    assert "Existing AGENTS.md:" in prompt
+    assert "Run `make test`." in prompt
+
+
+@pytest.mark.asyncio
+async def test_prompt_finds_agents_md_in_vibe_dir(tmp_path: Path) -> None:
+    vibe_dir = tmp_path / ".vibe"
+    vibe_dir.mkdir()
+    (vibe_dir / "AGENTS.md").write_text("# Vibe-scoped guide\n", encoding="utf-8")
+
+    prompt = await build_init_prompt(tmp_path)
+
+    assert "already exists" in prompt
+    assert "Vibe-scoped guide" in prompt
+
+
+@pytest.mark.asyncio
+async def test_does_not_write_any_file(tmp_path: Path) -> None:
+    """The builder only reads; the agent writes AGENTS.md during its turn."""
+    before = set(tmp_path.iterdir())
+
+    await build_init_prompt(tmp_path)
+
+    assert set(tmp_path.iterdir()) == before

--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -179,6 +179,11 @@ class CommandRegistry:
                 description="Select theme",
                 handler="_show_theme",
             ),
+            "init": Command(
+                aliases=frozenset(["/init"]),
+                description="Analyze the project and set up AGENTS.md with build/test commands and conventions",
+                handler="_init_project",
+            ),
         }
 
     @property

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -2165,6 +2165,37 @@ class VibeApp(App):  # noqa: PLR0904
             return
         await self._switch_to_theme_picker_app()
 
+    async def _init_project(self, cmd_args: str = "", **kwargs: Any) -> None:
+        """Handle /init: let the agent explore the repo and author AGENTS.md.
+
+        We build an instruction prompt and hand it to the agent as a normal turn
+        (same path as the initial prompt), so it explores the repo and writes the
+        file itself — repo-aware output, watchable and rewindable.
+        """
+        if self._agent_running:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    "Cannot run /init while the agent is working. Please wait.",
+                    collapsed=self._tools_collapsed,
+                )
+            )
+            return
+
+        try:
+            from vibe.setup.init import build_init_prompt
+
+            prompt = await build_init_prompt(Path.cwd())
+        except Exception as e:
+            logger.error("Failed to build /init prompt: %s", e, exc_info=True)
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    f"Failed to analyze project: {e}", collapsed=self._tools_collapsed
+                )
+            )
+            return
+
+        await self._handle_user_message(prompt, title_source="/init")
+
     async def _show_proxy_setup(self, **kwargs: Any) -> None:
         if self._current_bottom_app == BottomApp.ProxySetup:
             return

--- a/vibe/core/skills/builtins/vibe.py
+++ b/vibe/core/skills/builtins/vibe.py
@@ -570,6 +570,7 @@ Custom agents are TOML files in `~/.vibe/agents/NAME.toml`.
 - `/leanstall` - Install the Lean 4 agent (leanstral)
 - `/unleanstall` - Uninstall the Lean 4 agent
 - `/data-retention` - Show data retention information
+- `/init` - Set up AGENTS.md. Hands the agent a single turn to explore the repo (manifests, build config, source) and write a new AGENTS.md — or improve an existing one — with build/test/run commands, the stack, layout, and conventions
 - `/teleport` - Teleport session to Vibe Code Web (only available when Vibe Code is enabled)
 - `/exit` - Exit the application
 

--- a/vibe/setup/init/__init__.py
+++ b/vibe/setup/init/__init__.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+# Where an existing AGENTS.md may live, in preference order.
+_AGENTS_MD_LOCATIONS = ("AGENTS.md", ".vibe/AGENTS.md")
+
+
+async def build_init_prompt(cwd: Path | None = None) -> str:
+    """Build the `/init` prompt handed to the agent.
+
+    `/init` is a single agent turn: the agent explores the repo with its own
+    tools and authors AGENTS.md itself. There is no separate detection engine —
+    the agent reads the manifests, config, and source directly, so the output is
+    repo-aware and we don't carry a renderer or a detection registry that rots as
+    stacks change. The turn is visible and rewindable like any other.
+
+    Args:
+        cwd: Directory to analyze. Defaults to the current working directory.
+
+    Returns:
+        A prompt string suitable for driving a single agent turn.
+    """
+    workdir = (cwd or Path.cwd()).resolve()
+    existing = _read_existing_agents_md(workdir)
+
+    if existing.strip():
+        action = (
+            "An AGENTS.md already exists (shown at the end). Review it against the "
+            "current repo and apply concrete, targeted improvements — fix stale "
+            "commands, fill real gaps. Do not rewrite it wholesale."
+        )
+    else:
+        action = "No AGENTS.md exists yet. Create one at ./AGENTS.md."
+
+    sections = [
+        "Set up this project's AGENTS.md (agent onboarding guide).",
+        action,
+        (
+            "Explore the repo first. Read the manifests (package.json, "
+            "pyproject.toml, Cargo.toml, go.mod, composer.json, Gemfile, ...), "
+            "build config, CI workflows, and the key source directories to learn "
+            "the real stack and commands. For a monorepo, check nested projects, "
+            "not just the root. Don't guess — confirm every command and convention "
+            "against the actual files before you write it down."
+        ),
+        (
+            "Then author AGENTS.md so a coding agent can be productive immediately:\n"
+            "- Build / test / run / lint commands that actually work in THIS repo\n"
+            "- Languages, frameworks, and package managers in use\n"
+            "- Project layout and where the important code lives\n"
+            "- Conventions you can observe in the code (don't invent them)\n"
+            "- For a monorepo, note each sub-project's stack and how to work in it\n\n"
+            "Keep it concise and accurate — no filler."
+        ),
+    ]
+
+    if existing.strip():
+        sections.append(
+            "Existing AGENTS.md:\n```markdown\n" + existing.strip() + "\n```"
+        )
+
+    return "\n\n".join(sections)
+
+
+def _read_existing_agents_md(workdir: Path) -> str:
+    for rel in _AGENTS_MD_LOCATIONS:
+        path = workdir / rel
+        if path.exists():
+            try:
+                return path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                return ""
+    return ""


### PR DESCRIPTION
## What

Adds a `/init` command that sets up an `AGENTS.md` for the current project.

`/init` runs as a **single agent turn**: it hands the agent an instruction
prompt, and the agent explores the repo with its own tools — manifests
(`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `composer.json`,
`Gemfile`, …), build config, CI workflows, key source dirs — then writes a new
`AGENTS.md`, or improves an existing one in place. The turn is visible and
rewindable like any other.

## Why pure-agent (no detection engine)

The agent already has the tools to read the repo, so there's deliberately **no
deterministic detection engine** behind this — no language/framework registry to
keep in sync as stacks change. Output is repo-aware: commands are confirmed
against the actual files, conventions are read from the code, monorepo
sub-projects are picked up from manifests across the tree.

I also have a heavier *hybrid* variant — see the closed #812 — that pre-scans the
repo with a ~1,300-line detector (`analyzer.py` + `registry.py`) and feeds the
agent hint facts. I kept that out of this PR on purpose: it adds an open-ended
detection registry for the project to maintain, and the agent re-verifies
everything anyway. #812 can be reopened in one click — happy to revive it as a
follow-up if you'd prefer to own a deterministic scanner. Just let me know.

## Changes

| File | Purpose |
|------|---------|
| `vibe/setup/init/__init__.py` | `build_init_prompt` — assembles the `/init` turn |
| `vibe/cli/commands.py` | Register `/init` |
| `vibe/cli/textual_ui/app.py` | `_init_project` handler |
| `vibe/core/skills/builtins/vibe.py` | Document `/init` in the command reference |
| `tests/setup/test_init_prompt.py` | Tests: create vs. improve branches, no-write guarantee |
| `docs/agents-md.md`, `docs/README.md` | AGENTS.md guide + link |

## How to test

### Quick start

```bash
cd ~/code/your-project
# --project runs Vibe from the branch source while keeping the cwd on your repo,
# so /init operates on your-project (not the mistral-vibe source).
uv --project /path/to/mistral-vibe run vibe
# In the TUI, type: /init
```

### Full walkthrough

1. **Clone this branch** and navigate to a target repo:
   ```bash
   git clone -b feature/init-command-lean https://github.com/jasperf/mistral-vibe.git
   cd ~/code/your-project
   # --project keeps the cwd on your repo so /init targets your-project.
   uv --project /path/to/mistral-vibe run vibe
   ```

2. **In the Vibe TUI**, type `/init` and press Enter. The agent will:
   - Explore the repo (manifests, build config, CI workflows, source)
   - Write a new `AGENTS.md`, or improve an existing one
   - The turn is visible and rewindable like any other

3. **Verify the result:**
   ```bash
   cat AGENTS.md
   ```

### What to look for

- The generated `AGENTS.md` should contain working build/test/run/lint commands (confirmed against actual files)
- Conventions should be observed from the code, not invented
- If an `AGENTS.md` already exists, it should be improved in place — not rewritten wholesale
- For monorepos, each sub-project's stack should be noted

### Prompt builder only (no TUI)

To verify just the prompt generation without the full agent turn:

```bash
cd ~/code/your-project
# --project resolves Vibe's deps while leaving the cwd on the target repo,
# so build_init_prompt() inspects your-project (not the mistral-vibe source).
uv --project /path/to/mistral-vibe run python -c "
import asyncio
from vibe.setup.init import build_init_prompt
print(asyncio.run(build_init_prompt()))
"
```

## Automated tests

- `pytest tests/setup/test_init_prompt.py` — 4 passing
- `ruff check` clean on all touched files


