### PR TITLE
chore: Add more informative error message when hitting authentication…

### DIFF
--- a/tests/core/test_backend_error.py
+++ b/tests/core/test_backend_error.py
@@ -58,7 +58,7 @@ class TestBackendErrorFmt:
 
     def test_unauthorized_short_circuits(self) -> None:
         err = _make_error(status=401)
-        assert str(err) == "Invalid API key. Please check your API key and try again."
+        assert str(err) == "Invalid API key. Please check your API key and try again.  Try `vibe --setup` and re-authenticate"
 
     def test_rate_limit_short_circuits(self) -> None:
         err = _make_error(status=429)


### PR DESCRIPTION
When hitting a 401 authentication error, the error message is very uninformative and doesn't show that you (might) need to reauthenticate. 

I've added instructions how to re-authenticate. Just use `vibe --setup`