### PR TITLE
fix: export CHAT agent in BUILTIN_AGENTS

### DIFF
--- a/vibe/core/agents/models.py
+++ b/vibe/core/agents/models.py
@@ -200,6 +200,7 @@ LEAN = AgentProfile(
 
 BUILTIN_AGENTS: dict[str, AgentProfile] = {
     BuiltinAgentName.DEFAULT: DEFAULT,
+    BuiltinAgentName.CHAT: CHAT,
     BuiltinAgentName.PLAN: PLAN,
     BuiltinAgentName.ACCEPT_EDITS: ACCEPT_EDITS,
     BuiltinAgentName.AUTO_APPROVE: AUTO_APPROVE,


### PR DESCRIPTION
The  agent profile was defined at line 124 but never included in the  dictionary, causing `vibe --agent chat` to fail with a key error.

This PR adds  to the export map.

Fixes #825