### PR TITLE
fix(skills): allow dots in skill names for cross-platform compatibility

### DIFF
--- a/tests/skills/test_manager.py
+++ b/tests/skills/test_manager.py
@@ -51,6 +51,16 @@ class TestSkillManagerDiscovery:
         assert "skill-two" in manager.available_skills
         assert "skill-three" in manager.available_skills
 
+    def test_discovers_skill_with_dots_in_name(self, skills_dir: Path) -> None:
+        create_skill(
+            skills_dir, "ama.accounting.mailbox.vendor-receipts", "A namespaced skill"
+        )
+
+        config = build_test_vibe_config(skill_paths=[skills_dir])
+        manager = SkillManager(lambda: config)
+
+        assert "ama.accounting.mailbox.vendor-receipts" in manager.available_skills
+
     def test_ignores_directories_without_skill_md(self, skills_dir: Path) -> None:
         # Create a directory that's not a skill
         not_a_skill = skills_dir / "not-a-skill"

--- a/tests/skills/test_models.py
+++ b/tests/skills/test_models.py
@@ -59,6 +59,22 @@ class TestSkillMetadata:
             SkillMetadata(name="-test-skill-", description="A test skill")
         assert "name" in str(exc_info.value).lower()
 
+    def test_accepts_dots_in_name(self) -> None:
+        meta = SkillMetadata(
+            name="ama.accounting.mailbox.vendor-receipts", description="A test skill"
+        )
+        assert meta.name == "ama.accounting.mailbox.vendor-receipts"
+
+    def test_raises_error_for_consecutive_dots(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            SkillMetadata(name="test..skill", description="A test skill")
+        assert "name" in str(exc_info.value).lower()
+
+    def test_raises_error_for_leading_trailing_dots(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            SkillMetadata(name=".test.skill.", description="A test skill")
+        assert "name" in str(exc_info.value).lower()
+
     def test_parses_allowed_tools_from_space_delimited_string(self) -> None:
         meta = SkillMetadata(
             name="test",

--- a/vibe/core/skills/models.py
+++ b/vibe/core/skills/models.py
@@ -41,8 +41,8 @@ class SkillMetadata(BaseModel):
         ...,
         min_length=1,
         max_length=64,
-        pattern=r"^[a-z0-9]+(-[a-z0-9]+)*$",
-        description="Skill identifier. Lowercase letters, numbers, and hyphens only.",
+        pattern=r"^[a-z0-9]+([-.][a-z0-9]+)*$",
+        description="Skill identifier. Lowercase letters, numbers, hyphens, and dots.",
     )
     description: str = Field(
         ...,


### PR DESCRIPTION
Fixes #867

Skill directories that use dot namespacing (like `ama.accounting.mailbox.vendor-receipts`) work in other agent CLIs but fail Vibe's skill name validation, which only allowed lowercase alphanumerics separated by hyphens. Anyone sharing skills across tools has to rename their directories just for Vibe.

This relaxes the `SkillMetadata.name` pattern to also accept dots as separators: `^[a-z0-9]+([-.][a-z0-9]+)*$`. Leading, trailing and consecutive separators are still rejected, and everything that was valid before stays valid. The registry name sanitizer already produces names that satisfy the old pattern, so nothing else needed to change.

Testing:
- New model tests for dotted names (valid, consecutive dots, leading/trailing dots)
- New manager test loading a skill from a dotted directory end to end
- Full tests/skills suite passes (114 tests), ruff and pyright clean

@elGrogz would appreciate a look when you get a chance, this one keeps coming up for people moving skills between tools.
