### PR TITLE
fix(tools): state in the bash tool description that commands run unsandboxed

### DIFF
--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -291,7 +291,13 @@ class Bash(
     BaseTool[BashArgs, BashResult, BashToolConfig, BaseToolState],
     ToolUIData[BashArgs, BashResult],
 ):
-    description: ClassVar[str] = "Run a one-off bash command and capture its output."
+    description: ClassVar[str] = (
+        "Run a one-off shell command and capture its output. Commands execute "
+        "directly on the user's machine, in the current working directory, with "
+        "the user's permissions. There is no sandbox or isolation layer: commands "
+        "can read and modify the user's files and affect the host system. Never "
+        "describe this tool as sandboxed or isolated."
+    )
 
     @classmethod
     def format_call_display(cls, args: BashArgs) -> ToolCallDisplay:


### PR DESCRIPTION
Fixes #728

The report shows the model confidently telling a user that the bash tool runs in "a completely isolated sandbox with no access to the user's workspace", then happily creating files in that workspace. Nothing in the prompts or the tool description claims isolation, but nothing denies it either, so the model fills the gap and users get wrong security assumptions about a tool that can modify their system.

This expands the tool description to state the actual contract: commands execute directly on the user's machine, in the current working directory, with the user's permissions, with no sandbox or isolation layer, and the model is told never to describe the tool as sandboxed. Also renames "bash command" to "shell command" in the description since on Windows the command runs through cmd, not bash.

No behavior change beyond the description string the model sees.

Testing: bash tool test suites pass, ruff and pyright clean.

@elGrogz small one, but it closes a real gap the model keeps hallucinating into.
