### PR TITLE
fix(cli): decode manual ! command output with the OEM code page fallback on Windows

### DIFF
--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -9,6 +9,7 @@ from vibe.core.utils import compact_complete_display, get_server_url_from_api_ba
 import vibe.core.utils.io as io_utils
 from vibe.core.utils.io import (
     _FILE_WRITE_LOCKS,
+    IncrementalSafeDecoder,
     decode_safe,
     file_write_lock,
     read_lines_safe,
@@ -218,6 +219,57 @@ class TestReadSafeResultEncoding:
         assert got.encoding == "utf-16-le"
         # utf-16-le leaves the BOM as U+FEFF in the string (unlike utf-8-sig).
         assert got.text == "\ufeffa\n"
+
+
+class TestIncrementalSafeDecoder:
+    def test_utf8_multibyte_split_across_chunks(self) -> None:
+        decoder = IncrementalSafeDecoder(from_subprocess=True)
+        raw = "héllo wörld".encode()
+        text = "".join(decoder.decode(bytes([b])) for b in raw)
+        text += decoder.decode(b"", final=True)
+        assert text == "héllo wörld"
+
+    def test_falls_back_to_oem_code_page_for_console_output(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(io_utils, "_windows_oem_encoding", lambda: "cp949")
+        decoder = IncrementalSafeDecoder(from_subprocess=True)
+        raw = "'ls'은(는) 내부 또는 외부 명령이 아닙니다.".encode("cp949")
+        chunks = [raw[i : i + 5] for i in range(0, len(raw), 5)]
+        text = "".join(decoder.decode(chunk) for chunk in chunks)
+        text += decoder.decode(b"", final=True)
+        assert text == "'ls'은(는) 내부 또는 외부 명령이 아닙니다."
+
+    def test_ascii_prefix_then_oem_bytes_keeps_prefix(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(io_utils, "_windows_oem_encoding", lambda: "cp850")
+        decoder = IncrementalSafeDecoder(from_subprocess=True)
+        text = decoder.decode(b"ok: ")
+        text += decoder.decode("répertoire".encode("cp850"), final=True)
+        assert text == "ok: répertoire"
+
+    def test_undecodable_bytes_are_replaced_not_raised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(io_utils, "_windows_oem_encoding", lambda: None)
+        monkeypatch.setattr(
+            io_utils.locale, "getpreferredencoding", lambda _false: "ascii"
+        )
+        decoder = IncrementalSafeDecoder(from_subprocess=True)
+        text = decoder.decode(b"a\xff\xfeb", final=True)
+        assert text == "a��b"
+
+    def test_truncated_utf8_tail_replaced_on_final(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(io_utils, "_windows_oem_encoding", lambda: None)
+        monkeypatch.setattr(
+            io_utils.locale, "getpreferredencoding", lambda _false: "ascii"
+        )
+        decoder = IncrementalSafeDecoder(from_subprocess=True)
+        text = decoder.decode("é".encode()[:1], final=True)
+        assert text == "�"
 
 
 class TestReadSafeAsync:

--- a/tests/tools/test_ui_bash_execution.py
+++ b/tests/tools/test_ui_bash_execution.py
@@ -132,7 +132,9 @@ async def test_ui_handles_non_utf8_stderr(vibe_app: VibeApp) -> None:
         await pilot.press("enter")
         message = await _wait_for_bash_output_message(vibe_app, pilot)
         output_widget = message.query_one(".bash-output", Static)
-        assert str(output_widget.render()) == "��"
+        # accept both possible encodings, as the locale fallback decoder may
+        # map the bytes instead of replacing them
+        assert str(output_widget.render()) in {"��", "\xff\xfe", r"\xff\xfe"}
         assert_no_command_error(vibe_app)
 
 

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import codecs
 from collections.abc import AsyncGenerator
 from contextlib import aclosing, suppress
 from dataclasses import dataclass
@@ -239,6 +238,7 @@ from vibe.core.utils import (
     get_user_cancellation_message,
     is_dangerous_directory,
 )
+from vibe.core.utils.io import IncrementalSafeDecoder
 
 _VSCODE_FAMILY_TERMINALS = {Terminal.VSCODE, Terminal.VSCODE_INSIDERS, Terminal.CURSOR}
 
@@ -1453,7 +1453,7 @@ class VibeApp(App):  # noqa: PLR0904
     ) -> None:
         if not stream:
             return
-        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        decoder = IncrementalSafeDecoder(from_subprocess=True)
         while True:
             chunk = await stream.read(4096)
             if not chunk:

--- a/vibe/core/utils/io.py
+++ b/vibe/core/utils/io.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 from collections.abc import AsyncIterator, Iterator
 import contextlib
 from contextlib import asynccontextmanager
@@ -123,6 +124,46 @@ def decode_safe(
         text = raw.decode(encoding, errors=errors)
     text, newline = normalize_newlines(text)
     return ReadSafeResult(text, encoding, newline)
+
+
+class IncrementalSafeDecoder:
+    """Streaming counterpart of :func:`decode_safe`.
+
+    Decodes chunks optimistically as UTF-8 and, on the first invalid byte,
+    switches permanently to the subprocess/locale encoding (Windows OEM code
+    page for console output) with undecodable bytes replaced. Bytes buffered
+    across chunk boundaries are re-decoded with the fallback codec, so no
+    output is lost on the switch.
+    """
+
+    def __init__(self, *, from_subprocess: bool = False) -> None:
+        self._utf8 = codecs.getincrementaldecoder("utf-8")()
+        self._fallback: codecs.IncrementalDecoder | None = None
+        self._from_subprocess = from_subprocess
+
+    def _fallback_decoder(self) -> codecs.IncrementalDecoder:
+        preferred = _windows_oem_encoding() if self._from_subprocess else None
+        for encoding in (preferred, locale.getpreferredencoding(False)):
+            if not encoding:
+                continue
+            try:
+                return codecs.getincrementaldecoder(encoding)("replace")
+            except LookupError:
+                continue
+        return codecs.getincrementaldecoder("utf-8")("replace")
+
+    def decode(self, chunk: bytes, *, final: bool = False) -> str:
+        if self._fallback is not None:
+            return self._fallback.decode(chunk, final)
+        try:
+            return self._utf8.decode(chunk, final)
+        except UnicodeDecodeError:
+            # The strict UTF-8 decoder leaves its internal buffer untouched
+            # when it raises, so buffered tail bytes plus this chunk are
+            # exactly the bytes not yet turned into text.
+            pending = bytes(self._utf8.getstate()[0]) + chunk
+            self._fallback = self._fallback_decoder()
+            return self._fallback.decode(pending, final)
 
 
 def read_safe(path: Path, *, raise_on_error: bool = False) -> ReadSafeResult:


### PR DESCRIPTION
Fixes #777

Output of manual `!` commands in the TUI is decoded as hardcoded UTF-8 with `errors="replace"`. Windows console programs emit the OEM code page instead (cp949 on Korean systems, cp850/cp437 on many others), so any non-ASCII output renders as replacement characters. The report in #777 shows a cmd error message in Korean turning into garbage.

The one-off bash tool already solved this: it decodes through `decode_safe(..., from_subprocess=True)`, which prefers the Windows OEM code page. The streaming `!` path just never got the same treatment.

This adds `IncrementalSafeDecoder` to `vibe.core.utils.io`, a streaming counterpart of `decode_safe`: it decodes optimistically as UTF-8 and on the first invalid byte switches permanently to the OEM code page (or the locale encoding) with undecodable bytes replaced. The strict UTF-8 incremental decoder leaves its internal buffer untouched when it raises, so bytes buffered across chunk boundaries are re-decoded by the fallback codec and nothing is lost at the switch point. On systems where the locale is UTF-8 the behavior is identical to before.

`_bash_read_stream` in the TUI now uses it with `from_subprocess=True`.

Testing:
- New decoder tests: multibyte UTF-8 split across chunk reads, cp949 Korean output in 5-byte chunks, ASCII prefix before OEM bytes, undecodable bytes replaced, truncated tail flushed on final
- Updated the non-UTF-8 stderr UI test to accept the locale-decoded rendering, matching what the stdout twin test already does
- tests/tools/test_ui_bash_execution.py and tests/core/test_utils.py pass, ruff and pyright clean

Verified on a Windows 11 machine. @elGrogz tagging you for a review pass when convenient.
