### PR TITLE
Fix clipboard verification failure showing false success messages

### DIFF
--- a/tests/cli/test_clipboard.py
+++ b/tests/cli/test_clipboard.py
@@ -257,7 +257,7 @@ def test_copy_to_clipboard_stops_after_verified_copy() -> None:
 
 
 def test_copy_to_clipboard_tries_all_when_verify_fails() -> None:
-    """Tries all strategies when _read_clipboard never confirms."""
+    """Tries all strategies when _read_clipboard never confirms, then raises."""
     mock_first = MagicMock()
     mock_second = MagicMock()
 
@@ -265,7 +265,8 @@ def test_copy_to_clipboard_tries_all_when_verify_fails() -> None:
         patch("vibe.cli.clipboard._COPY_METHODS", [mock_first, mock_second]),
         patch("vibe.cli.clipboard._read_clipboard", return_value=None),
     ):
-        _copy_to_clipboard("hello")
+        with pytest.raises(RuntimeError, match="Clipboard copy succeeded but verification failed"):
+            _copy_to_clipboard("hello")
 
     mock_first.assert_called_once_with("hello")
     mock_second.assert_called_once_with("hello")

--- a/vibe/cli/clipboard.py
+++ b/vibe/cli/clipboard.py
@@ -128,6 +128,7 @@ def _copy_to_clipboard(text: str) -> None:
 
     if all_strategies_failed:
         raise RuntimeError("All clipboard strategies failed")
+    raise RuntimeError("Clipboard copy succeeded but verification failed")
 
 
 def _get_selected_texts(app: App) -> list[str]:


### PR DESCRIPTION
When clipboard copy strategies succeed but verification fails (e.g., copy writes succeed but read-back doesn't match), Vibe would incorrectly show success messages like 'Selection copied to clipboard' or 'Last agent message copied to clipboard' even though the clipboard didn't actually contain the text.

This fix ensures that _copy_to_clipboard() raises RuntimeError when copy strategies execute without exception but verification fails, causing the caller to show a failure notification instead of a false success message.

Root cause in my case: I was missing `xclip`.