### PR TITLE
fix(session): restore persisted stats when resuming a session

### DIFF
--- a/tests/agent_loop/test_agent_stats.py
+++ b/tests/agent_loop/test_agent_stats.py
@@ -750,3 +750,39 @@ class TestStatsEdgeCases:
         await agent.reload_with_initial_messages(base_config=new_config)
 
         assert agent.config.active_model == "devstral-small"
+
+
+class TestRestoreFromSession:
+    def test_restores_persisted_fields(self) -> None:
+        stats = AgentStats()
+        persisted = AgentStats(
+            steps=7,
+            session_prompt_tokens=1200,
+            session_completion_tokens=340,
+            context_tokens=45_000,
+        ).model_dump()
+
+        stats.restore_from_session(persisted)
+
+        assert stats.steps == 7
+        assert stats.session_prompt_tokens == 1200
+        assert stats.session_completion_tokens == 340
+        assert stats.context_tokens == 45_000
+
+    def test_fires_registered_listeners(self) -> None:
+        stats = AgentStats()
+        seen: list[int] = []
+        stats.add_listener("context_tokens", lambda s: seen.append(s.context_tokens))
+
+        stats.restore_from_session(AgentStats(context_tokens=999).model_dump())
+
+        assert seen[-1] == 999
+
+    def test_ignores_invalid_payloads(self) -> None:
+        stats = AgentStats(context_tokens=5)
+
+        stats.restore_from_session(None)
+        stats.restore_from_session("garbage")
+        stats.restore_from_session({"context_tokens": "not-an-int"})
+
+        assert stats.context_tokens == 5

--- a/tests/cli/test_resume_restores_stats.py
+++ b/tests/cli/test_resume_restores_stats.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests.conftest import build_test_agent_loop, build_test_vibe_config
+from vibe.cli.cli import _resume_previous_session
+from vibe.core.session.session_loader import SessionLoader
+from vibe.core.types import LLMMessage, Role
+
+
+def _write_session(session_dir: Path) -> Path:
+    session_dir.mkdir(parents=True)
+    messages = [
+        LLMMessage(role=Role.user, content="Hello"),
+        LLMMessage(role=Role.assistant, content="Hi there!"),
+    ]
+    with (session_dir / "messages.jsonl").open("w", encoding="utf-8") as f:
+        for message in messages:
+            f.write(json.dumps(message.model_dump(exclude_none=True)) + "\n")
+    (session_dir / "meta.json").write_text(
+        json.dumps({
+            "session_id": "11111111-1111-1111-1111-111111111111",
+            "start_time": "2026-01-01T12:00:00Z",
+            "end_time": "2026-01-01T12:05:00Z",
+            "total_messages": 2,
+            "stats": {
+                "steps": 3,
+                "session_prompt_tokens": 1000,
+                "session_completion_tokens": 200,
+                "context_tokens": 42_000,
+            },
+            "username": "testuser",
+            "environment": {"working_directory": "/test"},
+        }),
+        encoding="utf-8",
+    )
+    return session_dir
+
+
+def test_resume_previous_session_restores_stats(tmp_path: Path) -> None:
+    agent_loop = build_test_agent_loop(config=build_test_vibe_config())
+    session_path = _write_session(tmp_path / "session")
+    loaded_messages, _ = SessionLoader.load_session(session_path)
+
+    _resume_previous_session(agent_loop, loaded_messages, session_path)
+
+    assert agent_loop.stats.context_tokens == 42_000
+    assert agent_loop.stats.session_prompt_tokens == 1000
+    assert agent_loop.stats.session_completion_tokens == 200
+    assert agent_loop.stats.steps == 3
+
+
+def test_resume_previous_session_tolerates_missing_stats(tmp_path: Path) -> None:
+    agent_loop = build_test_agent_loop(config=build_test_vibe_config())
+    session_path = _write_session(tmp_path / "session")
+    metadata_path = session_path / "meta.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    del metadata["stats"]
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    loaded_messages, _ = SessionLoader.load_session(session_path)
+
+    _resume_previous_session(agent_loop, loaded_messages, session_path)
+
+    assert agent_loop.stats.context_tokens == 0

--- a/vibe/acp/acp_agent_loop.py
+++ b/vibe/acp/acp_agent_loop.py
@@ -1241,6 +1241,7 @@ class VibeAcpAgentLoop(AcpAgent):
         loaded_session_id = metadata.get("session_id", agent_loop.session_id)
         agent_loop.session_id = loaded_session_id
         agent_loop.parent_session_id = metadata.get("parent_session_id")
+        agent_loop.stats.restore_from_session(metadata.get("stats"))
         agent_loop.session_logger.resume_existing_session(
             loaded_session_id, session_dir
         )

--- a/vibe/cli/cli.py
+++ b/vibe/cli/cli.py
@@ -210,6 +210,7 @@ def _resume_previous_session(
     session_id = metadata.get("session_id", agent_loop.session_id)
     agent_loop.session_id = session_id
     agent_loop.parent_session_id = metadata.get("parent_session_id")
+    agent_loop.stats.restore_from_session(metadata.get("stats"))
     agent_loop.session_logger.resume_existing_session(session_id, session_path)
 
     logger.info(

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -2576,6 +2576,7 @@ class VibeApp(App):  # noqa: PLR0904
 
         self.agent_loop.session_id = session.session_id
         self.agent_loop.parent_session_id = metadata.get("parent_session_id")
+        self.agent_loop.stats.restore_from_session(metadata.get("stats"))
         self.agent_loop.session_logger.resume_existing_session(
             session.session_id, session_path
         )

--- a/vibe/core/types.py
+++ b/vibe/core/types.py
@@ -23,6 +23,7 @@ from pydantic import (
     Field,
     JsonValue,
     PrivateAttr,
+    ValidationError,
     computed_field,
     field_validator,
     model_validator,
@@ -89,6 +90,17 @@ class AgentStats(BaseModel):
         fresh = AgentStats()
         fresh._listeners = previous._listeners.copy()
         return fresh
+
+    def restore_from_session(self, data: Any) -> None:
+        """Restore persisted stat values in place so registered listeners fire
+        and existing references stay valid. Invalid payloads are ignored.
+        """
+        try:
+            restored = AgentStats.model_validate(data)
+        except ValidationError:
+            return
+        for field in type(self).model_fields:
+            setattr(self, field, getattr(restored, field))
 
     @computed_field
     @property


### PR DESCRIPTION
Fixes #712
Fixes #713

After resuming a session the context indicator in the bottom right shows 0% (and the session totals reset) until the first new completion arrives. The messages restore fine; only the stats are lost.

Root cause: `stats.context_tokens` is only ever set from live LLM usage in the agent loop. The values are already persisted in the session metadata on every interaction (`save_interaction` writes `stats.model_dump()`), but none of the resume paths read them back.

Change:

- New `AgentStats.restore_from_session(data)`: validates the persisted payload and copies the values onto the live stats object field by field, in place, so listeners registered on the object (like the context progress meter) fire and existing references stay valid. Invalid or missing payloads are ignored silently, matching how the rest of the metadata is read defensively.
- Called from all three resume paths: `vibe --resume` / `--continue` at startup, the in-app session picker, and the ACP `loadSession` handler. The ACP path also sends a usage update right after loading, which previously reported zeros.

Testing:
- Unit tests for the new method: field restoration, listener firing, invalid payloads ignored
- Integration tests for the CLI resume path against a session directory on disk, with and without a stats block in the metadata
- tests/agent_loop/test_agent_stats.py, tests/cli/test_ui_session_resume.py and the ACP session tests pass on Linux, ruff and pyright clean

@elGrogz two long-standing duplicate reports close with this one.
