### PR TITLE
fix(cli): fall back to home dir when workdir is deleted

### DIFF
--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -356,3 +356,24 @@ class TestFileWriteLock:
         release.set()
         await asyncio.gather(t1, t2)
         assert order == ["first-acquired", "first-released", "second-acquired"]
+
+
+class TestSafeCwd:
+    def test_safe_cwd_returns_cwd_normally(self) -> None:
+        from vibe.core.utils.paths import safe_cwd
+
+        assert safe_cwd() == Path.cwd()
+
+    def test_safe_cwd_falls_back_to_home_when_cwd_deleted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from vibe.core.utils.paths import safe_cwd
+
+        monkeypatch.setattr(
+            Path,
+            "cwd",
+            classmethod(
+                lambda cls: (_ for _ in ()).throw(FileNotFoundError("deleted"))
+            ),
+        )
+        assert safe_cwd() == Path.home()

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -238,6 +238,7 @@ from vibe.core.utils import (
     CancellationReason,
     get_user_cancellation_message,
     is_dangerous_directory,
+    safe_cwd,
 )
 
 _VSCODE_FAMILY_TERMINALS = {Terminal.VSCODE, Terminal.VSCODE_INSIDERS, Terminal.CURSOR}
@@ -968,7 +969,7 @@ class VibeApp(App):  # noqa: PLR0904
         self, content: str, *, skill_name: str | None = None
     ) -> bool:
         payload = await asyncio.to_thread(
-            build_path_prompt_payload, content, base_dir=Path.cwd()
+            build_path_prompt_payload, content, base_dir=safe_cwd()
         )
         images = await self._prepare_images_or_abort(payload)
         if images is None:
@@ -1670,7 +1671,7 @@ class VibeApp(App):  # noqa: PLR0904
         self, message: str, *, title_source: str | None = None
     ) -> None:
         prompt_payload = await asyncio.to_thread(
-            build_path_prompt_payload, message, base_dir=Path.cwd()
+            build_path_prompt_payload, message, base_dir=safe_cwd()
         )
         images = await self._prepare_images_or_abort(prompt_payload)
         if images is None:
@@ -1890,7 +1891,7 @@ class VibeApp(App):  # noqa: PLR0904
             # Payload building, prompt rendering, and title segmentation all
             # stat or read @-mentioned files; keep them off the UI thread.
             prompt_payload = prebuilt_payload or await asyncio.to_thread(
-                build_path_prompt_payload, prompt, base_dir=Path.cwd()
+                build_path_prompt_payload, prompt, base_dir=safe_cwd()
             )
             self._send_at_mention_telemetry(prompt_payload, message_id)
             images = await self._resolve_turn_images(prompt_payload, prebuilt_images)
@@ -1902,7 +1903,7 @@ class VibeApp(App):  # noqa: PLR0904
             auto_title: str | None = None
             if self.agent_loop.session_logger.needs_initial_auto_title():
                 title_segments = await asyncio.to_thread(
-                    build_title_segments, title_source or prompt, base_dir=Path.cwd()
+                    build_title_segments, title_source or prompt, base_dir=safe_cwd()
                 )
                 auto_title = format_session_title(title_segments) or None
             self._narrator_manager.cancel()

--- a/vibe/core/utils/__init__.py
+++ b/vibe/core/utils/__init__.py
@@ -21,7 +21,7 @@ from vibe.core.utils.http import (
 )
 from vibe.core.utils.matching import name_matches
 from vibe.core.utils.merge import MergeConflictError, MergeStrategy
-from vibe.core.utils.paths import is_dangerous_directory
+from vibe.core.utils.paths import is_dangerous_directory, safe_cwd
 from vibe.core.utils.platform import (
     get_platform_display_name,
     get_platform_id,
@@ -73,5 +73,6 @@ __all__ = [
     "kill_async_subprocess",
     "name_matches",
     "run_sync",
+    "safe_cwd",
     "utc_now",
 ]

--- a/vibe/core/utils/paths.py
+++ b/vibe/core/utils/paths.py
@@ -40,3 +40,16 @@ def is_dangerous_directory(path: Path | str = ".") -> tuple[bool, str]:
         except (OSError, ValueError):
             continue
     return False, ""
+
+
+def safe_cwd() -> Path:
+    """Return the current working directory, falling back to the home directory
+    if the working directory has been deleted while the process is running.
+
+    Fixes #846: Path.cwd() raises FileNotFoundError when the working directory
+    is deleted by another process during a session.
+    """
+    try:
+        return Path.cwd()
+    except FileNotFoundError:
+        return Path.home()


### PR DESCRIPTION
## Problem

Fixes #846

`Path.cwd()` raises `FileNotFoundError` when the working directory is deleted while vibe is running. The crash happens on the next message send, because `_handle_user_message` and related call sites do `build_path_prompt_payload(..., base_dir=Path.cwd())`.

Repro steps:

1. `cd /tmp/test_vibe && vibe`
2. From another terminal: `rm -rf /tmp/test_vibe`
3. Type and send any message in vibe
4. App crashes with `FileNotFoundError: [Errno 2] No such file or directory`

## Fix

Added `safe_cwd()` in `vibe/core/utils/paths.py`. Returns `Path.cwd()` normally, falls back to `Path.home()` if the cwd no longer exists.

```python
def safe_cwd() -> Path:
    try:
        return Path.cwd()
    except FileNotFoundError:
        return Path.home()
```

Exported it from `vibe/core/utils/__init__.py`. Replaced `Path.cwd()` with `safe_cwd()` on the message submit path in `vibe/cli/textual_ui/app.py`:

- `build_path_prompt_payload` (3 call sites)
- `build_title_segments`

## Evidence

Standalone script, ran once to reproduce the bug and once to confirm the fix, in the same process for a direct before/after comparison:

```python
import os, tempfile
from pathlib import Path
from vibe.core.utils.paths import safe_cwd

d = tempfile.mkdtemp()
os.chdir(d)
os.rmdir(d)

print("BEFORE (bug, direct Path.cwd()):")
try:
    print("no crash:", Path.cwd())
except FileNotFoundError as e:
    print("crash reproduced ->", type(e).__name__, e)

print("AFTER (fix, safe_cwd()):")
print("ok:", safe_cwd())
```

Output:

```
BEFORE (bug, direct Path.cwd()):
crash reproduced -> FileNotFoundError [Errno 2] No such file or directory

AFTER (fix, safe_cwd()):
ok: /home/lcheng
```

The BEFORE line matches the exact exception from the issue report. The AFTER line shows `safe_cwd()` recovering with `Path.home()` instead of crashing, using the identical deleted directory state.

## Tests

Added `TestSafeCwd` in `tests/core/test_utils.py`:

- `test_safe_cwd_returns_cwd_normally`, confirms unchanged behavior when cwd is valid
- `test_safe_cwd_falls_back_to_home_when_cwd_deleted`, mocks `Path.cwd()` to raise `FileNotFoundError` and asserts fallback to `Path.home()`

Result:

```
tests/core/test_utils.py::TestSafeCwd::test_safe_cwd_returns_cwd_normally PASSED
tests/core/test_utils.py::TestSafeCwd::test_safe_cwd_falls_back_to_home_when_cwd_deleted PASSED
2 passed in 22.60s
```

Full suite:

```
371 passed, 3 skipped
```

The 3 skips and one timeout in `tests/agent_loop/e2e/test_e2e_agent_loop.py` are pre-existing, require a live backend and API key, and are unrelated to this change.

## Files changed

- `vibe/core/utils/paths.py`
- `vibe/core/utils/__init__.py`
- `vibe/cli/textual_ui/app.py`
- `tests/core/test_utils.py`