### PR TITLE
fix(llm): drop past reasoning content from requests when thinking is off

### DIFF
--- a/tests/backend/test_openai_adapter.py
+++ b/tests/backend/test_openai_adapter.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vibe.core.config import ProviderConfig
+from vibe.core.llm.backend.generic import OpenAIAdapter
+from vibe.core.types import LLMMessage, Role
+
+
+@pytest.fixture
+def adapter():
+    return OpenAIAdapter()
+
+
+@pytest.fixture
+def provider():
+    return ProviderConfig(
+        name="test-openai",
+        api_base="https://api.example.com/v1",
+        api_key_env_var="TEST_API_KEY",
+    )
+
+
+def _prepare(adapter, provider, messages, **kwargs):
+    defaults = dict(
+        model_name="m",
+        messages=messages,
+        temperature=0,
+        tools=None,
+        max_tokens=None,
+        tool_choice=None,
+        enable_streaming=False,
+        provider=provider,
+    )
+    defaults.update(kwargs)
+    return json.loads(adapter.prepare_request(**defaults).body)
+
+
+def _history_with_reasoning() -> list[LLMMessage]:
+    return [
+        LLMMessage(role=Role.user, content="Hi"),
+        LLMMessage(
+            role=Role.assistant, content="Answer", reasoning_content="Let me think..."
+        ),
+    ]
+
+
+class TestReasoningContentForwarding:
+    def test_reasoning_dropped_when_thinking_off(self, adapter, provider):
+        payload = _prepare(adapter, provider, _history_with_reasoning(), thinking="off")
+        msg = payload["messages"][1]
+        assert msg["content"] == "Answer"
+        assert "reasoning_content" not in msg
+
+    def test_reasoning_kept_when_thinking_enabled(self, adapter, provider):
+        payload = _prepare(
+            adapter, provider, _history_with_reasoning(), thinking="medium"
+        )
+        msg = payload["messages"][1]
+        assert msg["reasoning_content"] == "Let me think..."
+
+    def test_reasoning_renamed_and_dropped_with_custom_field_name(self, adapter):
+        provider = ProviderConfig(
+            name="test-openai",
+            api_base="https://api.example.com/v1",
+            api_key_env_var="TEST_API_KEY",
+            reasoning_field_name="reasoning",
+        )
+        kept = _prepare(adapter, provider, _history_with_reasoning(), thinking="high")
+        assert kept["messages"][1]["reasoning"] == "Let me think..."
+
+        dropped = _prepare(adapter, provider, _history_with_reasoning(), thinking="off")
+        assert "reasoning" not in dropped["messages"][1]
+        assert "reasoning_content" not in dropped["messages"][1]

--- a/tests/backend/test_reasoning_adapter.py
+++ b/tests/backend/test_reasoning_adapter.py
@@ -87,6 +87,41 @@ class TestThinkingBlocksConversion:
             {"type": "text", "text": "Answer"},
         ]
 
+    def test_reasoning_dropped_when_thinking_off(self, adapter, provider):
+        messages = [
+            LLMMessage(role=Role.user, content="Hi"),
+            LLMMessage(
+                role=Role.assistant,
+                content="Answer",
+                reasoning_content="Let me think...",
+            ),
+        ]
+        payload = _prepare(adapter, provider, messages, thinking="off")
+        assert payload["messages"][1]["content"] == "Answer"
+
+    def test_reasoning_dropped_when_thinking_off_keeps_tool_calls(
+        self, adapter, provider
+    ):
+        messages = [
+            LLMMessage(role=Role.user, content="Hi"),
+            LLMMessage(
+                role=Role.assistant,
+                content="Let me search.",
+                reasoning_content="I should look this up.",
+                tool_calls=[
+                    ToolCall(
+                        id="tc_1",
+                        index=0,
+                        function=FunctionCall(name="search", arguments='{"q": "test"}'),
+                    )
+                ],
+            ),
+        ]
+        payload = _prepare(adapter, provider, messages, thinking="off")
+        msg = payload["messages"][1]
+        assert msg["content"] == "Let me search."
+        assert msg["tool_calls"][0]["id"] == "tc_1"
+
     def test_assistant_without_reasoning_is_plain_string(self, adapter, provider):
         messages = [
             LLMMessage(role=Role.user, content="Hi"),

--- a/vibe/core/llm/backend/generic.py
+++ b/vibe/core/llm/backend/generic.py
@@ -112,21 +112,23 @@ class OpenAIAdapter(APIAdapter):
         thinking: str = "off",
     ) -> PreparedRequest:
         field_name = provider.reasoning_field_name
+        exclude = {
+            "message_id",
+            "reasoning_message_id",
+            "reasoning_state",
+            "injected",
+            "images",
+            "user_display_content",
+        }
+        # Models with thinking disabled can reject reasoning input (e.g. after
+        # switching from a reasoning model mid-session), so past reasoning
+        # content is dropped from the request.
+        if thinking == "off":
+            exclude.add("reasoning_content")
         converted_messages = [
             self._user_with_images_to_parts(
                 self._reasoning_to_api(
-                    msg.model_dump(
-                        exclude_none=True,
-                        exclude={
-                            "message_id",
-                            "reasoning_message_id",
-                            "reasoning_state",
-                            "injected",
-                            "images",
-                            "user_display_content",
-                        },
-                    ),
-                    field_name,
+                    msg.model_dump(exclude_none=True, exclude=exclude), field_name
                 ),
                 msg,
             )

--- a/vibe/core/llm/backend/reasoning_adapter.py
+++ b/vibe/core/llm/backend/reasoning_adapter.py
@@ -22,7 +22,9 @@ from vibe.core.types import (
 class ReasoningAdapter(APIAdapter):
     endpoint: ClassVar[str] = "/chat/completions"
 
-    def _convert_message(self, msg: LLMMessage) -> dict[str, Any]:
+    def _convert_message(
+        self, msg: LLMMessage, *, include_reasoning: bool
+    ) -> dict[str, Any]:
         match msg.role:
             case Role.system:
                 return {"role": "system", "content": msg.content or ""}
@@ -38,7 +40,9 @@ class ReasoningAdapter(APIAdapter):
                     return {"role": "user", "content": parts}
                 return {"role": "user", "content": msg.content or ""}
             case Role.assistant:
-                return self._convert_assistant_message(msg)
+                return self._convert_assistant_message(
+                    msg, include_reasoning=include_reasoning
+                )
             case Role.tool:
                 result: dict[str, Any] = {
                     "role": "tool",
@@ -49,10 +53,12 @@ class ReasoningAdapter(APIAdapter):
                     result["name"] = msg.name
                 return result
 
-    def _convert_assistant_message(self, msg: LLMMessage) -> dict[str, Any]:
+    def _convert_assistant_message(
+        self, msg: LLMMessage, *, include_reasoning: bool
+    ) -> dict[str, Any]:
         result: dict[str, Any] = {"role": "assistant"}
 
-        if msg.reasoning_content:
+        if include_reasoning and msg.reasoning_content:
             content: list[dict[str, Any]] = [
                 {
                     "type": "thinking",
@@ -130,7 +136,13 @@ class ReasoningAdapter(APIAdapter):
         api_key: str | None = None,
         thinking: str = "off",
     ) -> PreparedRequest:
-        converted_messages = [self._convert_message(msg) for msg in messages]
+        # Models with thinking disabled reject thinking blocks in the input
+        # (e.g. after switching from a reasoning model mid-session), so past
+        # reasoning content is dropped from the request.
+        converted_messages = [
+            self._convert_message(msg, include_reasoning=thinking != "off")
+            for msg in messages
+        ]
 
         payload = self._build_payload(
             model_name=model_name,


### PR DESCRIPTION
Fixes #758
Fixes #710

Switching mid-session from a reasoning model to one without reasoning support (mistral-medium-3.5 to devstral-small for example) fails every following request with:

```
status: 400 Bad Request
provider_message: Reasoning input is not enabled for this model
```

even with thinking set to off. The conversation history still contains assistant messages with reasoning content from the previous model, and two of the three request builders forward it no matter what the target model's thinking setting is:

- `ReasoningAdapter._convert_assistant_message` always emits `thinking` content blocks when `reasoning_content` is present
- `OpenAIAdapter.prepare_request` always includes `reasoning_content` in the dumped message

The Mistral SDK backend already handles this correctly with `include_reasoning_content=model.thinking != "off"`, so this applies the same rule to the other two adapters: when thinking is off, past reasoning content is dropped from the outgoing request. Text content and tool calls are untouched, and behavior with thinking enabled is unchanged.

Testing:
- New ReasoningAdapter tests: reasoning dropped when off, kept with tool calls intact
- New OpenAIAdapter tests: dropped when off, kept when enabled, and correct interaction with a custom `reasoning_field_name`
- Full tests/backend suite passes (232 tests), ruff and pyright clean

@michelTho you triaged #758 as a shared harness issue, so tagging you here.
