### PR TITLE
Add @pytest.mark.network mark for build for network disconnected environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,6 +256,9 @@ ignore_decorators = ["@*"]
 [tool.pytest.ini_options]
 addopts = "-vvvv -q -n auto --durations=10 --import-mode=importlib --maxschedchunk=1"
 timeout = 10
+markers = [
+    "network: tests that require network-capable execution environment",
+]
 filterwarnings = [
     # (e2e) streaming mock server is started in a thread; and the cli is spawn in a fork
     "ignore:This process \\(pid=.*\\) is multi-threaded, use of forkpty\\(\\) may lead to deadlocks in the child\\.:DeprecationWarning",

--- a/tests/acp/test_acp.py
+++ b/tests/acp/test_acp.py
@@ -39,6 +39,7 @@ from vibe.core.types import FunctionCall, ToolCall
 RESPONSE_TIMEOUT = 2.0
 MOCK_ENTRYPOINT_PATH = "tests/mock/mock_entrypoint.py"
 PLAYGROUND_DIR = TESTS_ROOT / "playground"
+pytestmark = pytest.mark.network
 
 
 def deep_merge(target: dict, source: dict) -> None:

--- a/tests/acp/test_acp_entrypoint_smoke.py
+++ b/tests/acp/test_acp_entrypoint_smoke.py
@@ -21,6 +21,8 @@ BROWSER_AUTH_DESCRIPTION = (
     "Sign into Mistral Vibe through your Mistral AI Studio account."
 )
 
+pytestmark = pytest.mark.network
+
 
 class _AcpSmokeClient(Client):
     def on_connect(self, conn: Any) -> None:

--- a/tests/e2e/test_cli_tui_fresh_install.py
+++ b/tests/e2e/test_cli_tui_fresh_install.py
@@ -62,6 +62,7 @@ def _install_fresh_wheel(tmp_path: Path, wheel_path: Path) -> Path:
     return _venv_executable(venv_path, "vibe")
 
 
+@pytest.mark.network
 @pytest.mark.timeout(90)
 def test_fresh_wheel_install_can_spawn_cli_and_complete_happy_path(
     streaming_mock_server: StreamingMockServer,

--- a/tests/e2e/test_cli_tui_hooks.py
+++ b/tests/e2e/test_cli_tui_hooks.py
@@ -19,6 +19,8 @@ from tests.e2e.common import (
 )
 from tests.e2e.mock_server import StreamingMockServer
 
+pytestmark = pytest.mark.network
+
 
 def _enable_hooks(vibe_home: Path, invocation_path: Path) -> None:
     config_path = vibe_home / "config.toml"

--- a/tests/e2e/test_cli_tui_onboarding.py
+++ b/tests/e2e/test_cli_tui_onboarding.py
@@ -7,6 +7,8 @@ import pytest
 
 from tests.e2e.common import SpawnedVibeProcessFixture, ansi_tolerant_pattern
 
+pytestmark = pytest.mark.network
+
 
 @pytest.mark.timeout(15)
 def test_spawn_cli_shows_onboarding_when_api_key_missing(

--- a/tests/e2e/test_cli_tui_session_exit.py
+++ b/tests/e2e/test_cli_tui_session_exit.py
@@ -23,6 +23,8 @@ from tests.e2e.common import (
 from tests.e2e.mock_server import StreamingMockServer
 from vibe.core.utils.io import read_safe
 
+pytestmark = pytest.mark.network
+
 
 def _usage_by_run_factory(
     request_index: int, _payload: object

--- a/tests/e2e/test_cli_tui_streaming.py
+++ b/tests/e2e/test_cli_tui_streaming.py
@@ -14,6 +14,8 @@ from tests.e2e.common import (
 )
 from tests.e2e.mock_server import StreamingMockServer
 
+pytestmark = pytest.mark.network
+
 
 @pytest.mark.timeout(15)
 def test_spawn_cli_to_send_and_receive_message(

--- a/tests/e2e/test_cli_tui_tool_approval.py
+++ b/tests/e2e/test_cli_tui_tool_approval.py
@@ -14,6 +14,8 @@ from tests.e2e.common import (
 )
 from tests.e2e.mock_server import ChatCompletionsRequestPayload, StreamingMockServer
 
+pytestmark = pytest.mark.network
+
 PREDICTABLE_OUTPUT = "__E2E_BASH_OK__"
 TOOL_ARGUMENTS = f'{{"command":"printf \\"{PREDICTABLE_OUTPUT}\\\\n\\""}}'
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -6,6 +6,8 @@ import stat
 import subprocess
 from textwrap import dedent
 
+import pytest
+
 INSTALL_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "install.sh"
 
 _FAKE_VIBE_SCRIPT = """#!/usr/bin/env bash
@@ -102,6 +104,7 @@ def _run_install_script(
     )
 
 
+@pytest.mark.network
 def test_install_reports_missing_path_for_uv_tool_bin(tmp_path: Path) -> None:
     home = tmp_path / "home"
     fake_bin = tmp_path / "fake-bin"


### PR DESCRIPTION
Linux (not only) distributions build their packages in the network isolated environments (for reproducbility, if not for the security reasons). This commit adds pytest mark `network` which marks requiring network access, which needs to be skipped in such environments.