### PR TITLE
fix(keyring): chunk secrets over the Windows Credential Manager blob limit

### DIFF
--- a/tests/core/test_keyring.py
+++ b/tests/core/test_keyring.py
@@ -441,6 +441,108 @@ def test_delete_raises_missing_when_all_services_are_missing(
     assert deleted == [(service, "CUSTOM_API_KEY") for service in _ALL_SERVICES]
 
 
+class _FakeWindowsCredentialStore:
+    """In-memory stand-in for WinVaultKeyring enforcing the credential blob limit."""
+
+    def __init__(self) -> None:
+        self.store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        if len(password.encode("utf-16-le")) > 2400:
+            raise OSError(1783, "CredWrite", "The stub received bad data.")
+        self.store[(service, username)] = password
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self.store.get((service, username))
+
+    def delete_password(self, service: str, username: str) -> None:
+        if (service, username) not in self.store:
+            raise PasswordDeleteError()
+        del self.store[(service, username)]
+
+
+@pytest.fixture
+def windows_credential_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> _FakeWindowsCredentialStore:
+    fake = _FakeWindowsCredentialStore()
+    monkeypatch.setattr(keyring, "set_password", fake.set_password)
+    monkeypatch.setattr(keyring, "get_password", fake.get_password)
+    monkeypatch.setattr(keyring, "delete_password", fake.delete_password)
+    monkeypatch.setattr(
+        keyring_utils, "_uses_windows_credential_chunking", lambda: True
+    )
+    return fake
+
+
+_OVERSIZED_TOKEN = "t" * 3000
+
+
+def test_windows_oversized_secret_is_chunked_and_reads_back(
+    windows_credential_store: _FakeWindowsCredentialStore,
+) -> None:
+    set_api_key_in_keyring("CUSTOM_API_KEY", _OVERSIZED_TOKEN)
+    keyring_utils.clear_api_key_keyring_cache()
+
+    assert get_api_key_from_keyring("CUSTOM_API_KEY") == _OVERSIZED_TOKEN
+    marker = windows_credential_store.store[(_CURRENT_SERVICE, "CUSTOM_API_KEY")]
+    assert marker == "__vibe-chunked-v1__:5"
+    assert all(
+        len(value.encode("utf-16-le")) <= 2400
+        for value in windows_credential_store.store.values()
+    )
+
+
+def test_windows_small_secret_is_stored_directly(
+    windows_credential_store: _FakeWindowsCredentialStore,
+) -> None:
+    set_api_key_in_keyring("CUSTOM_API_KEY", "small-key")
+
+    assert windows_credential_store.store == {
+        (_CURRENT_SERVICE, "CUSTOM_API_KEY"): "small-key"
+    }
+
+
+def test_windows_rewrite_with_fewer_chunks_removes_stale_entries(
+    windows_credential_store: _FakeWindowsCredentialStore,
+) -> None:
+    set_api_key_in_keyring("CUSTOM_API_KEY", _OVERSIZED_TOKEN)
+    set_api_key_in_keyring("CUSTOM_API_KEY", "u" * 1300)
+    keyring_utils.clear_api_key_keyring_cache()
+
+    assert get_api_key_from_keyring("CUSTOM_API_KEY") == "u" * 1300
+    chunk_keys = [
+        username
+        for service, username in windows_credential_store.store
+        if service == _CURRENT_SERVICE and "__chunk_" in username
+    ]
+    assert sorted(chunk_keys) == [
+        "CUSTOM_API_KEY__chunk_0",
+        "CUSTOM_API_KEY__chunk_1",
+        "CUSTOM_API_KEY__chunk_2",
+    ]
+
+
+def test_windows_delete_removes_marker_and_chunks(
+    windows_credential_store: _FakeWindowsCredentialStore,
+) -> None:
+    set_api_key_in_keyring("CUSTOM_API_KEY", _OVERSIZED_TOKEN)
+
+    delete_api_key_from_keyring("CUSTOM_API_KEY")
+
+    assert windows_credential_store.store == {}
+
+
+def test_windows_missing_chunk_reads_as_absent(
+    windows_credential_store: _FakeWindowsCredentialStore,
+) -> None:
+    set_api_key_in_keyring("CUSTOM_API_KEY", _OVERSIZED_TOKEN)
+    keyring_utils.clear_api_key_keyring_cache()
+    del windows_credential_store.store[(_CURRENT_SERVICE, "CUSTOM_API_KEY__chunk_2")]
+
+    assert get_api_key_from_keyring("CUSTOM_API_KEY") is None
+
+
 def test_macos_set_recreates_item_with_security_stdin_and_unrestricted_acl(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/vibe/core/utils/keyring.py
+++ b/vibe/core/utils/keyring.py
@@ -5,6 +5,7 @@ import shlex
 import subprocess
 import sys
 from threading import Lock
+from typing import Final
 
 import keyring
 from keyring.errors import KeyringError, PasswordDeleteError
@@ -15,6 +16,15 @@ _DISABLE_KEYRING_ENV_VAR = "VIBE_TEST_DISABLE_KEYRING"
 _cache_lock = Lock()
 _api_key_cache: dict[str, str | None] = {}
 _SECURITY_NOT_FOUND = "could not be found"
+
+# The Windows Credential Manager rejects blobs over CRED_MAX_CREDENTIAL_BLOB_SIZE
+# (2560 bytes; keyring stores passwords as UTF-16). Larger secrets, such as MCP
+# OAuth token payloads, are split across `<username>__chunk_<i>` entries with the
+# main entry holding a marker recording the chunk count.
+_WIN_CRED_MAX_UTF16_BYTES: Final = 2400
+_WIN_CHUNK_CHARS: Final = 600
+_CHUNK_MARKER_PREFIX: Final = "__vibe-chunked-v1__:"
+_MAX_CHUNK_COUNT: Final = 100
 
 
 class _PasswordNotFoundError(KeyringError):
@@ -58,10 +68,81 @@ def _delete_macos_password(service: str, username: str) -> None:
         raise KeyringError("Can't delete password in macOS Keychain") from exc
 
 
+def _uses_windows_credential_chunking() -> bool:
+    return sys.platform == "win32"
+
+
+def _chunk_username(username: str, index: int) -> str:
+    return f"{username}__chunk_{index}"
+
+
+def _exceeds_windows_blob_limit(password: str) -> bool:
+    return len(password.encode("utf-16-le")) > _WIN_CRED_MAX_UTF16_BYTES
+
+
+def _parse_chunk_count(value: str) -> int | None:
+    if not value.startswith(_CHUNK_MARKER_PREFIX):
+        return None
+    suffix = value.removeprefix(_CHUNK_MARKER_PREFIX)
+    if not suffix.isdigit():
+        return None
+    count = int(suffix)
+    return count if 0 < count <= _MAX_CHUNK_COUNT else None
+
+
+def _delete_chunks(service: str, username: str, *, start: int) -> None:
+    for index in range(start, _MAX_CHUNK_COUNT):
+        try:
+            keyring.delete_password(service, _chunk_username(username, index))
+        except (PasswordDeleteError, KeyringError):
+            return
+
+
+def _set_chunked_password(service: str, username: str, password: str) -> None:
+    chunks = [
+        password[index : index + _WIN_CHUNK_CHARS]
+        for index in range(0, len(password), _WIN_CHUNK_CHARS)
+    ]
+    if len(chunks) > _MAX_CHUNK_COUNT:
+        raise KeyringError("Secret is too large for the Windows Credential Manager")
+    # The marker is deleted first and rewritten last so an interrupted write
+    # reads back as an absent secret, never as a mix of old and new chunks.
+    try:
+        keyring.delete_password(service, username)
+    except PasswordDeleteError:
+        pass
+    for index, chunk in enumerate(chunks):
+        keyring.set_password(service, _chunk_username(username, index), chunk)
+    keyring.set_password(service, username, f"{_CHUNK_MARKER_PREFIX}{len(chunks)}")
+    _delete_chunks(service, username, start=len(chunks))
+
+
+def _read_chunked_password(service: str, username: str, count: int) -> str | None:
+    parts: list[str] = []
+    for index in range(count):
+        part = keyring.get_password(service, _chunk_username(username, index))
+        if part is None:
+            return None
+        parts.append(part)
+    return "".join(parts)
+
+
+def _delete_password_with_chunks(service: str, username: str) -> None:
+    value = keyring.get_password(service, username)
+    keyring.delete_password(service, username)
+    if value is not None and _parse_chunk_count(value) is not None:
+        _delete_chunks(service, username, start=0)
+
+
 def _set_password(service: str, username: str, password: str) -> None:
     if not _should_use_macos_security():
         try:
-            keyring.set_password(service, username, password)
+            if _uses_windows_credential_chunking() and _exceeds_windows_blob_limit(
+                password
+            ):
+                _set_chunked_password(service, username, password)
+            else:
+                keyring.set_password(service, username, password)
         except ImportError as exc:
             raise KeyringError("Can't load keyring backend") from exc
         return
@@ -104,9 +185,12 @@ def _get_password(service: str, username: str) -> str | None:
         return result.stdout.removesuffix("\n")
 
     try:
-        return keyring.get_password(service, username)
+        value = keyring.get_password(service, username)
     except ImportError as exc:
         raise KeyringError("Can't load keyring backend") from exc
+    if value is None or (count := _parse_chunk_count(value)) is None:
+        return value
+    return _read_chunked_password(service, username, count)
 
 
 def _delete_password(service: str, username: str) -> None:
@@ -115,7 +199,10 @@ def _delete_password(service: str, username: str) -> None:
         return
 
     try:
-        keyring.delete_password(service, username)
+        if _uses_windows_credential_chunking():
+            _delete_password_with_chunks(service, username)
+        else:
+            keyring.delete_password(service, username)
     except ImportError as exc:
         raise KeyringError("Can't load keyring backend") from exc
 


### PR DESCRIPTION
Fixes #841

`/mcp login` crashes on Windows when the OAuth flow tries to persist tokens:

```
OSError: (1783, 'CredWrite', 'The stub received bad data')
```

The token JSON (access token, refresh token, metadata) routinely exceeds CRED_MAX_CREDENTIAL_BLOB_SIZE, the 2560-byte limit the Windows Credential Manager enforces on a single credential. keyring stores passwords as UTF-16, so the practical limit is about 1200 characters.

Change, all inside `vibe/core/utils/keyring.py`:

- On Windows, a secret that does not fit in one credential is split across `<username>__chunk_<i>` entries, and the main entry stores a marker recording the chunk count
- Reads detect the marker and reassemble transparently; a missing chunk reads as an absent secret rather than corrupt data
- Deletes remove the marker and all chunks; rewrites clean up stale chunks left over from a longer previous value
- The marker is deleted first and rewritten last, so an interrupted write reads back as absent instead of a mix of old and new chunks
- Secrets that fit in one credential keep the exact previous behavior on every platform, macOS and Linux paths are untouched

Testing:
- Five new unit tests against an in-memory credential store that enforces the real 2400-byte blob limit: chunked roundtrip, small secrets stored directly, stale chunk cleanup on shrink, delete removing everything, missing chunk read as absent
- Full tests/core/test_keyring.py, test_mcp_oauth.py and setup/auth suites pass (82 tests), ruff and pyright clean
- Verified against the real Credential Manager on Windows 11: a 2843-char OAuth payload reproduces WinError 1783 on a raw write, stores as five chunks through this path, reads back identical after a cache clear, and deletes cleanly

@michelTho this one hard-blocks OAuth MCP servers for Windows users, so flagging it for your queue.
