### PR TITLE
fix(config): unconditionally rename devstral-2 alias in _migrate_model_renames

### DIFF
--- a/tests/core/test_migration.py
+++ b/tests/core/test_migration.py
@@ -1,0 +1,24 @@
+from vibe.core.config._migration import migrate_config
+
+
+def test_active_model_rename_does_not_dangle_with_custom_model_name():
+    """Regression for #860.
+
+    When a devstral-2 model entry has a non-standard 'name' (not
+    'mistral-vibe-cli-latest'), the old code renamed active_model to
+    'mistral-medium-3.5' but left the model alias as 'devstral-2'.
+    That mismatch caused:
+        Active model 'mistral-medium-3.5' not found in configuration.
+    The fix makes the alias rename unconditional.
+    """
+    data = {
+        "active_model": "devstral-2",
+        "models": [
+            {"alias": "devstral-2", "name": "custom-old-name", "provider": "mistral"}
+        ],
+    }
+    migrate_config(data)
+    aliases = {m["alias"] for m in data["models"]}
+    assert data["active_model"] in aliases, (
+        f"active_model={data['active_model']!r} is dangling, aliases={aliases}"
+    )

--- a/vibe/core/config/_migration.py
+++ b/vibe/core/config/_migration.py
@@ -109,16 +109,14 @@ def _migrate_model_renames(data: dict[str, Any]) -> bool:
     """Rename devstral-2 to mistral-medium-3.5 and update its config."""
     changed = False
     for model in data.get("models", []):
-        if (
-            model.get("name") == "mistral-vibe-cli-latest"
-            and model.get("alias") == "devstral-2"
-        ):
+        if model.get("alias") == "devstral-2":
             model["alias"] = "mistral-medium-3.5"
-            model["temperature"] = 1.0
-            model["input_price"] = 1.5
-            model["output_price"] = 7.5
-            model["thinking"] = "high"
             changed = True
+            if model.get("name") == "mistral-vibe-cli-latest":
+                model["temperature"] = 1.0
+                model["input_price"] = 1.5
+                model["output_price"] = 7.5
+                model["thinking"] = "high"
 
         if (
             model.get("name") == "mistral-vibe-cli-latest"


### PR DESCRIPTION
## Problem

Fixes #860

`_migrate_model_renames` renames `active_model` from `devstral-2` to `mistral-medium-3.5` unconditionally, but only renames the model alias when `name == "mistral-vibe-cli-latest"`. Users with a custom or legacy model name end up with a dangling `active_model` reference, causing the session to fail immediately on startup with no way to recover through the UI.

## Root Cause

The alias rename was gated on `name`, but the `active_model` rename was not. The two fell out of sync for any model entry where `name` was not the official value.

```python
# before: alias rename only fires when name matches
if (
    model.get("name") == "mistral-vibe-cli-latest"
    and model.get("alias") == "devstral-2"
):
    model["alias"] = "mistral-medium-3.5"

# active_model rename fires regardless
if data.get("active_model") == "devstral-2":
    data["active_model"] = "mistral-medium-3.5"
```

Result: `active_model = "mistral-medium-3.5"` but `models[].alias` still `"devstral-2"`.

## Fix

Decouple the alias rename from the `name` check. Price and temperature bumps remain gated on the official model name to avoid clobbering user-tuned values.

## Evidence

**Before** (`python repro_860.py` against unpatched code)
=== AFTER migrate_config ===
active_model  = mistral-medium-3.5
model aliases = ['devstral-2']
BUG CONFIRMED: active_model dangling -> mistral-medium-3.5 not in {'devstral-2'}

**After** (same script against patched code)
=== AFTER migrate_config ===
active_model  = mistral-medium-3.5
model aliases = ['mistral-medium-3.5']
OK: active_model is in models list

**Tests**
python -m pytest tests/core/test_migration.py -v
PASSED tests/core/test_migration.py::test_active_model_rename_does_not_dangle_with_custom_model_name
1 passed in 4.71s

`test_active_model_rename_does_not_dangle_with_custom_model_name` reproduces the exact #860 scenario and fails on unpatched code.