### PR TITLE
Fallback when active model is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Example custom agent configuration (`~/.vibe/agents/redteam.toml`):
 
 ```toml
 # Custom agent configuration for red-teaming
-active_model = "mistral-medium-3.5"
+active_model = "mistral-medium-3.5"  # Falls back to the first configured model if missing
 system_prompt_id = "redteam"
 
 # Disable some tools for this agent

--- a/tests/core/test_config_resolution.py
+++ b/tests/core/test_config_resolution.py
@@ -201,6 +201,38 @@ class TestSaveUpdates:
         assert result == {"tools": {"bash": {"default_timeout": 600}}}
 
 
+class TestActiveModelFallback:
+    def test_falls_back_to_first_configured_model_when_active_model_is_missing(
+        self,
+    ) -> None:
+        model_a = ModelConfig(name="model-a", provider="mistral", alias="model-a")
+        model_b = ModelConfig(name="model-b", provider="mistral", alias="model-b")
+
+        cfg = VibeConfig(
+            active_model="missing-model",
+            models=[model_a, model_b],
+            enable_update_checks=False,
+        )
+
+        assert cfg.active_model == "model-a"
+        assert cfg.get_active_model().alias == "model-a"
+
+    def test_raises_when_active_model_is_missing_and_no_models_are_configured(
+        self,
+    ) -> None:
+        cfg = VibeConfig(
+            active_model="missing-model",
+            models=[],
+            providers=[],
+            enable_update_checks=False,
+        )
+
+        with pytest.raises(
+            ValueError, match="Active model 'missing-model' not found in configuration"
+        ):
+            cfg.get_active_model()
+
+
 class TestSystemTrustStoreConfig:
     def test_load_configures_ssl_context_from_toml(self, config_dir: Path) -> None:
         config_file = config_dir / "config.toml"

--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -971,6 +971,22 @@ class VibeConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def _fallback_missing_active_model(self) -> VibeConfig:
+        if any(model.alias == self.active_model for model in self.models):
+            return self
+        if not self.models:
+            return self
+
+        configured_active_model = self.active_model
+        self.active_model = self.models[0].alias
+        logger.warning(
+            "Active model %r not found in configuration; falling back to %r",
+            configured_active_model,
+            self.active_model,
+        )
+        return self
+
+    @model_validator(mode="after")
     def _check_compaction_model_provider(self) -> VibeConfig:
         if self.compaction_model is None:
             return self

--- a/vibe/core/skills/builtins/vibe.py
+++ b/vibe/core/skills/builtins/vibe.py
@@ -108,6 +108,7 @@ from `~/.vibe/prompts/`, and finally from the built-in bundled prompts.
 ```toml
 # Model selection
 active_model = "mistral-medium-3.5"  # Model alias to use (see [[models]])
+# If active_model is missing from [[models]], Vibe falls back to the first model.
 
 # UI preferences
 vim_keybindings = false


### PR DESCRIPTION
## Summary
- Fall back to the first configured model when `active_model` does not match any model alias.
- Keep the existing error behavior when no models are configured at all.
- Document the fallback in README and the builtin Vibe skill.

## Verification
- `uv run ruff check --fix .`
- `uv run ruff format .`
- `uv run pytest tests/core/test_config_resolution.py -q`
- `uv run pyright vibe/core/config/_settings.py tests/core/test_config_resolution.py`
- `git diff --check`

Fixes VIBE-3294.
