### PR TITLE
fix(openrouter): map thinking config to reasoning API parameter

### DIFF
--- a/tests/backend/test_openrouter_reasoning.py
+++ b/tests/backend/test_openrouter_reasoning.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+
+from vibe.core.config import ProviderConfig
+from vibe.core.llm.backend.generic import OpenAIAdapter
+from vibe.core.types import LLMMessage, Role
+
+
+def _prepare_payload(*, provider_name: str, thinking: str) -> dict:
+    adapter = OpenAIAdapter()
+    provider = ProviderConfig(
+        name=provider_name,
+        api_base="https://openrouter.ai/api/v1",
+        api_key_env_var="OPENROUTER_API_KEY",
+    )
+    request = adapter.prepare_request(
+        model_name="mistral-medium-3.5",
+        messages=[LLMMessage(role=Role.user, content="hello")],
+        temperature=0.2,
+        tools=None,
+        max_tokens=None,
+        tool_choice=None,
+        enable_streaming=False,
+        provider=provider,
+        thinking=thinking,
+    )
+    return json.loads(request.body)
+
+
+class TestOpenRouterReasoning:
+    def test_maps_high_thinking_to_reasoning_effort(self):
+        payload = _prepare_payload(provider_name="openrouter", thinking="high")
+
+        assert payload["reasoning"] == {"effort": "high"}
+
+    def test_maps_off_thinking_to_disabled_reasoning(self):
+        payload = _prepare_payload(provider_name="openrouter", thinking="off")
+
+        assert payload["reasoning"] == {"enabled": False}
+
+    def test_maps_max_thinking_to_high_effort(self):
+        payload = _prepare_payload(provider_name="openrouter", thinking="max")
+
+        assert payload["reasoning"] == {"effort": "high"}
+
+    def test_does_not_override_existing_reasoning_field(self):
+        adapter = OpenAIAdapter()
+        payload = {"model": "test", "reasoning": {"effort": "medium"}}
+
+        result = adapter.apply_openrouter_reasoning(payload, thinking="high")
+
+        assert result["reasoning"] == {"effort": "medium"}
+
+    def test_other_providers_do_not_get_reasoning_field(self):
+        payload = _prepare_payload(provider_name="fireworks", thinking="high")
+
+        assert "reasoning" not in payload

--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -67,6 +67,22 @@ class OpenAIAdapter(APIAdapter):
             headers["Authorization"] = f"Bearer {api_key}"
         return headers
 
+    @staticmethod
+    def apply_openrouter_reasoning(
+        payload: dict[str, Any], thinking: str
+    ) -> dict[str, Any]:
+        if "reasoning" in payload:
+            return payload
+
+        if thinking == "off":
+            payload["reasoning"] = {"enabled": False}
+        elif thinking == "max":
+            payload["reasoning"] = {"effort": "high"}
+        elif thinking in {"low", "medium", "high"}:
+            payload["reasoning"] = {"effort": thinking}
+
+        return payload
+
     def _reasoning_to_api(
         self, msg_dict: dict[str, Any], field_name: str
     ) -> dict[str, Any]:
@@ -136,6 +152,9 @@ class OpenAIAdapter(APIAdapter):
         payload = self.build_payload(
             model_name, converted_messages, temperature, tools, max_tokens, tool_choice
         )
+
+        if provider.name == "openrouter":
+            payload = self.apply_openrouter_reasoning(payload, thinking)
 
         if enable_streaming:
             payload["stream"] = True


### PR DESCRIPTION
## Summary

Translate Vibe's `thinking` model config into OpenRouter's request-level `reasoning` object when the provider name is `openrouter`.

## Motivation

Fixes #855. OpenRouter expects `reasoning` as a dict (for example `{"enabled": false}` or `{"effort": "high"}`), but the generic OpenAI adapter previously ignored `thinking` for OpenRouter requests. As a result:

- Models with reasoning disabled by default never showed reasoning even when `thinking = "high"` was configured
- Models with reasoning enabled by default could not be turned off with `thinking = "off"`

## Changes

- Add `OpenAIAdapter.apply_openrouter_reasoning()` to map Vibe thinking levels to OpenRouter's API shape
- Call it from `prepare_request()` when `provider.name == "openrouter"`
- Add unit tests in `tests/backend/test_openrouter_reasoning.py`

## Tests

```bash
uv run pytest tests/backend/test_openrouter_reasoning.py -n0 -v
```

Result: 5 passed

```bash
uv run ruff check vibe/core/llm/backend/generic.py tests/backend/test_openrouter_reasoning.py
```

Result: All checks passed

## Notes

- Reviewed by composer-2.5 sub-agent: **APPROVE**
- Existing `reasoning` fields in the payload are left untouched
- `thinking = "max"` maps to `{"effort": "high"}` (same collapse used elsewhere in Vibe)