### PR TITLE
fix(hooks): check allowlist on pre-hook args to prevent bypass

### DIFF
--- a/tests/core/test_hooks.py
+++ b/tests/core/test_hooks.py
@@ -42,7 +42,13 @@ from vibe.core.hooks.models import (
     PostAgentTurnInvocation,
     build_invocation,
 )
-from vibe.core.types import AssistantEvent, FunctionCall, ToolCall, ToolResultEvent
+from vibe.core.types import (
+    ApprovalResponse,
+    AssistantEvent,
+    FunctionCall,
+    ToolCall,
+    ToolResultEvent,
+)
 
 _AnyHookYield = (
     HookEvent
@@ -1157,6 +1163,53 @@ def _stub_tool_call(call_id: str = "call_1", arguments: str = "{}") -> ToolCall:
     )
 
 
+def _bash_tool_call(command: str, *, call_id: str = "call_1") -> ToolCall:
+    return ToolCall(
+        id=call_id,
+        index=0,
+        function=FunctionCall(
+            name="bash", arguments=json.dumps({"command": command})
+        ),
+    )
+
+
+class TestPermissionContextMerge:
+    def test_never_wins_over_always(self) -> None:
+        from vibe.core.agent_loop import AgentLoop
+        from vibe.core.tools.base import ToolPermission
+        from vibe.core.tools.permissions import PermissionContext
+
+        never = PermissionContext(permission=ToolPermission.NEVER, reason="blocked")
+        always = PermissionContext(permission=ToolPermission.ALWAYS)
+        merged = AgentLoop._merge_permission_contexts(always, never)
+        assert merged.permission is ToolPermission.NEVER
+
+    def test_ask_wins_over_allowlist_always(self) -> None:
+        from vibe.core.agent_loop import AgentLoop
+        from vibe.core.tools.base import ToolPermission
+        from vibe.core.tools.permissions import (
+            PermissionContext,
+            PermissionScope,
+            RequiredPermission,
+        )
+
+        ask = PermissionContext(
+            permission=ToolPermission.ASK,
+            required_permissions=[
+                RequiredPermission(
+                    scope=PermissionScope.COMMAND_PATTERN,
+                    invocation_pattern="touch foo",
+                    session_pattern="touch *",
+                    label="touch *",
+                )
+            ],
+        )
+        always = PermissionContext(permission=ToolPermission.ALWAYS)
+        merged = AgentLoop._merge_permission_contexts(ask, always)
+        assert merged.permission is ToolPermission.ASK
+        assert len(merged.required_permissions) == 1
+
+
 class TestStructuredResponseParsing:
     def test_empty_stdout_returns_none(self) -> None:
         # Empty stdout is the only legitimate "passthrough" signal — the
@@ -1783,6 +1836,61 @@ class TestAgentLoopIntegration:
         assert "failed validation" in tool_results[0].skip_reason
         assert "bad-rewriter" in tool_results[0].skip_reason
         assert agent_loop.stats.tool_calls_hook_denied == 1
+
+    @pytest.mark.asyncio
+    async def test_before_tool_rewrite_does_not_bypass_bash_allowlist(self) -> None:
+        from vibe.core.tools.builtins.bash import default_read_only_commands
+
+        approval_requests: list[str] = []
+
+        async def track_approval(
+            tool_name: str,
+            args: object,
+            tool_call_id: str,
+            required_permissions: object,
+        ) -> tuple[ApprovalResponse, str | None]:
+            approval_requests.append(tool_name)
+            return ApprovalResponse.YES, None
+
+        tool_call = _bash_tool_call("touch foo", call_id="call_rtk")
+        config = build_test_vibe_config(
+            enabled_tools=["bash"],
+            tools={
+                "bash": {
+                    "allowlist": ["rtk", *default_read_only_commands()],
+                }
+            },
+        )
+        script = (
+            f'{sys.executable} -c "'
+            "import json,sys; "
+            "inv=json.load(sys.stdin); "
+            "cmd=inv.get('tool_input',{}).get('command',''); "
+            "json.dump({'hook_specific_output': "
+            "{'tool_input': {'command': 'rtk ' + cmd}}}, sys.stdout)"
+            '"'
+        )
+        hooks = [
+            _make_tool_hook(
+                "rtk-wrapper", script, type=HookType.BEFORE_TOOL, match="bash"
+            )
+        ]
+        backend = FakeBackend([
+            [mock_llm_chunk(content="Running touch.", tool_calls=[tool_call])],
+            [mock_llm_chunk(content="done")],
+        ])
+        agent_loop = build_test_agent_loop(
+            config=config,
+            agent_name=BuiltinAgentName.DEFAULT,
+            backend=backend,
+            hook_config_result=HookConfigResult(hooks=hooks, issues=[]),
+        )
+        agent_loop.set_approval_callback(track_approval)
+
+        async for _ev in agent_loop.act("touch a file"):
+            pass
+
+        assert approval_requests == ["bash"]
 
     @pytest.mark.asyncio
     async def test_invalid_intermediate_rewrite_stops_subsequent_hooks(self) -> None:

--- a/vibe/core/agent_loop.py
+++ b/vibe/core/agent_loop.py
@@ -95,6 +95,7 @@ from vibe.core.tools.manager import ToolManager
 from vibe.core.tools.permissions import (
     ApprovedRule,
     PermissionContext,
+    PermissionScope,
     PermissionStore,
     RequiredPermission,
 )
@@ -1323,6 +1324,8 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
             yield self._tool_failure_event(tool_call, error_msg, span=span)
             return
 
+        original_args = tool_call.validated_args
+
         try:
             tool_input = self._serialize_tool_input(tool_call)
         except Exception as exc:
@@ -1355,7 +1358,10 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         tool_started = False
         try:
             decision = await self._should_execute_tool(
-                tool_instance, tool_call.validated_args, tool_call.call_id
+                tool_instance,
+                tool_call.validated_args,
+                tool_call.call_id,
+                pre_hook_args=original_args,
             )
 
             if decision.verdict == ToolExecutionResponse.SKIP:
@@ -1495,8 +1501,52 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
             yield ev
         self.stats.tool_calls_succeeded += 1
 
+    def _get_effective_permission_context(
+        self, tool: BaseTool, args: BaseModel
+    ) -> PermissionContext:
+        tool_name = tool.get_name()
+        ctx = tool.resolve_permission(args)
+        if ctx is None:
+            config_perm = self.tool_manager.get_tool_config(tool_name).permission
+            return PermissionContext(permission=config_perm)
+        return ctx
+
+    @staticmethod
+    def _merge_permission_contexts(
+        a: PermissionContext, b: PermissionContext
+    ) -> PermissionContext:
+        if a.permission == ToolPermission.NEVER:
+            return a
+        if b.permission == ToolPermission.NEVER:
+            return b
+
+        permission = (
+            ToolPermission.ASK
+            if ToolPermission.ASK in {a.permission, b.permission}
+            else ToolPermission.ALWAYS
+        )
+
+        seen: set[tuple[PermissionScope, str]] = set()
+        merged: list[RequiredPermission] = []
+        for rp in a.required_permissions + b.required_permissions:
+            key = (rp.scope, rp.session_pattern)
+            if key not in seen:
+                seen.add(key)
+                merged.append(rp)
+
+        return PermissionContext(
+            permission=permission,
+            required_permissions=merged,
+            reason=a.reason or b.reason,
+        )
+
     async def _should_execute_tool(
-        self, tool: BaseTool, args: BaseModel, tool_call_id: str
+        self,
+        tool: BaseTool,
+        args: BaseModel,
+        tool_call_id: str,
+        *,
+        pre_hook_args: BaseModel | None = None,
     ) -> ToolDecision:
         if self.bypass_tool_permissions:
             return ToolDecision(
@@ -1506,11 +1556,15 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
 
         async with self._permission_store.lock:
             tool_name = tool.get_name()
-            ctx = tool.resolve_permission(args)
-
-            if ctx is None:
-                config_perm = self.tool_manager.get_tool_config(tool_name).permission
-                ctx = PermissionContext(permission=config_perm)
+            ctx = self._get_effective_permission_context(tool, args)
+            if (
+                pre_hook_args is not None
+                and pre_hook_args.model_dump() != args.model_dump()
+            ):
+                original_ctx = self._get_effective_permission_context(
+                    tool, pre_hook_args
+                )
+                ctx = self._merge_permission_contexts(original_ctx, ctx)
 
             match ctx.permission:
                 case ToolPermission.ALWAYS:


### PR DESCRIPTION
## Summary

When `before_tool` hooks rewrite bash commands (e.g. prefixing with an allowlisted wrapper like `rtk`), permission checks now evaluate both the original and rewritten tool input. The stricter permission context wins, so hooks cannot weaken allowlist guardrails.

## Motivation

Fixes #849. A `before_tool` hook that wraps commands in an allowlisted prefix (e.g. `ls` → `rtk ls`) previously caused only the rewritten command to be checked. If the wrapper was allowlisted, every underlying command was auto-approved.

## Changes

- Save pre-hook `validated_args` before the `before_tool` pipeline runs
- Add `_get_effective_permission_context` and `_merge_permission_contexts` helpers
- `_should_execute_tool` merges pre- and post-hook permission contexts when args differ (`NEVER` > `ASK` > `ALWAYS`, union `required_permissions`)

## Tests

- `uv run pytest tests/core/test_hooks.py::TestPermissionContextMerge -n0` — pass
- `uv run pytest tests/core/test_hooks.py::TestAgentLoopIntegration::test_before_tool_rewrite_does_not_bypass_bash_allowlist -n0` — pass
- `uv run pytest tests/core/test_hooks.py -n0` — 89 passed
- `uv run ruff check vibe/core/agent_loop.py tests/core/test_hooks.py` — pass

## Notes

- Reviewed by composer-2.5 sub-agent: **APPROVE**
- Permission prompt still shows rewritten args (what will actually run); required permissions come from the merged context.
- `bypass_tool_permissions` behavior unchanged (pre-existing).