### PR TITLE
fix(config): merge user and project TOML when loading VibeConfig

### DIFF
--- a/tests/core/test_config_resolution.py
+++ b/tests/core/test_config_resolution.py
@@ -156,6 +156,81 @@ class TestResolveConfigFile:
         assert mgr.config_file == VIBE_HOME.path / "config.toml"
 
 
+class TestLayeredTomlConfigMerge:
+    def test_user_models_preserved_when_project_config_exists(
+        self,
+        tmp_working_directory: Path,
+        config_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user_config = config_dir / "config.toml"
+        user_data = {
+            **_custom_provider_payload(),
+            "active_model": "devstral-large",
+            "models": [
+                {
+                    "name": "devstral-latest",
+                    "provider": "custom-provider",
+                    "alias": "devstral-large",
+                }
+            ],
+            "providers": [_custom_provider_payload()],
+        }
+        with user_config.open("wb") as f:
+            tomli_w.dump(user_data, f)
+
+        project_config_dir = tmp_working_directory / ".vibe"
+        project_config_dir.mkdir()
+        project_config = project_config_dir / "config.toml"
+        with project_config.open("wb") as f:
+            tomli_w.dump(
+                {
+                    "enable_experimental_hooks": True,
+                    "tools": {"read_file": {"permission": "always"}},
+                },
+                f,
+            )
+
+        monkeypatch.setattr(trusted_folders_manager, "is_trusted", lambda _: True)
+        monkeypatch.setenv("CUSTOM_API_KEY", "test-key")
+        reset_harness_files_manager()
+        init_harness_files_manager("user", "project")
+
+        config = VibeConfig.load()
+
+        assert config.active_model == "devstral-large"
+        assert any(model.alias == "devstral-large" for model in config.models)
+        assert config.enable_experimental_hooks is True
+        assert config.tools["read"]["permission"] == "always"
+
+    def test_project_active_model_overrides_user_when_explicitly_set(
+        self,
+        tmp_working_directory: Path,
+        config_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user_config = config_dir / "config.toml"
+        with user_config.open("rb") as f:
+            user_data = tomllib.load(f)
+        user_data["active_model"] = "user-model"
+        with user_config.open("wb") as f:
+            tomli_w.dump(user_data, f)
+
+        project_config_dir = tmp_working_directory / ".vibe"
+        project_config_dir.mkdir()
+        project_config = project_config_dir / "config.toml"
+        with project_config.open("wb") as f:
+            tomli_w.dump({"active_model": "project-model"}, f)
+
+        monkeypatch.setattr(trusted_folders_manager, "is_trusted", lambda _: True)
+        reset_harness_files_manager()
+        init_harness_files_manager("user", "project")
+
+        config = VibeConfig.load()
+
+        assert config.active_model == "project-model"
+
+
 class TestSaveUpdates:
     def test_merges_nested_tool_updates_without_materializing_defaults(
         self, config_dir: Path

--- a/tests/core/test_config_resolution.py
+++ b/tests/core/test_config_resolution.py
@@ -230,6 +230,65 @@ class TestLayeredTomlConfigMerge:
 
         assert config.active_model == "project-model"
 
+    def test_untrusted_project_uses_user_config_only(
+        self,
+        tmp_working_directory: Path,
+        config_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user_config = config_dir / "config.toml"
+        with user_config.open("rb") as f:
+            user_data = tomllib.load(f)
+        user_data["active_model"] = "user-model"
+        with user_config.open("wb") as f:
+            tomli_w.dump(user_data, f)
+
+        project_config_dir = tmp_working_directory / ".vibe"
+        project_config_dir.mkdir()
+        project_config = project_config_dir / "config.toml"
+        with project_config.open("wb") as f:
+            tomli_w.dump({"active_model": "project-model"}, f)
+
+        monkeypatch.setattr(trusted_folders_manager, "is_trusted", lambda _: False)
+        reset_harness_files_manager()
+        init_harness_files_manager("user", "project")
+
+        config = VibeConfig.load()
+
+        assert config.active_model == "user-model"
+
+    def test_save_updates_does_not_write_user_fields_into_project_toml(
+        self,
+        tmp_working_directory: Path,
+        config_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user_config = config_dir / "config.toml"
+        with user_config.open("rb") as f:
+            user_data = tomllib.load(f)
+        user_data["active_model"] = "user-only-model"
+        with user_config.open("wb") as f:
+            tomli_w.dump(user_data, f)
+
+        project_config_dir = tmp_working_directory / ".vibe"
+        project_config_dir.mkdir()
+        project_config = project_config_dir / "config.toml"
+        with project_config.open("wb") as f:
+            tomli_w.dump({"enable_experimental_hooks": True}, f)
+
+        monkeypatch.setattr(trusted_folders_manager, "is_trusted", lambda _: True)
+        reset_harness_files_manager()
+        init_harness_files_manager("user", "project")
+
+        VibeConfig.save_updates({"tools": {"bash": {"permission": "always"}}})
+
+        with project_config.open("rb") as f:
+            persisted = tomllib.load(f)
+
+        assert persisted["tools"]["bash"]["permission"] == "always"
+        assert "active_model" not in persisted
+        assert "models" not in persisted
+
 
 class TestSaveUpdates:
     def test_merges_nested_tool_updates_without_materializing_defaults(

--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from collections.abc import MutableMapping
 from enum import StrEnum, auto
 import os
@@ -46,6 +45,7 @@ from vibe.core.prompts import (
 )
 from vibe.core.types import Backend
 from vibe.core.utils import configure_ssl_context, get_server_url_from_api_base
+from vibe.core.utils.concurrency import run_sync
 from vibe.core.utils.keyring import get_api_key_from_keyring
 
 
@@ -128,7 +128,14 @@ def _load_layered_toml_config() -> dict[str, Any]:
         builder.add_layers([UserConfigLayer(), ProjectConfigLayer()])
         return await builder.build_merged()
 
-    return asyncio.run(_load())
+    return run_sync(_load())
+
+
+def _load_persisted_toml_config() -> dict[str, Any]:
+    """Load the single on-disk config file targeted by save/migrate paths."""
+    mgr = get_harness_files_manager()
+    file = mgr.config_file or mgr.user_config_file
+    return _read_toml_file(file) if file.is_file() else {}
 
 
 class TomlFileSettingsSource(PydanticBaseSettingsSource):
@@ -1104,7 +1111,7 @@ class VibeConfig(BaseSettings):
                 self.models[i] = m.model_copy(update={"thinking": level})
                 break
 
-        current_config = TomlFileSettingsSource(type(self)).toml_data
+        current_config = _load_persisted_toml_config()
         models = current_config.get("models", [])
         for entry in models:
             if entry.get("alias", entry.get("name")) == model.alias:
@@ -1142,13 +1149,13 @@ class VibeConfig(BaseSettings):
 
     @classmethod
     def get_persisted_config(cls) -> dict[str, Any]:
-        return TomlFileSettingsSource(cls).toml_data
+        return _load_persisted_toml_config()
 
     @classmethod
     def save_updates(cls, updates: dict[str, Any]) -> None:
         if not get_harness_files_manager().persist_allowed:
             return
-        current_config = TomlFileSettingsSource(cls).toml_data
+        current_config = _load_persisted_toml_config()
         merged_config = deep_update(current_config, updates)
         cls.dump_config(merged_config)
 

--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import MutableMapping
 from enum import StrEnum, auto
 import os
@@ -103,24 +104,50 @@ class MissingAPIKeyError(RuntimeError):
         self.provider_name = provider_name
 
 
+def _read_toml_file(file: Path) -> dict[str, Any]:
+    try:
+        with file.open("rb") as f:
+            return tomllib.load(f)
+    except FileNotFoundError:
+        return {}
+    except tomllib.TOMLDecodeError as e:
+        raise RuntimeError(f"Invalid TOML in {file}: {e}") from e
+    except OSError as e:
+        raise RuntimeError(f"Cannot read {file}: {e}") from e
+
+
+def _load_layered_toml_config() -> dict[str, Any]:
+    """Load and merge user + project TOML config using schema merge semantics."""
+    from vibe.core.config.builder import ConfigBuilder
+    from vibe.core.config.layers.project import ProjectConfigLayer
+    from vibe.core.config.layers.user import UserConfigLayer
+    from vibe.core.config.vibe_schema import VibeConfigSchema
+
+    async def _load() -> dict[str, Any]:
+        builder = ConfigBuilder(VibeConfigSchema)
+        builder.add_layers([UserConfigLayer(), ProjectConfigLayer()])
+        return await builder.build_merged()
+
+    return asyncio.run(_load())
+
+
 class TomlFileSettingsSource(PydanticBaseSettingsSource):
     def __init__(self, settings_cls: type[BaseSettings]) -> None:
         super().__init__(settings_cls)
         self.toml_data = self._load_toml()
 
     def _load_toml(self) -> dict[str, Any]:
-        file = get_harness_files_manager().config_file
-        if file is None:
-            return {}
         try:
-            with file.open("rb") as f:
-                return tomllib.load(f)
-        except FileNotFoundError:
+            get_harness_files_manager()
+        except RuntimeError:
             return {}
-        except tomllib.TOMLDecodeError as e:
-            raise RuntimeError(f"Invalid TOML in {file}: {e}") from e
-        except OSError as e:
-            raise RuntimeError(f"Cannot read {file}: {e}") from e
+
+        mgr = get_harness_files_manager()
+        if "project" not in mgr.sources:
+            user_file = mgr.user_config_file
+            return _read_toml_file(user_file) if user_file.is_file() else {}
+
+        return _load_layered_toml_config()
 
     def get_field_value(
         self, field: FieldInfo, field_name: str

--- a/vibe/core/config/builder.py
+++ b/vibe/core/config/builder.py
@@ -61,6 +61,24 @@ class ConfigBuilder[S: ConfigSchema]:
             merged, origins = self._merge_fields(self._schema, layer_dicts)
             return self._schema(origins=origins, **merged)
 
+    async def build_merged(self, force_load: bool = False) -> dict[str, Any]:
+        """Merge all layers and return the raw merged dict (no schema defaults)."""
+        async with self._lock:
+            internal_layers = self._layers.copy()
+
+            layer_dicts: list[_LayerData] = []
+            for layer in internal_layers:
+                try:
+                    data = await layer.load(force=force_load)
+                    raw = data.model_dump()
+                    if raw:
+                        layer_dicts.append(_LayerData(name=layer.name, data=raw))
+                except (UntrustedLayerError, EmptyLayerError):
+                    continue
+
+            merged, _ = self._merge_fields(self._schema, layer_dicts)
+            return merged
+
     def _merge_fields(
         self, schema: type[S], layer_dicts: list[_LayerData]
     ) -> tuple[dict[str, Any], dict[str, Any]]:


### PR DESCRIPTION
## Summary

When both a user-level (`~/.vibe/config.toml`) and a trusted project-level (`.vibe/config.toml`) config exist, `VibeConfig.load()` previously read only the project file via `TomlFileSettingsSource`. User-defined `[[models]]`, `active_model`, and other personal settings were silently discarded.

This change loads and merges both layers using the existing `ConfigBuilder` + `VibeConfigSchema` merge semantics (`WithUnionMerge` for models, `WithReplaceMerge` for scalars, `WithShallowMerge` for tools).

## Motivation

Fixes #657 — custom models configured in `~/.vibe/config.toml` were ignored whenever a project `.vibe/config.toml` existed, causing Vibe to fall back to hardcoded defaults like `mistral-medium-3.5`.

## Changes

- Add `ConfigBuilder.build_merged()` to return the raw merged dict without materializing schema defaults
- Update `TomlFileSettingsSource` to use layered merge (user → project) when the harness includes the project source
- Keep `save_updates` / `get_persisted_config` / `set_thinking` on the single on-disk backing file via `_load_persisted_toml_config()` to avoid leaking user fields into project TOML
- Use `run_sync()` instead of `asyncio.run()` so `VibeConfig.load()` works inside running event loops

## Tests

```bash
uv run pytest tests/core/test_config_resolution.py::TestLayeredTomlConfigMerge -q
uv run pytest tests/core/test_config_resolution.py tests/core/test_config_builder.py tests/core/test_project_config_layer.py tests/core/test_user_config_layer.py -q
```

- 4 new regression tests in `TestLayeredTomlConfigMerge`
- 141 config-related tests passed locally

## Notes

- Project layer still requires folder trust; untrusted projects continue to use user config only
- `ProjectConfigLayer` walk-up discovery applies when merging (parent `.vibe/config.toml` can contribute), consistent with the layered config system already in the repo
- Reviewed with composer-2.5 sub-agent; persist isolation and async-safety fixes applied per review feedback

Fixes #657