### PR TITLE
fix(io): sniff BOM before plain UTF-8 so SKILL.md files with a BOM load

### DIFF
--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -210,6 +210,15 @@ class TestReadSafeResultEncoding:
         assert got.text == "ok\n"
         assert got.encoding == "utf-8"
 
+    def test_reports_utf8_sig_and_strips_bom_for_utf8_bom_file(
+        self, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "bom.txt"
+        f.write_bytes(b"\xef\xbb\xbf---\nname: x\n---\n")
+        got = read_safe(f)
+        assert got.encoding == "utf-8-sig"
+        assert got.text == "---\nname: x\n---\n"
+
     @pytest.mark.asyncio
     async def test_async_reports_utf16_when_bom_present(self, tmp_path: Path) -> None:
         f = tmp_path / "u16.txt"

--- a/tests/skills/test_manager.py
+++ b/tests/skills/test_manager.py
@@ -51,6 +51,18 @@ class TestSkillManagerDiscovery:
         assert "skill-two" in manager.available_skills
         assert "skill-three" in manager.available_skills
 
+    def test_discovers_skill_with_utf8_bom(self, skills_dir: Path) -> None:
+        bom_skill_dir = skills_dir / "bom-skill"
+        bom_skill_dir.mkdir()
+        content = "---\nname: bom-skill\ndescription: A BOM skill\n---\n\nBody"
+        (bom_skill_dir / "SKILL.md").write_bytes(b"\xef\xbb\xbf" + content.encode())
+
+        config = build_test_vibe_config(skill_paths=[skills_dir])
+        manager = SkillManager(lambda: config)
+
+        assert "bom-skill" in manager.available_skills
+        assert manager.available_skills["bom-skill"].description == "A BOM skill"
+
     def test_ignores_directories_without_skill_md(self, skills_dir: Path) -> None:
         # Create a directory that's not a skill
         not_a_skill = skills_dir / "not-a-skill"

--- a/vibe/core/utils/io.py
+++ b/vibe/core/utils/io.py
@@ -84,8 +84,11 @@ def _get_candidate_encodings(
             seen.add(key)
             yield encoding
 
-    yield from _emit("utf-8")
+    # BOM sniffing must run before the plain UTF-8 attempt: a UTF-8 BOM file
+    # decodes "successfully" as utf-8 but keeps U+FEFF at the start of the
+    # text, breaking startswith-style checks downstream (e.g. frontmatter).
     yield from _emit(_encodings_from_bom(raw))
+    yield from _emit("utf-8")
     yield from _emit(preferred_encoding)
     yield from _emit(locale.getpreferredencoding(False))
     yield from _emit(_encoding_from_best_match(raw))


### PR DESCRIPTION
Fixes #701

A SKILL.md saved with a UTF-8 BOM (common when editing on Windows, Notepad and some editors add it silently) is reported as invalid with "Missing or invalid YAML frontmatter" even though the file looks perfectly fine.

Root cause: `decode_safe` tries plain `utf-8` before sniffing the BOM. A UTF-8 BOM file decodes successfully as utf-8, so the BOM survives as U+FEFF at the start of the returned text. The frontmatter splitter then sees `﻿---` instead of `---` on the first line and rejects the file (`str.strip()` does not remove U+FEFF, it is not whitespace).

Fix: try the BOM-derived codec first. For these files the codec is now `utf-8-sig`, which strips the marker. Round-trip writes stay byte-identical because the edit path reuses the reported encoding, so the BOM is preserved on write. The utf-16/32 BOM cases behave exactly as before since plain utf-8 decoding already failed on those.

This also fixes the same silent failure for any other file read through `read_safe`, AGENTS.md included.

Testing:
- New io test asserting utf-8-sig is reported and the BOM is stripped
- New manager test loading a BOM SKILL.md end to end
- Existing utf-16 encoding tests unchanged and passing, ruff and pyright clean

@michelTho tagging you for review when you have a moment.
