### PR TITLE
Handle broken keyring backends during MCP OAuth login

### DIFF
--- a/tests/core/test_keyring.py
+++ b/tests/core/test_keyring.py
@@ -11,6 +11,7 @@ import vibe.core.utils.keyring as keyring_utils
 from vibe.core.utils.keyring import (
     delete_api_key_from_keyring,
     get_api_key_from_keyring,
+    is_keyring_available,
     set_api_key_in_keyring,
 )
 
@@ -126,6 +127,32 @@ def test_get_does_not_overwrite_concurrent_cache_write(
         raise errors[0]
     assert results == ["new-key"]
     assert get_api_key_from_keyring("CUSTOM_API_KEY") == "new-key"
+
+
+def test_keyring_backend_detection_error_returns_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _get_keyring() -> object:
+        raise ModuleNotFoundError("No module named 'flyte'")
+
+    monkeypatch.setattr(keyring, "get_keyring", _get_keyring)
+
+    assert is_keyring_available() is False
+
+
+def test_keyring_backend_errors_are_wrapped(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _backend_error(*_args: object) -> None:
+        raise ModuleNotFoundError("No module named 'flyte'")
+
+    monkeypatch.setattr(keyring, "get_password", _backend_error)
+    monkeypatch.setattr(keyring, "set_password", _backend_error)
+    monkeypatch.setattr(keyring, "delete_password", _backend_error)
+
+    assert get_api_key_from_keyring("CUSTOM_API_KEY") is None
+    with pytest.raises(KeyringError, match="Keyring backend is unavailable"):
+        set_api_key_in_keyring("CUSTOM_API_KEY", "new-key")
+    with pytest.raises(KeyringError, match="Keyring backend is unavailable"):
+        delete_api_key_from_keyring("CUSTOM_API_KEY")
 
 
 def test_disabled_keyring_get_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/core/test_mcp_oauth.py
+++ b/tests/core/test_mcp_oauth.py
@@ -183,8 +183,9 @@ class TestKeyringTokenStorage:
         assert loaded_b is not None and loaded_b.access_token == "B"
 
     def test_headless_init_raises(self, headless_keyring: None) -> None:
-        with pytest.raises(MCPOAuthHeadlessError) as exc_info:
-            KeyringTokenStorage(alias="linear")
+        with patch("vibe.core.auth.mcp_oauth.is_keyring_available", return_value=False):
+            with pytest.raises(MCPOAuthHeadlessError) as exc_info:
+                KeyringTokenStorage(alias="linear")
         msg = str(exc_info.value)
         assert "linear" in msg
         assert "api_key_env" in msg

--- a/vibe/core/auth/mcp_oauth.py
+++ b/vibe/core/auth/mcp_oauth.py
@@ -8,8 +8,6 @@ import urllib.parse
 
 import anyio.to_thread
 import httpx
-import keyring
-import keyring.backends.fail
 import keyring.errors
 from mcp.client.auth import (
     OAuthClientProvider,
@@ -25,6 +23,7 @@ from vibe.core.utils.http import build_ssl_context
 from vibe.core.utils.keyring import (
     delete_api_key_from_keyring,
     get_api_key_from_keyring,
+    is_keyring_available,
     set_api_key_in_keyring,
 )
 
@@ -167,8 +166,7 @@ class KeyringTokenStorage(TokenStorage):
         *,
         fallback_client_info: OAuthClientInformationFull | None = None,
     ) -> None:
-        backend = keyring.get_keyring()
-        if isinstance(backend, keyring.backends.fail.Keyring):
+        if not is_keyring_available():
             raise MCPOAuthHeadlessError(server_alias=alias)
         self._alias = alias
         self._fallback_client_info = fallback_client_info

--- a/vibe/core/utils/keyring.py
+++ b/vibe/core/utils/keyring.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+import logging
 import os
 import shlex
 import subprocess
@@ -7,6 +10,7 @@ import sys
 from threading import Lock
 
 import keyring
+import keyring.backends.fail
 from keyring.errors import KeyringError, PasswordDeleteError
 
 _KEYRING_SERVICE = "ai.mistral.vibe"
@@ -15,6 +19,7 @@ _DISABLE_KEYRING_ENV_VAR = "VIBE_TEST_DISABLE_KEYRING"
 _cache_lock = Lock()
 _api_key_cache: dict[str, str | None] = {}
 _SECURITY_NOT_FOUND = "could not be found"
+_KEYRING_BACKEND_LOGGER = "keyring.backend"
 
 
 class _PasswordNotFoundError(KeyringError):
@@ -27,6 +32,34 @@ def _is_keyring_disabled() -> bool:
 
 def _should_use_macos_security() -> bool:
     return sys.platform == "darwin"
+
+
+@contextmanager
+def _suppress_keyring_backend_plugin_errors() -> Iterator[None]:
+    logger = logging.getLogger(_KEYRING_BACKEND_LOGGER)
+    disabled = logger.disabled
+    logger.disabled = True
+    try:
+        yield
+    finally:
+        logger.disabled = disabled
+
+
+def _keyring_backend_error(exc: Exception) -> KeyringError:
+    return KeyringError(f"Keyring backend is unavailable: {exc}")
+
+
+def is_keyring_available() -> bool:
+    if _is_keyring_disabled():
+        return False
+    if _should_use_macos_security():
+        return True
+    try:
+        with _suppress_keyring_backend_plugin_errors():
+            backend = keyring.get_keyring()
+    except Exception:
+        return False
+    return not isinstance(backend, keyring.backends.fail.Keyring)
 
 
 def _run_security(
@@ -60,7 +93,13 @@ def _delete_macos_password(service: str, username: str) -> None:
 
 def _set_password(service: str, username: str, password: str) -> None:
     if not _should_use_macos_security():
-        keyring.set_password(service, username, password)
+        try:
+            with _suppress_keyring_backend_plugin_errors():
+                keyring.set_password(service, username, password)
+        except KeyringError:
+            raise
+        except Exception as exc:
+            raise _keyring_backend_error(exc) from exc
         return
 
     try:
@@ -100,7 +139,13 @@ def _get_password(service: str, username: str) -> str | None:
             raise KeyringError("Can't get password from macOS Keychain") from exc
         return result.stdout.removesuffix("\n")
 
-    return keyring.get_password(service, username)
+    try:
+        with _suppress_keyring_backend_plugin_errors():
+            return keyring.get_password(service, username)
+    except KeyringError:
+        raise
+    except Exception as exc:
+        raise _keyring_backend_error(exc) from exc
 
 
 def _delete_password(service: str, username: str) -> None:
@@ -108,7 +153,13 @@ def _delete_password(service: str, username: str) -> None:
         _delete_macos_password(service, username)
         return
 
-    keyring.delete_password(service, username)
+    try:
+        with _suppress_keyring_backend_plugin_errors():
+            keyring.delete_password(service, username)
+    except KeyringError:
+        raise
+    except Exception as exc:
+        raise _keyring_backend_error(exc) from exc
 
 
 def _migrate_legacy_password(username: str, password: str, legacy_service: str) -> None:


### PR DESCRIPTION
## Summary
- Harden keyring backend discovery and operations against broken optional backend plugins, including `ModuleNotFoundError: No module named 'flyte'`.
- Use the shared keyring availability probe for MCP OAuth token storage instead of calling `keyring.get_keyring()` directly.
- Add regression coverage for keyring backend detection and operation errors leaking from third-party plugins.

## Verification
- `uv run ruff format .`
- `uv run ruff check --fix .`
- `uv run pyright`
- `uv run pytest tests/core/test_keyring.py tests/core/test_mcp_oauth.py tests/tools/test_mcp_registry_oauth.py`

Note: local git hooks were run with `SKIP=pyright` for commit/push because the pre-commit pyright hook attempted to install from npm and failed with `SELF_SIGNED_CERT_IN_CHAIN`; `uv run pyright` passed locally.
