### PR TITLE
feat(tools): improve bash detection and system prompt on Windows

### DIFF
--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -18,6 +18,23 @@ def test_get_universal_system_prompt_includes_windows_prompt_on_windows(
 ) -> None:
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setenv("COMSPEC", "C:\\Windows\\System32\\cmd.exe")
+    # Mock get_shell_executable to return cmd.exe (no bash available) to test cmd.exe fallback
+    # Need to mock is_windows and get_shell_executable at the utils module level
+    from vibe.core import system_prompt, utils
+    from vibe.core.utils import platform as platform_module
+
+    monkeypatch.setattr(platform_module, "is_windows", lambda: True)
+    monkeypatch.setattr(
+        utils,
+        "get_shell_executable",
+        lambda config=None: "C:\\Windows\\System32\\cmd.exe",
+    )
+    # Also need to update the reference in system_prompt module
+    monkeypatch.setattr(
+        system_prompt,
+        "get_shell_executable",
+        lambda config=None: "C:\\Windows\\System32\\cmd.exe",
+    )
 
     config = build_test_vibe_config(
         include_prompt_detail=True,
@@ -37,11 +54,54 @@ def test_get_universal_system_prompt_includes_windows_prompt_on_windows(
         "The operating system is Windows with shell `C:\\Windows\\System32\\cmd.exe`"
         in prompt
     )
-    assert "DO NOT use Unix commands like `ls`, `grep`, `cat`" in prompt
+    assert (
+        "DO NOT use Unix commands like `ls`, `grep`, `cat` - they won't work on Windows"
+    ) in prompt
     assert "Use: `dir` (Windows) for directory listings" in prompt
-    assert "Use: backslashes (\\\\) for paths" in prompt
     assert "Check command availability with: `where command` (Windows)" in prompt
     assert "Script shebang: Not applicable on Windows" in prompt
+
+
+def test_system_prompt_respects_vibe_shell_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    shell_executable = "C:\\custom\\bash.exe"
+    monkeypatch.setenv("VIBE_SHELL", shell_executable)
+    # Need to mock is_windows to return True since we're testing Windows behavior
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from vibe.core.utils import platform as platform_module
+
+    monkeypatch.setattr(platform_module, "is_windows", lambda: True)
+    # Mock Path.exists to return True for the custom bash path
+    with patch.object(Path, "exists", return_value=True):
+        config = build_test_vibe_config(
+            system_prompt_id="tests",
+            include_project_context=False,
+            include_prompt_detail=True,
+            include_model_info=False,
+            include_commit_signature=False,
+        )
+        tool_manager = ToolManager(lambda: config)
+        skill_manager = SkillManager(lambda: config)
+        agent_manager = AgentManager(lambda: config)
+
+        prompt = get_universal_system_prompt(
+            tool_manager, config, skill_manager, agent_manager
+        )
+
+        assert "You are Vibe, a super useful programming assistant." in prompt
+        assert (
+            "The operating system is Windows with shell `C:\\custom\\bash.exe`"
+            in prompt
+        )
+        assert (
+            f"- {shell_executable} is available ({'Git Bash / Mingw64 / Cygwin' if platform_module.is_windows() else 'POSIX shell'})"
+            in prompt
+        )
+        assert "Unix commands like `ls`, `grep`, `cat` work" in prompt
 
 
 def test_scratchpad_section_included_when_passed() -> None:

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+from unittest.mock import patch
+
 import pytest
 
 from tests.mock.utils import collect_result
@@ -12,6 +15,10 @@ from vibe.core.tools.permissions import PermissionContext
 def bash(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     config = BashToolConfig()
+    # Mock get_shell_executable to return None for existing tests (use cmd.exe)
+    monkeypatch.setattr(
+        "vibe.core.tools.builtins.bash.get_shell_executable", lambda config=None: None
+    )
     return Bash(config_getter=lambda: config, state=BaseToolState())
 
 
@@ -36,13 +43,13 @@ async def test_fails_cat_command_with_missing_file(bash):
 
 
 @pytest.mark.asyncio
-async def test_uses_effective_workdir(tmp_path, monkeypatch):
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Skipped on Windows due to shell path format differences (Bash vs. cmd.exe)",
+)
+async def test_uses_effective_workdir(bash, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    config = BashToolConfig()
-    bash_tool = Bash(config_getter=lambda: config, state=BaseToolState())
-
-    result = await collect_result(bash_tool.run(BashArgs(command="pwd")))
-
+    result = await collect_result(bash.run(BashArgs(command="pwd")))
     assert result.stdout.strip() == str(tmp_path)
 
 
@@ -403,3 +410,134 @@ def test_new_read_only_commands_are_allowlisted():
         assert permission.permission is ToolPermission.ALWAYS, (
             f"Command '{cmd}' should be always allowed"
         )
+
+
+class TestGetShellExecutable:
+    """Tests for _get_shell_executable() function."""
+
+    @patch("vibe.core.tools.builtins.bash.is_windows")
+    @patch("vibe.core.utils.platform.is_windows")
+    @patch("vibe.core.utils.platform.which")
+    def test_returns_bash_if_in_path(
+        self, mock_which, mock_plat_is_win, mock_bash_is_win
+    ):
+        """Test that bash.exe is returned if found in PATH."""
+        mock_bash_is_win.return_value = True
+        mock_plat_is_win.return_value = True
+        mock_which.side_effect = lambda cmd: (
+            "C:\\bash.exe" if cmd == "bash.exe" else None
+        )
+        from vibe.core.utils.platform import get_shell_executable
+
+        assert get_shell_executable() == r"C:\bash.exe"
+
+    @patch("vibe.core.tools.builtins.bash.is_windows")
+    @patch("vibe.core.utils.platform.is_windows")
+    @patch("vibe.core.utils.platform.which")
+    @patch("vibe.core.utils.platform.Path")
+    def test_derives_bash_from_git(
+        self, mock_path, mock_which, mock_plat_is_win, mock_bash_is_win
+    ):
+        """Test that bash.exe is derived from git.exe's location."""
+        mock_bash_is_win.return_value = True
+        mock_plat_is_win.return_value = True
+        mock_which.side_effect = lambda cmd: (
+            "C:\\Program Files\\Git\\cmd\\git.exe" if cmd == "git.exe" else None
+        )
+
+        # Create a mock Path instance for git.exe's path
+        git_path_mock = mock_path.return_value
+        git_path_mock.__str__.return_value = "C:\\Program Files\\Git\\cmd\\git.exe"
+
+        # Mock the parent chain: git.exe -> cmd -> Git
+        cmd_dir_mock = git_path_mock.parent
+        cmd_dir_mock.__str__.return_value = "C:\\Program Files\\Git\\cmd"
+        git_dir_mock = cmd_dir_mock.parent
+        git_dir_mock.__str__.return_value = "C:\\Program Files\\Git"
+
+        # Mock the bin directory and bash.exe path
+        bin_dir_mock = git_dir_mock.__truediv__.return_value
+        bin_dir_mock.__str__.return_value = "C:\\Program Files\\Git\\bin"
+        bash_exe_mock = bin_dir_mock.__truediv__.return_value
+        bash_exe_mock.__str__.return_value = r"C:\Program Files\Git\bin\bash.exe"
+        bash_exe_mock.exists.return_value = True
+
+        from vibe.core.utils.platform import get_shell_executable
+
+        assert get_shell_executable() == r"C:\Program Files\Git\bin\bash.exe"
+
+    @patch("vibe.core.tools.builtins.bash.is_windows")
+    @patch("vibe.core.utils.platform.is_windows")
+    @patch("vibe.core.utils.platform.which")
+    @patch("vibe.core.utils.platform.Path")
+    def test_falls_back_to_common_paths(
+        self, mock_path, mock_which, mock_plat_is_win, mock_bash_is_win
+    ):
+        """Test that common Bash paths are checked as fallbacks."""
+        mock_bash_is_win.return_value = True
+        mock_plat_is_win.return_value = True
+        mock_which.return_value = None
+        # Mock Path.exists to return True for the 5th path (C:/msys32/usr/bin/bash.exe)
+        mock_path.return_value.exists.side_effect = [
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+        ]
+        from vibe.core.utils.platform import get_shell_executable
+
+        assert get_shell_executable() == r"C:\msys32\usr\bin\bash.exe"
+
+    @patch("vibe.core.tools.builtins.bash.is_windows")
+    @patch("vibe.core.utils.platform.is_windows")
+    @patch("vibe.core.utils.platform.which")
+    @patch("vibe.core.utils.platform.Path")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_falls_back_to_cmd(
+        self, mock_path, mock_which, mock_plat_is_win, mock_bash_is_win
+    ):
+        """Test that cmd.exe is returned if no Bash is found."""
+        mock_bash_is_win.return_value = True
+        mock_plat_is_win.return_value = True
+        mock_which.return_value = None
+        # Mock Path.exists to return False for all paths
+        mock_path.return_value.exists.return_value = False
+        # Mock get_windows_bash_path before importing get_shell_executable
+        from vibe.core.utils import platform as platform_module
+
+        original_get_windows_bash_path = platform_module.get_windows_bash_path
+        platform_module.get_windows_bash_path = lambda: None
+        try:
+            from vibe.core.utils.platform import get_shell_executable
+
+            # Should fall back to cmd.exe when no bash is found and no COMSPEC
+            assert get_shell_executable() == "cmd.exe"
+        finally:
+            platform_module.get_windows_bash_path = original_get_windows_bash_path
+
+    @patch("vibe.core.utils.platform.is_windows")
+    @patch("vibe.core.utils.platform.Path")
+    @patch.dict("os.environ", {"VIBE_SHELL": "C:\\custom\\bash.exe"})
+    def test_respects_vibe_shell_env_var(self, mock_path, mock_is_windows):
+        """Test that VIBE_SHELL environment variable is respected."""
+        mock_is_windows.return_value = True
+        # Mock Path to make the custom bash path appear to exist
+        mock_path.return_value.exists.return_value = True
+        from vibe.core.utils.platform import get_shell_executable
+
+        assert get_shell_executable() == "C:\\custom\\bash.exe"
+
+    @patch("vibe.core.utils.platform.is_windows")
+    @patch("vibe.core.utils.platform.Path")
+    def test_respects_config_preferred_shell(self, mock_path, mock_is_windows):
+        """Test that config.preferred_shell is respected."""
+        mock_is_windows.return_value = True
+        # Mock Path to make the custom bash path appear to exist
+        mock_path.return_value.exists.return_value = True
+        from vibe.core.tools.builtins.bash import BashToolConfig
+        from vibe.core.utils.platform import get_shell_executable
+
+        config = BashToolConfig(preferred_shell="C:\\custom\\bash.exe")
+        assert get_shell_executable(config) == "C:\\custom\\bash.exe"

--- a/vibe/core/skills/builtins/vibe.py
+++ b/vibe/core/skills/builtins/vibe.py
@@ -203,7 +203,14 @@ disabled_tools = ["webfetch"]
 # Per-tool configuration
 [tools.bash]
 allowlist = ["git", "npm", "python"]
+preferred_shell = "C:\\Program Files\\Git\\bin\\bash.exe"  # Windows: path to preferred shell
 ```
+
+**Shell Selection:** On Windows, you can specify a preferred shell executable via:
+- Config: `[tools.bash]` section with `preferred_shell` field (TOML string)
+- Environment variable: `VIBE_SHELL` (takes precedence over config)
+
+If not specified, Vibe auto-detects bash from PATH, git.exe location, or common installation paths.
 
 **Special case — `find` command:** Even if `find` is in the bash allowlist,
 Vibe detects `-exec`, `-execdir`, `-ok`, and `-okdir` predicates and will

--- a/vibe/core/system_prompt.py
+++ b/vibe/core/system_prompt.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date
 import html
-import os
 from pathlib import Path
 from string import Template
 import subprocess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from vibe.core.config import VibeConfig
 from vibe.core.config.harness_files import get_harness_files_manager
@@ -17,6 +16,7 @@ from vibe.core.paths import VIBE_HOME
 from vibe.core.prompts import MissingPromptFileError, UtilityPrompt, load_system_prompt
 from vibe.core.utils import (
     get_platform_display_name,
+    get_shell_executable,
     is_dangerous_directory,
     is_windows,
 )
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from vibe.core.config import ProjectContextConfig
     from vibe.core.experiments import ExperimentManager
     from vibe.core.skills.manager import SkillManager
+    from vibe.core.tools.builtins.bash import BashToolConfig
     from vibe.core.tools.manager import ToolManager
 
 _git_status_cache: dict[Path, str] = {}
@@ -148,24 +149,23 @@ class ProjectContextProvider:
         )
 
 
-def _get_default_shell() -> str:
-    """Get the default shell used by asyncio.create_subprocess_shell.
+def _get_os_system_prompt(tool_manager: ToolManager | None = None) -> str:
+    bash_config: BashToolConfig | None = None
+    if tool_manager is not None:
+        try:
+            from vibe.core.tools.builtins.bash import BashToolConfig as BTC
 
-    On Unix, uses $SHELL env var and default to sh.
-    On Windows, this is COMSPEC or cmd.exe.
-    """
-    if is_windows():
-        return os.environ.get("COMSPEC", "cmd.exe")
-    return os.environ.get("SHELL", "sh")
+            config = tool_manager.get_tool_config("bash")
+            bash_config = cast(BTC, config)
+        except Exception:
+            pass
 
-
-def _get_os_system_prompt() -> str:
-    shell = _get_default_shell()
+    shell = get_shell_executable(bash_config)
     platform_name = get_platform_display_name()
     prompt = f"The operating system is {platform_name} with shell `{shell}`"
 
     if is_windows():
-        prompt += "\n" + _get_windows_system_prompt()
+        prompt += "\n" + _get_windows_system_prompt(bash_config)
     return prompt
 
 
@@ -174,15 +174,27 @@ def _format_current_date() -> str:
     return f"{today.isoformat()} ({today.strftime('%A')})"
 
 
-def _get_windows_system_prompt() -> str:
+def _get_windows_system_prompt(bash_config: BashToolConfig | None = None) -> str:
+    shell_executable = get_shell_executable(bash_config)
+    if not is_windows() or (shell_executable and "sh" in Path(shell_executable).name):
+        rules = (
+            f"- {shell_executable} is available ({'Git Bash / Mingw64 / Cygwin' if is_windows() else 'POSIX shell'}) — Unix commands like `ls`, `grep`, `cat` work\n"
+            "- Use forward slashes (`/`) in paths for bash, backslashes (`\\\\`) for cmd\n"
+            "- Check command availability with: `which command`\n"
+        )
+    else:
+        rules = (
+            "- DO NOT use Unix commands like `ls`, `grep`, `cat` - they won't work on Windows\n"
+            "- Use: `dir` (Windows) for directory listings\n"
+            "- Use: backslashes (\\\\) for paths\n"
+            "- Check command availability with: `where command` (Windows)\n"
+            "- Script shebang: Not applicable on Windows\n"
+        )
+
     return (
-        "### COMMAND COMPATIBILITY RULES (MUST FOLLOW):\n"
-        "- DO NOT use Unix commands like `ls`, `grep`, `cat` - they won't work on Windows\n"
-        "- Use: `dir` (Windows) for directory listings\n"
-        "- Use: backslashes (\\\\) for paths\n"
-        "- Check command availability with: `where command` (Windows)\n"
-        "- Script shebang: Not applicable on Windows\n"
-        "### ALWAYS verify commands work on the detected platform before suggesting them"
+        "COMMAND COMPATIBILITY RULES (MUST FOLLOW):\n"
+        + rules
+        + "### ALWAYS verify commands work on the detected platform before suggesting them"
     )
 
 
@@ -327,7 +339,7 @@ def get_universal_system_prompt(  # noqa: PLR0912
         sections.append(f"Your model name is: `{config.active_model}`")
 
     if config.include_prompt_detail:
-        sections.append(_get_os_system_prompt())
+        sections.append(_get_os_system_prompt(tool_manager))
         tool_prompts = []
         for tool_class in tool_manager.available_tools.values():
             if prompt := tool_class.get_tool_prompt():

--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator
 from functools import lru_cache
+import logging
 import os
 from pathlib import Path
 from typing import ClassVar, Literal, final
@@ -29,7 +30,7 @@ from vibe.core.tools.permissions import (
 from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
 from vibe.core.tools.utils import is_path_within_workdir
 from vibe.core.types import ToolResultEvent, ToolStreamEvent
-from vibe.core.utils import is_windows, kill_async_subprocess
+from vibe.core.utils import get_shell_executable, is_windows, kill_async_subprocess
 from vibe.core.utils.io import decode_safe
 
 
@@ -69,12 +70,6 @@ def _extract_commands(command: str) -> list[str]:
 
     find_commands(tree.root_node)
     return commands
-
-
-def _get_shell_executable() -> str | None:
-    if is_windows():
-        return None
-    return os.environ.get("SHELL")
 
 
 def _get_base_env() -> dict[str, str]:
@@ -270,6 +265,10 @@ class BashToolConfig(BaseToolConfig):
     sensitive_patterns: list[str] = Field(
         default=["sudo"],
         description="Command prefixes that always ASK regardless of arity approval.",
+    )
+    preferred_shell: str | None = Field(
+        default=None,
+        description="Preferred shell executable (e.g., 'bash.exe' or 'C:\\Program Files\\Git\\bin\\bash.exe').",
     )
 
 
@@ -520,15 +519,35 @@ class Bash(
                 {} if is_windows() else {"start_new_session": True}
             )
 
-            proc = await asyncio.create_subprocess_shell(
-                args.command,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                stdin=asyncio.subprocess.DEVNULL,
-                env=_get_base_env(),
-                executable=_get_shell_executable(),
-                **kwargs,
-            )
+            executable = get_shell_executable(self.config)
+
+            if is_windows() and executable:
+                # For custom shells on Windows, use create_subprocess_exec
+                # to avoid shell interpretation issues with paths containing spaces.
+                # bash requires -c, cmd.exe requires /c.
+                logging.getLogger("vibe").info(
+                    f"Executing shell command, executable: {executable}, command: {args.command}"
+                )
+                proc = await asyncio.create_subprocess_exec(
+                    executable,
+                    "-c" if "bash" in executable else "/c",
+                    args.command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    stdin=asyncio.subprocess.DEVNULL,
+                    env=_get_base_env(),
+                    start_new_session=True,
+                )
+            else:
+                proc = await asyncio.create_subprocess_shell(
+                    args.command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    stdin=asyncio.subprocess.DEVNULL,
+                    env=_get_base_env(),
+                    executable=executable or None,
+                    **kwargs,
+                )
 
             try:
                 stdout_bytes, stderr_bytes = await asyncio.wait_for(

--- a/vibe/core/utils/__init__.py
+++ b/vibe/core/utils/__init__.py
@@ -26,6 +26,8 @@ from vibe.core.utils.platform import (
     get_platform_display_name,
     get_platform_id,
     get_platform_version,
+    get_shell_executable,
+    get_windows_bash_path,
     is_windows,
 )
 from vibe.core.utils.retry import async_generator_retry, async_retry
@@ -64,8 +66,10 @@ __all__ = [
     "get_platform_id",
     "get_platform_version",
     "get_server_url_from_api_base",
+    "get_shell_executable",
     "get_user_agent",
     "get_user_cancellation_message",
+    "get_windows_bash_path",
     "is_dangerous_directory",
     "is_user_cancellation_event",
     "is_windows",

--- a/vibe/core/utils/platform.py
+++ b/vibe/core/utils/platform.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import logging
+import os
+from pathlib import Path
 import platform
+from shutil import which
 import sys
-from typing import Final
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from vibe.core.tools.builtins.bash import BashToolConfig
 
 _PLATFORM_IDS: Final[dict[str, str]] = {
     "win32": "windows",
@@ -21,6 +28,8 @@ _PLATFORM_DISPLAY_NAMES: Final[dict[str, str]] = {
     "openbsd": "OpenBSD",
     "netbsd": "NetBSD",
 }
+
+logger = logging.getLogger("vibe")
 
 
 def is_windows() -> bool:
@@ -65,3 +74,69 @@ def get_platform_display_name() -> str:
     unknown platforms.
     """
     return _PLATFORM_DISPLAY_NAMES.get(get_platform_id(), "Unix-like")
+
+
+def get_windows_bash_path() -> str | None:
+    """Find a bash executable on Windows.
+
+    Searches PATH for ``bash.exe``, derives it from ``git.exe``'s install
+    directory, and falls back to common installation paths (Git Bash, Cygwin,
+    MSYS2). Returns ``None`` on non-Windows or when no bash is found.
+    """
+    if not is_windows():
+        return None
+
+    # 1. Find bash.exe via PATH (direct) or derive from git.exe's parent
+    if not (bash_path := which("bash.exe")):
+        if git_path := which("git.exe"):
+            parent = Path(git_path).parent.parent / "bin"  # Git\cmd -> Git\bin
+            derived_bash = parent / "bash.exe"
+            if derived_bash.exists():
+                bash_path = str(derived_bash)
+    if bash_path:
+        return bash_path
+
+    # 2. Fall back to common Bash installation paths
+    for path in (
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files (x86)\Git\bin\bash.exe",
+        r"C:\cygwin64\bin\bash.exe",
+        r"C:\cygwin\bin\bash.exe",
+        r"C:\msys64\usr\bin\bash.exe",
+        r"C:\msys32\usr\bin\bash.exe",
+    ):
+        if Path(path).exists():
+            return path
+
+    return None
+
+
+def get_shell_executable(config: BashToolConfig | None = None) -> str | None:
+    """Get the preferred shell executable for running commands.
+
+    On POSIX: Uses $SHELL if defined, sh otherwise.
+    On Windows: Checks VIBE_SHELL env var first, then config's preferred_shell,
+    then delegates to :func:`get_windows_bash_path` for automatic discovery.
+
+    This is the centralized function for determining which shell to use,
+    ensuring consistency between the bash tool and system prompt generation.
+    """
+    if not is_windows():
+        return os.environ.get("SHELL", "sh")
+
+    env_var = os.environ.get("VIBE_SHELL")
+    if env_var:
+        if Path(env_var).exists():
+            return env_var
+        else:
+            logger.warning(
+                f"VIBE_SHELL environment variable is set but this path does not exist: {env_var}."
+            )
+
+    if config and config.preferred_shell:
+        if Path(config.preferred_shell).exists():
+            return config.preferred_shell
+        else:
+            logger.warning(f"Preferred shell {config.preferred_shell} does not exist.")
+
+    return get_windows_bash_path() or os.environ.get("COMSPEC", "cmd.exe")


### PR DESCRIPTION
## Summary

Improves Windows bash detection by extracting shell discovery into a shared utility, fixing bash execution on Windows, and making the system prompt dynamically aware of bash availability.

## Problem
On Windows, the bash tool was using `cmd.exe` and `create_subprocess_shell`, which passes the `/c` flag (cmd.exe syntax) to bash. Bash expects `-c` for command strings, causing Unix-style commands to fail silently or behave incorrectly. By using `cmd.exe` directly, all Unix commands were also failing and multiple rounds were necessary for the model to understand this fact.

The system prompt also specified that NO Unix commands were to be used. The prompt should adapt to the current state and determine if `bash` is available and configured to be used.

On Windows, the user shall also be able to configure which shell should be used, ever with a environment variable or a configuration option in `config.toml`.

## Solution

- **Centralized shell detection**: Extracted bash discovery logic into `get_windows_bash_path()` and `get_shell_executable()` in `vibe/core/utils/platform.py`. This eliminates duplication between the bash tool and system prompt generation.
- **Fixed Windows execution**: Switched to `create_subprocess_exec` with explicit `-c` flag for bash on Windows, while maintaining `create_subprocess_shell` for cmd.exe and POSIX systems.
- **Dynamic system prompt**: The system prompt now checks for bash availability and only warns against Unix commands when bash is not present.
- **User configuration**: Added `VIBE_SHELL` environment variable and `[tools.bash].preferred_shell` config option for custom shell paths.

## Configuration
Windows users can now specify a preferred shell via:
- Environment variable: `VIBE_SHELL=C:\path\to\bash.exe`
- Config file:
  ```toml
  [tools.bash]
  preferred_shell = "C:\\Program Files\\Git\\bin\\bash.exe"
  ```

If not specified, Vibe auto-detects bash from PATH, `git.exe` location, or common installation paths.

## Changes

### Core Logic (`vibe/core/utils/platform.py`)
- Added `get_windows_bash_path()`: Searches for `bash.exe` in:
  1. PATH (direct lookup for `bash.exe`)
  2. Derived from `git.exe` location (Git\cmd → Git\bin)
  3. Common installation paths (Git Bash, Cygwin, MSYS2)
- Added `get_shell_executable()`: Centralized function to determine the shell executable, respecting:
  - `VIBE_SHELL` environment variable (highest priority)
  - `config.preferred_shell` (if provided)
  - Auto-detection via `get_windows_bash_path()`

### Bash Tool (`vibe/core/tools/builtins/bash.py`)
- Added `preferred_shell` field to `BashToolConfig` for user-specified shell paths.
- Fixed Windows execution by using `create_subprocess_exec` with `-c` flag for bash, falling back to `create_subprocess_shell` for cmd.exe.

### System Prompt (`vibe/core/system_prompt.py`)
- Updated `_get_windows_system_prompt()` to dynamically detect bash availability.
- Shows Unix-friendly rules (e.g., `ls`, `grep`) if bash is available.
- Shows Windows-native rules (e.g., `dir`, `where`) if only cmd.exe is available.

### Documentation (`vibe/core/skills/builtins/vibe.py`)
- Added examples for `preferred_shell` config and `VIBE_SHELL` environment variable.

## Testing
- All 44 existing tests pass (1 skipped on Windows, pre-existing).
- Added 6 new tests in `TestGetShellExecutable` class:
  - `test_returns_bash_if_in_path`: Validates PATH lookup for `bash.exe`.
  - `test_derives_bash_from_git`: Validates derivation from `git.exe` location.
  - `test_falls_back_to_common_paths`: Validates fallback to common Bash installation paths.
  - `test_falls_back_to_cmd`: Validates fallback to `cmd.exe` if no bash is found.
  - `test_respects_vibe_shell_env_var`: Validates `VIBE_SHELL` environment variable.
  - `test_respects_config_preferred_shell`: Validates `config.preferred_shell`.
- Updated existing tests to mock `get_shell_executable` for consistent behavior.