### PR TITLE
fix(tools): stop the bash tool hanging when a detached child holds the pipes

### DIFF
--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+import time
+
 import pytest
 
 from tests.mock.utils import collect_result
@@ -52,6 +55,27 @@ async def test_handles_timeout(bash):
         await collect_result(bash.run(BashArgs(command="sleep 2", timeout=1)))
 
     assert "Command timed out after 1s" in str(err.value)
+
+
+@pytest.mark.asyncio
+async def test_returns_promptly_when_detached_child_keeps_pipes_open(bash, tmp_path):
+    script = tmp_path / "spawn_detached.py"
+    script.write_text(
+        "import subprocess, sys\n"
+        "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(15)'])\n"
+        "print('parent done')\n",
+        encoding="utf-8",
+    )
+
+    start = time.monotonic()
+    result = await collect_result(
+        bash.run(BashArgs(command=f'"{sys.executable}" "{script}"', timeout=30))
+    )
+    elapsed = time.monotonic() - start
+
+    assert result.returncode == 0
+    assert "parent done" in result.stdout
+    assert elapsed < 10
 
 
 @pytest.mark.asyncio

--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -77,6 +77,37 @@ def _get_shell_executable() -> str | None:
     return os.environ.get("SHELL")
 
 
+_PIPE_DRAIN_GRACE_SECONDS = 2.0
+_PIPE_READ_CHUNK_BYTES = 65536
+
+
+async def _pump_stream(
+    stream: asyncio.StreamReader | None, buffer: bytearray, max_bytes: int
+) -> None:
+    # Reading continues past max_bytes (discarding) so a chatty child never
+    # blocks on a full pipe and can reach EOF.
+    if stream is None:
+        return
+    while chunk := await stream.read(_PIPE_READ_CHUNK_BYTES):
+        if len(buffer) < max_bytes:
+            buffer.extend(chunk[: max_bytes - len(buffer)])
+
+
+async def _wait_for_returncode(proc: asyncio.subprocess.Process, timeout: int) -> None:
+    # Process.wait() only resolves once every pipe has hit EOF
+    # (BaseSubprocessTransport._try_finish), so a detached child inheriting
+    # the pipes stalls it long after the command itself exited. returncode is
+    # set as soon as the process exits, so poll it instead.
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    delay = 0.01
+    while proc.returncode is None:
+        if loop.time() >= deadline:
+            raise TimeoutError
+        await asyncio.sleep(delay)
+        delay = min(delay * 2, 0.25)
+
+
 def _get_base_env() -> dict[str, str]:
     base_env = {**os.environ, "CI": "true", "NONINTERACTIVE": "1", "NO_TTY": "1"}
 
@@ -530,22 +561,31 @@ class Bash(
                 **kwargs,
             )
 
+            stdout_buf = bytearray()
+            stderr_buf = bytearray()
+            pumps = [
+                asyncio.create_task(_pump_stream(proc.stdout, stdout_buf, max_bytes)),
+                asyncio.create_task(_pump_stream(proc.stderr, stderr_buf, max_bytes)),
+            ]
             try:
-                stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                    proc.communicate(), timeout=timeout
-                )
+                await _wait_for_returncode(proc, timeout)
             except TimeoutError:
                 await kill_async_subprocess(proc)
                 raise self._build_timeout_error(args.command, timeout)
+            finally:
+                await asyncio.wait(pumps, timeout=_PIPE_DRAIN_GRACE_SECONDS)
+                for pump in pumps:
+                    pump.cancel()
+                await asyncio.gather(*pumps, return_exceptions=True)
 
             stdout = (
-                decode_safe(stdout_bytes, from_subprocess=True).text[:max_bytes]
-                if stdout_bytes
+                decode_safe(bytes(stdout_buf), from_subprocess=True).text[:max_bytes]
+                if stdout_buf
                 else ""
             )
             stderr = (
-                decode_safe(stderr_bytes, from_subprocess=True).text[:max_bytes]
-                if stderr_bytes
+                decode_safe(bytes(stderr_buf), from_subprocess=True).text[:max_bytes]
+                if stderr_buf
                 else ""
             )
 

--- a/vibe/core/utils/async_subprocess.py
+++ b/vibe/core/utils/async_subprocess.py
@@ -60,6 +60,11 @@ async def kill_async_subprocess(
                     exc_info=True,
                 )
 
-        await proc.wait()
+        # Process.wait() only resolves once every pipe has hit EOF
+        # (BaseSubprocessTransport._try_finish); a detached grandchild holding
+        # an inherited pipe would stall it forever even though the child was
+        # just killed. returncode is set on process exit, so poll it instead.
+        while proc.returncode is None:
+            await asyncio.sleep(0.02)
     except (ProcessLookupError, PermissionError, OSError):
         pass


### PR DESCRIPTION
Fixes #831

A tool call that spawns a detached or backgrounded child process left the bash tool stuck until its timeout (300s by default) even though the command itself finished instantly, exactly as the standalone reproducer in #831 shows.

Root cause, two layers deep:

1. `proc.communicate()` waits for EOF on stdout/stderr, and a detached child that inherited those pipes keeps them open for as long as it lives.
2. Swapping in `proc.wait()` does not help: asyncio's `BaseSubprocessTransport` only wakes exit waiters in `_call_connection_lost`, which requires the process to have exited AND every pipe transport to have disconnected (`_try_finish` in CPython's asyncio/base_subprocess.py). So `wait()` is pipe-hostage too. I verified this empirically before landing on the approach below.

Change in the bash tool:

- stdout/stderr are pumped concurrently into buffers bounded by `max_output_bytes` (reading continues past the cap so a chatty child never blocks on a full pipe; this also stops a flood of output from buffering unbounded in memory, which communicate() did)
- process exit is detected by polling `returncode`, which the transport sets as soon as the process exits, with the timeout as deadline
- after exit, the pipes get a 2 second grace period to reach EOF, then the tool returns with whatever output was captured

`kill_async_subprocess` had the same pipe dependency through `proc.wait()` after killing, which could stall the timeout path indefinitely when the surviving pipe holder was outside the killed group; it polls `returncode` now as well.

Testing:
- New test spawning a grandchild that holds the inherited pipes for 15s and asserting the tool returns with the parent's output well before that
- Full tests/tools/test_bash.py and tests/agent_loop/e2e/test_e2e_bash.py suites pass on Linux (50 tests), ruff and pyright clean
- Manually verified before/after: the reproducer scenario went from blocking the full 15s to returning in about 2s, with normal commands and timeout enforcement unchanged

@michelTho this closes out the fuzzer-style reproducer in #831.
