### PR TITLE
Add setting to clear context on plan accept

### DIFF
--- a/tests/agent_loop/test_agent_clear_context_on_plan_accept.py
+++ b/tests/agent_loop/test_agent_clear_context_on_plan_accept.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+from pydantic import BaseModel
+import pytest
+
+from tests.conftest import build_test_agent_loop, build_test_vibe_config
+from tests.mock.utils import mock_llm_chunk
+from tests.stubs.fake_backend import FakeBackend
+from vibe.core.agent_loop import AgentLoop
+from vibe.core.agents.models import BuiltinAgentName
+from vibe.core.tools.base import BaseTool, BaseToolConfig, BaseToolState, InvokeContext
+from vibe.core.types import (
+    BaseEvent,
+    ContextClearedEvent,
+    FunctionCall,
+    Role,
+    ToolCall,
+    ToolStreamEvent,
+)
+from vibe.core.utils import VIBE_WARNING_TAG
+
+
+class _ClearToolArgs(BaseModel):
+    pass
+
+
+class _ClearToolResult(BaseModel):
+    message: str = "ok"
+
+
+class _ClearRequestingTool(
+    BaseTool[_ClearToolArgs, _ClearToolResult, BaseToolConfig, BaseToolState]
+):
+    """Stand-in for exit_plan_mode: it just requests the deferred context clear."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "stub_tool"
+
+    async def run(
+        self, args: _ClearToolArgs, ctx: InvokeContext | None = None
+    ) -> AsyncGenerator[ToolStreamEvent | _ClearToolResult, None]:
+        assert ctx is not None and ctx.request_clear_context_callback is not None
+        await ctx.request_clear_context_callback()
+        yield _ClearToolResult()
+
+
+def _build_loop(backend: FakeBackend) -> AgentLoop:
+    config = build_test_vibe_config(
+        enabled_tools=["stub_tool"],
+        system_prompt_id="tests",
+        include_project_context=False,
+        include_prompt_detail=False,
+    )
+    loop = build_test_agent_loop(
+        config=config, agent_name=BuiltinAgentName.AUTO_APPROVE, backend=backend
+    )
+    loop.tool_manager._all_tools["stub_tool"] = _ClearRequestingTool
+    return loop
+
+
+def _tool_call() -> ToolCall:
+    return ToolCall(
+        id="call_1", index=0, function=FunctionCall(name="stub_tool", arguments="{}")
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_clear_context_sets_flag() -> None:
+    loop = build_test_agent_loop()
+    assert loop._pending_clear_context is False
+    await loop._request_clear_context()
+    assert loop._pending_clear_context is True
+
+
+@pytest.mark.asyncio
+async def test_deferred_clear_wipes_history_and_seeds_plan() -> None:
+    backend = FakeBackend([
+        [mock_llm_chunk(content="Approving.", tool_calls=[_tool_call()])],
+        [mock_llm_chunk(content="Implementing now.")],
+    ])
+    loop = _build_loop(backend)
+    loop._plan_session.read = lambda: "# Approved Plan\n\n- Step 1"  # type: ignore[method-assign]
+
+    events: list[BaseEvent] = [ev async for ev in loop.act("ship it")]
+
+    assert any(isinstance(e, ContextClearedEvent) for e in events)
+    assert loop._pending_clear_context is False
+
+    # History was wiped to the system prompt, then re-seeded with the plan and
+    # the post-clear implementation turn.
+    assert loop.messages[0].role == Role.system
+    seed = loop.messages[1]
+    assert seed.role == Role.user
+    assert seed.injected is True
+    assert "# Approved Plan" in (seed.content or "")
+    assert VIBE_WARNING_TAG in (seed.content or "")
+    # None of the pre-clear planning messages survive.
+    assert not any("ship it" in (m.content or "") for m in loop.messages)
+
+
+@pytest.mark.asyncio
+async def test_deferred_clear_with_empty_plan_appends_no_seed() -> None:
+    backend = FakeBackend([
+        [mock_llm_chunk(content="Approving.", tool_calls=[_tool_call()])],
+        [mock_llm_chunk(content="Implementing now.")],
+    ])
+    loop = _build_loop(backend)
+    loop._plan_session.read = lambda: None  # type: ignore[method-assign]
+
+    events: list[BaseEvent] = [ev async for ev in loop.act("ship it")]
+
+    assert any(isinstance(e, ContextClearedEvent) for e in events)
+    assert loop._pending_clear_context is False
+    # Clear happened (history reset to system prompt), no injected plan seed.
+    assert loop.messages[0].role == Role.system
+    assert not any(m.injected for m in loop.messages)

--- a/tests/core/test_config_resolution.py
+++ b/tests/core/test_config_resolution.py
@@ -200,6 +200,22 @@ class TestSaveUpdates:
 
         assert result == {"tools": {"bash": {"default_timeout": 600}}}
 
+    def test_show_clear_context_on_plan_accept_defaults_false(self) -> None:
+        assert VibeConfig().show_clear_context_on_plan_accept is False
+
+    def test_show_clear_context_on_plan_accept_round_trips(
+        self, config_dir: Path
+    ) -> None:
+        config_file = config_dir / "config.toml"
+        config_file.write_text("")
+
+        VibeConfig.save_updates({"show_clear_context_on_plan_accept": True})
+
+        with config_file.open("rb") as f:
+            result = tomllib.load(f)
+
+        assert result["show_clear_context_on_plan_accept"] is True
+
 
 class TestSystemTrustStoreConfig:
     def test_load_configures_ssl_context_from_toml(self, config_dir: Path) -> None:

--- a/tests/tools/test_exit_plan_mode.py
+++ b/tests/tools/test_exit_plan_mode.py
@@ -15,6 +15,10 @@ from vibe.core.tools.builtins.ask_user_question import (
     AskUserQuestionResult,
 )
 from vibe.core.tools.builtins.exit_plan_mode import (
+    LABEL_AUTO,
+    LABEL_CLEAR_AUTO,
+    LABEL_MANUAL,
+    LABEL_NO,
     ExitPlanMode,
     ExitPlanModeArgs,
     ExitPlanModeConfig,
@@ -22,8 +26,14 @@ from vibe.core.tools.builtins.exit_plan_mode import (
 
 
 @dataclass
+class MockConfig:
+    show_clear_context_on_plan_accept: bool = False
+
+
+@dataclass
 class MockAgentManager:
     active_profile: AgentProfile
+    config: MockConfig = field(default_factory=MockConfig)
     _switched_to: list[str] = field(default_factory=list)
 
     def switch_profile(self, name: str) -> None:
@@ -119,6 +129,143 @@ class MockSwitchAgentCallback:
 
     async def __call__(self, name: str) -> None:
         self.calls.append(name)
+
+
+class MockClearContextCallback:
+    def __init__(self) -> None:
+        self.calls: int = 0
+
+    async def __call__(self) -> None:
+        self.calls += 1
+
+
+def _answer(label: str) -> AskUserQuestionResult:
+    return AskUserQuestionResult(
+        answers=[Answer(question="q", answer=label, is_other=False)], cancelled=False
+    )
+
+
+class TestClearContextOption:
+    @pytest.mark.asyncio
+    async def test_setting_off_shows_three_options(
+        self, tool: ExitPlanMode, plan_manager: MockAgentManager
+    ) -> None:
+        cb = MockCallback(AskUserQuestionResult(answers=[], cancelled=True))
+        ctx = InvokeContext(
+            tool_call_id="t1",
+            agent_manager=plan_manager,  # type: ignore[arg-type]
+            user_input_callback=cb,
+        )
+        await collect_result(tool.run(ExitPlanModeArgs(), ctx))
+        assert isinstance(cb.received_args, AskUserQuestionArgs)
+        labels = [c.label for c in cb.received_args.questions[0].options]
+        assert labels == [LABEL_AUTO, LABEL_MANUAL, LABEL_NO]
+
+    @pytest.mark.asyncio
+    async def test_setting_on_prepends_clear_option(self, tool: ExitPlanMode) -> None:
+        manager = MockAgentManager(
+            active_profile=_plan_profile(),
+            config=MockConfig(show_clear_context_on_plan_accept=True),
+        )
+        cb = MockCallback(AskUserQuestionResult(answers=[], cancelled=True))
+        ctx = InvokeContext(
+            tool_call_id="t1",
+            agent_manager=manager,  # type: ignore[arg-type]
+            user_input_callback=cb,
+        )
+        await collect_result(tool.run(ExitPlanModeArgs(), ctx))
+        assert isinstance(cb.received_args, AskUserQuestionArgs)
+        labels = [c.label for c in cb.received_args.questions[0].options]
+        assert labels == [LABEL_CLEAR_AUTO, LABEL_AUTO, LABEL_MANUAL, LABEL_NO]
+
+    @pytest.mark.asyncio
+    async def test_clear_auto_switches_and_requests_clear(
+        self, tool: ExitPlanMode
+    ) -> None:
+        manager = MockAgentManager(
+            active_profile=_plan_profile(),
+            config=MockConfig(show_clear_context_on_plan_accept=True),
+        )
+        switch_cb = MockSwitchAgentCallback()
+        clear_cb = MockClearContextCallback()
+        ctx = InvokeContext(
+            tool_call_id="t1",
+            agent_manager=manager,  # type: ignore[arg-type]
+            user_input_callback=MockCallback(_answer(LABEL_CLEAR_AUTO)),
+            switch_agent_callback=switch_cb,
+            request_clear_context_callback=clear_cb,
+        )
+        result = await collect_result(tool.run(ExitPlanModeArgs(), ctx))
+        assert result.switched is True
+        assert switch_cb.calls == [BuiltinAgentName.ACCEPT_EDITS]
+        assert clear_cb.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_manual_switches_to_default_without_clear(
+        self, tool: ExitPlanMode
+    ) -> None:
+        manager = MockAgentManager(
+            active_profile=_plan_profile(),
+            config=MockConfig(show_clear_context_on_plan_accept=True),
+        )
+        switch_cb = MockSwitchAgentCallback()
+        clear_cb = MockClearContextCallback()
+        ctx = InvokeContext(
+            tool_call_id="t1",
+            agent_manager=manager,  # type: ignore[arg-type]
+            user_input_callback=MockCallback(_answer(LABEL_MANUAL)),
+            switch_agent_callback=switch_cb,
+            request_clear_context_callback=clear_cb,
+        )
+        result = await collect_result(tool.run(ExitPlanModeArgs(), ctx))
+        assert result.switched is True
+        assert switch_cb.calls == [BuiltinAgentName.DEFAULT]
+        assert clear_cb.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_non_clear_yes_does_not_request_clear(
+        self, tool: ExitPlanMode
+    ) -> None:
+        manager = MockAgentManager(
+            active_profile=_plan_profile(),
+            config=MockConfig(show_clear_context_on_plan_accept=True),
+        )
+        switch_cb = MockSwitchAgentCallback()
+        clear_cb = MockClearContextCallback()
+        ctx = InvokeContext(
+            tool_call_id="t1",
+            agent_manager=manager,  # type: ignore[arg-type]
+            user_input_callback=MockCallback(_answer(LABEL_AUTO)),
+            switch_agent_callback=switch_cb,
+            request_clear_context_callback=clear_cb,
+        )
+        result = await collect_result(tool.run(ExitPlanModeArgs(), ctx))
+        assert result.switched is True
+        assert switch_cb.calls == [BuiltinAgentName.ACCEPT_EDITS]
+        assert clear_cb.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_clear_result_message_excludes_plan_body(
+        self, tool: ExitPlanMode, tmp_path: Path
+    ) -> None:
+        plan_file = tmp_path / "plan.md"
+        plan_file.write_text("# My Plan\n\n- Step 1\n")
+        manager = MockAgentManager(
+            active_profile=_plan_profile(),
+            config=MockConfig(show_clear_context_on_plan_accept=True),
+        )
+        ctx = InvokeContext(
+            tool_call_id="t1",
+            agent_manager=manager,  # type: ignore[arg-type]
+            user_input_callback=MockCallback(_answer(LABEL_CLEAR_AUTO)),
+            switch_agent_callback=MockSwitchAgentCallback(),
+            request_clear_context_callback=MockClearContextCallback(),
+            plan_file_path=plan_file,
+        )
+        result = await collect_result(tool.run(ExitPlanModeArgs(), ctx))
+        assert result.switched is True
+        assert "# My Plan" not in result.message
+        assert "source of truth" not in result.message
 
 
 class TestAnswerHandling:

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -667,6 +667,7 @@ class VibeApp(App):  # noqa: PLR0904
             mount_callback=self._mount_and_scroll,
             get_tools_collapsed=lambda: self._tools_collapsed,
             on_profile_changed=self._on_profile_changed,
+            on_context_cleared=self._on_context_cleared,
         )
 
         self._chat_input_container = self.query_one(ChatInputContainer)
@@ -2487,15 +2488,24 @@ class VibeApp(App):  # noqa: PLR0904
         })
         await self._reload_config()
 
+    async def _reset_message_widgets(self) -> None:
+        """Tear down the on-screen conversation widgets and UI state.
+
+        Shared by ``/clear`` and the clear-context-on-plan-accept flow. Does not
+        touch the agent loop's message history — callers decide whether the core
+        history also needs clearing.
+        """
+        self._reset_ui_state()
+        if self._chat_input_container:
+            self._chat_input_container.set_custom_border(None)
+        if self.event_handler:
+            await self.event_handler.finalize_streaming()
+        await self._messages_area.remove_children()
+
     async def _clear_history(self, **kwargs: Any) -> None:
         try:
-            self._reset_ui_state()
-            if self._chat_input_container:
-                self._chat_input_container.set_custom_border(None)
             await self.agent_loop.clear_history()
-            if self.event_handler:
-                await self.event_handler.finalize_streaming()
-            await self._messages_area.remove_children()
+            await self._reset_message_widgets()
 
             await self._messages_area.mount(SlashCommandMessage("clear"))
             await self._mount_and_scroll(
@@ -2509,6 +2519,18 @@ class VibeApp(App):  # noqa: PLR0904
                     f"Failed to clear history: {e}", collapsed=self._tools_collapsed
                 )
             )
+
+    async def _on_context_cleared(self) -> None:
+        """React to a ContextClearedEvent emitted during plan accept.
+
+        Core already cleared the agent loop's history, so this only resets the
+        on-screen widgets and posts a notice that implementation is starting.
+        """
+        await self._reset_message_widgets()
+        await self._mount_and_scroll(
+            UserCommandMessage("Context cleared. Implementing the approved plan...")
+        )
+        self._chat_widget.scroll_home(animate=False)
 
     async def _show_log_path(self, **kwargs: Any) -> None:
         if not self.agent_loop.session_logger.enabled:

--- a/vibe/cli/textual_ui/handlers/event_handler.py
+++ b/vibe/cli/textual_ui/handlers/event_handler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -32,6 +32,7 @@ from vibe.core.types import (
     BaseEvent,
     CompactEndEvent,
     CompactStartEvent,
+    ContextClearedEvent,
     PlanReviewEndedEvent,
     PlanReviewRequestedEvent,
     ReasoningEvent,
@@ -54,10 +55,12 @@ class EventHandler:
         mount_callback: Callable,
         get_tools_collapsed: Callable[[], bool],
         on_profile_changed: Callable[[], None] | None = None,
+        on_context_cleared: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         self.mount_callback = mount_callback
         self.get_tools_collapsed = get_tools_collapsed
         self.on_profile_changed = on_profile_changed
+        self.on_context_cleared = on_context_cleared
         self.tool_calls: dict[str, ToolCallMessage] = {}
         self.current_compact: CompactMessage | None = None
         self.current_streaming_message: AssistantMessage | None = None
@@ -161,6 +164,10 @@ class EventHandler:
             case AgentProfileChangedEvent():
                 if self.on_profile_changed:
                     self.on_profile_changed()
+            case ContextClearedEvent():
+                await self.finalize_streaming()
+                if self.on_context_cleared:
+                    await self.on_context_cleared()
             case SessionTitleUpdatedEvent():
                 pass
             case UserMessageEvent():

--- a/vibe/cli/textual_ui/widgets/config_app.py
+++ b/vibe/cli/textual_ui/widgets/config_app.py
@@ -71,7 +71,6 @@ class ConfigApp(Container):
                 "file_watcher_for_autocomplete",
                 "Autocomplete watcher (may delay first autocompletion)",
             ),
-            ("show_clear_context_on_plan_accept", "Clear context on plan accept"),
         ]
 
     def _get_current_model(self) -> str:

--- a/vibe/cli/textual_ui/widgets/config_app.py
+++ b/vibe/cli/textual_ui/widgets/config_app.py
@@ -71,6 +71,7 @@ class ConfigApp(Container):
                 "file_watcher_for_autocomplete",
                 "Autocomplete watcher (may delay first autocompletion)",
             ),
+            ("show_clear_context_on_plan_accept", "Clear context on plan accept"),
         ]
 
     def _get_current_model(self) -> str:

--- a/vibe/core/agent_loop.py
+++ b/vibe/core/agent_loop.py
@@ -110,6 +110,7 @@ from vibe.core.types import (
     BaseEvent,
     CompactEndEvent,
     CompactStartEvent,
+    ContextClearedEvent,
     ContextTooLongError,
     ImageAttachment,
     LLMChunk,
@@ -368,6 +369,7 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         self._current_user_message_id: str | None = None
         self._is_user_prompt_call: bool = False
         self._pending_injected_messages: list[LLMMessage] = []
+        self._pending_clear_context: bool = False
 
         self.experiment_manager = ExperimentManager(
             client=RemoteEvalClient.from_settings(
@@ -929,7 +931,7 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         headers["x-affinity"] = self.session_id
         return headers
 
-    async def _conversation_loop(
+    async def _conversation_loop(  # noqa: PLR0912
         self,
         user_msg: str,
         client_message_id: str | None = None,
@@ -989,6 +991,12 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
                 # inner loop so before_tool rewrites land in the snapshot.
                 await self._save_messages()
                 self._is_user_prompt_call = False
+
+                if self._pending_clear_context:
+                    await self._perform_deferred_context_clear()
+                    yield ContextClearedEvent()
+                    should_break_loop = False
+                    continue
 
                 last_message = self.messages[-1]
                 should_break_loop = last_message.role != Role.tool
@@ -1359,6 +1367,7 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
                 sampling_callback=self._sampling_handler,
                 plan_file_path=self._plan_session.plan_file_path,
                 switch_agent_callback=self.switch_agent,
+                request_clear_context_callback=self._request_clear_context,
                 skill_manager=self.skill_manager,
                 scratchpad_dir=self.scratchpad_dir,
                 permission_store=self._permission_store,
@@ -1936,6 +1945,39 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
                 self.agent_profile,
             )
             raise
+
+    async def _request_clear_context(self) -> None:
+        """Signal that the context should be cleared at the next turn boundary.
+
+        The actual clear is deferred so the in-flight tool turn can finish
+        appending its tool-result before ``self.messages`` is wiped.
+        """
+        self._pending_clear_context = True
+
+    async def _perform_deferred_context_clear(self) -> None:
+        """Clear the conversation after a plan accept and re-seed the plan.
+
+        Runs at a turn boundary (never mid-tool) so the tool-result message has
+        already landed before ``self.messages`` is reset. The approved plan is
+        re-injected as a system-reminder so the implementing agent keeps going.
+        The caller emits the ``ContextClearedEvent`` for the UI.
+        """
+        self._pending_clear_context = False
+        plan_content = self._plan_session.read()
+        await self.clear_history()
+        if plan_content:
+            self.messages.append(
+                LLMMessage(
+                    role=Role.user,
+                    content=(
+                        f"<{VIBE_WARNING_TAG}>The conversation context was cleared "
+                        f"after the plan was approved. Implement the approved plan "
+                        f"below -- it is the source of truth:\n\n{plan_content}"
+                        f"</{VIBE_WARNING_TAG}>"
+                    ),
+                    injected=True,
+                )
+            )
 
     @requires_init
     async def switch_agent(self, agent_name: str) -> None:

--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -623,6 +623,7 @@ class VibeConfig(BaseSettings):
     file_watcher_for_autocomplete: bool = False
     displayed_workdir: str = ""
     context_warnings: bool = False
+    show_clear_context_on_plan_accept: bool = False
     voice_mode_enabled: bool = False
     narrator_enabled: bool = False
     active_transcribe_model: str = DEFAULT_ACTIVE_TRANSCRIBE_MODEL_CONFIG.alias

--- a/vibe/core/config/vibe_schema.py
+++ b/vibe/core/config/vibe_schema.py
@@ -212,6 +212,13 @@ class VibeConfigSchema(ConfigSchema):
     file_watcher_for_autocomplete: Annotated[bool, WithReplaceMerge()] = False
     displayed_workdir: Annotated[str, WithReplaceMerge()] = ""
     context_warnings: Annotated[bool, WithReplaceMerge()] = False
+    show_clear_context_on_plan_accept: Annotated[bool, WithReplaceMerge()] = Field(
+        default=False,
+        description=(
+            "When accepting a plan, offer to clear the conversation context before "
+            "implementing. The approved plan is re-injected into the fresh context."
+        ),
+    )
     voice_mode_enabled: Annotated[bool, WithReplaceMerge()] = False
     narrator_enabled: Annotated[bool, WithReplaceMerge()] = False
     bypass_tool_permissions: Annotated[bool, WithReplaceMerge()] = False

--- a/vibe/core/tools/base.py
+++ b/vibe/core/tools/base.py
@@ -37,7 +37,12 @@ if TYPE_CHECKING:
     from vibe.core.tools.mcp.pool import MCPConnectionPool
     from vibe.core.tools.mcp_sampling import MCPSamplingHandler
     from vibe.core.tools.permissions import PermissionContext, PermissionStore
-    from vibe.core.types import ApprovalCallback, SwitchAgentCallback, UserInputCallback
+    from vibe.core.types import (
+        ApprovalCallback,
+        ClearContextCallback,
+        SwitchAgentCallback,
+        UserInputCallback,
+    )
 
 ARGS_COUNT = 4
 
@@ -55,6 +60,7 @@ class InvokeContext:
     entrypoint_metadata: EntrypointMetadata | None = field(default=None)
     plan_file_path: Path | None = field(default=None)
     switch_agent_callback: SwitchAgentCallback | None = field(default=None)
+    request_clear_context_callback: ClearContextCallback | None = field(default=None)
     skill_manager: SkillManager | None = field(default=None)
     scratchpad_dir: Path | None = field(default=None)
     permission_store: PermissionStore | None = field(default=None)

--- a/vibe/core/tools/builtins/exit_plan_mode.py
+++ b/vibe/core/tools/builtins/exit_plan_mode.py
@@ -22,6 +22,11 @@ from vibe.core.tools.builtins.ask_user_question import (
 )
 from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
 
+LABEL_CLEAR_AUTO = "Yes, clear context and auto approve edits"
+LABEL_AUTO = "Yes, and auto approve edits"
+LABEL_MANUAL = "Yes, and request approval for edits"
+LABEL_NO = "No"
+
 
 class ExitPlanModeArgs(BaseModel):
     pass
@@ -71,6 +76,34 @@ class ExitPlanMode(
         if ctx.user_input_callback is None:
             raise ToolError("ExitPlanMode requires an interactive UI.")
 
+        clear_enabled = bool(
+            getattr(
+                ctx.agent_manager.config, "show_clear_context_on_plan_accept", False
+            )
+        )
+
+        options = [
+            Choice(
+                label=LABEL_AUTO,
+                description="Switch to accept-edits mode with auto-approve permissions",
+            ),
+            Choice(
+                label=LABEL_MANUAL,
+                description="Switch to default agent mode (manual approval for edits)",
+            ),
+            Choice(
+                label=LABEL_NO, description="Stay in plan mode and continue planning"
+            ),
+        ]
+        if clear_enabled:
+            options = [
+                Choice(
+                    label=LABEL_CLEAR_AUTO,
+                    description="Clear the planning context, then switch to accept-edits mode",
+                ),
+                *options,
+            ]
+
         plan_path = str(ctx.plan_file_path) if ctx.plan_file_path else ""
         confirmation = AskUserQuestionArgs(
             footer_note=f"Plan: {plan_path} (Ctrl+G to edit)",
@@ -78,20 +111,7 @@ class ExitPlanMode(
                 Question(
                     question="Plan is complete. Switch to accept-edits mode and start implementing?",
                     header="Plan ready",
-                    options=[
-                        Choice(
-                            label="Yes, and auto approve edits",
-                            description="Switch to accept-edits mode with auto-approve permissions",
-                        ),
-                        Choice(
-                            label="Yes, and request approval for edits",
-                            description="Switch to default agent mode (manual approval for edits)",
-                        ),
-                        Choice(
-                            label="No",
-                            description="Stay in plan mode and continue planning",
-                        ),
-                    ],
+                    options=options,
                 )
             ],
         )
@@ -107,31 +127,41 @@ class ExitPlanMode(
 
         answer = result.answers[0]
         answer_lower = answer.answer.lower()
-        if answer_lower == "yes, and auto approve edits":
-            if ctx.switch_agent_callback:
-                await ctx.switch_agent_callback(BuiltinAgentName.ACCEPT_EDITS)
-            else:
-                ctx.agent_manager.switch_profile(BuiltinAgentName.ACCEPT_EDITS)
-            yield ExitPlanModeResult(
-                switched=True,
-                message="Switched to accept-edits mode. You can now start implementing the plan.",
+        is_clear = answer_lower == LABEL_CLEAR_AUTO.lower()
+        if answer_lower in {LABEL_CLEAR_AUTO.lower(), LABEL_AUTO.lower()}:
+            target = BuiltinAgentName.ACCEPT_EDITS
+            base_message = "Switched to accept-edits mode. You can now start implementing the plan."
+            clear_message = (
+                "Switched to accept-edits mode. Clearing the planning context and "
+                "starting implementation from the approved plan."
             )
-        elif answer_lower == "yes, and request approval for edits":
-            if ctx.switch_agent_callback:
-                await ctx.switch_agent_callback(BuiltinAgentName.DEFAULT)
-            else:
-                ctx.agent_manager.switch_profile(BuiltinAgentName.DEFAULT)
-            yield ExitPlanModeResult(
-                switched=True,
-                message="Switched to default agent mode. Edits will require your approval.",
+        elif answer_lower == LABEL_MANUAL.lower():
+            target = BuiltinAgentName.DEFAULT
+            base_message = (
+                "Switched to default agent mode. Edits will require your approval."
             )
+            clear_message = base_message
         elif answer.is_other:
             yield ExitPlanModeResult(
                 switched=False,
                 message=f"Staying in plan mode. User feedback: {answer.answer}",
             )
+            return
         else:
             yield ExitPlanModeResult(
                 switched=False,
                 message="Staying in plan mode. Continue refining the plan.",
             )
+            return
+
+        if ctx.switch_agent_callback:
+            await ctx.switch_agent_callback(target)
+        else:
+            ctx.agent_manager.switch_profile(target)
+
+        if is_clear and ctx.request_clear_context_callback is not None:
+            await ctx.request_clear_context_callback()
+
+        yield ExitPlanModeResult(
+            switched=True, message=clear_message if is_clear else base_message
+        )

--- a/vibe/core/types.py
+++ b/vibe/core/types.py
@@ -553,6 +553,10 @@ class AgentProfileChangedEvent(BaseEvent):
     agent_name: str
 
 
+class ContextClearedEvent(BaseEvent):
+    """Emitted after the context is cleared on plan accept."""
+
+
 class SessionTitleUpdatedEvent(BaseEvent):
     title: str
 
@@ -572,6 +576,8 @@ type ApprovalCallback = Callable[
 type UserInputCallback = Callable[[BaseModel], Awaitable[BaseModel]]
 
 type SwitchAgentCallback = Callable[[str], Awaitable[None]]
+
+type ClearContextCallback = Callable[[], Awaitable[None]]
 
 
 class MessageList(Sequence[LLMMessage]):


### PR DESCRIPTION
Opt-in config `show_clear_context_on_plan_accept` clears the planning conversation and re-injects the approved plan before implementing, freeing the context window.