### PR TITLE
Fix TUI crash on MCP toggle when config.toml is invalid

### DIFF
--- a/tests/cli/test_ui_mcp_toggle.py
+++ b/tests/cli/test_ui_mcp_toggle.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from vibe.cli.textual_ui.app import VibeApp
+from vibe.cli.textual_ui.widgets.mcp_app import MCPApp, MCPSourceKind
+from vibe.core.config import ConfigFileError, VibeConfig
+from vibe.core.config.harness_files import get_harness_files_manager
+
+
+def _corrupt_config_file() -> None:
+    config_file = get_harness_files_manager().config_file
+    assert config_file is not None
+    config_file.write_text("[broken", encoding="utf-8")
+
+
+def test_get_persisted_config_raises_config_file_error_on_invalid_toml() -> None:
+    _corrupt_config_file()
+    with pytest.raises(ConfigFileError):
+        VibeConfig.get_persisted_config()
+
+
+@pytest.mark.asyncio
+async def test_mcp_toggle_notifies_instead_of_crashing_on_invalid_config(
+    vibe_app: VibeApp, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **_: object) -> None:
+        notifications.append(message)
+
+    async with vibe_app.run_test():
+        monkeypatch.setattr(vibe_app, "notify", fake_notify)
+        _corrupt_config_file()
+        message = MCPApp.MCPToggled(
+            name="some-connector", kind=MCPSourceKind.CONNECTOR, disabled=True
+        )
+        await vibe_app.on_mcpapp_mcptoggled(message)
+
+    assert notifications
+    assert "Invalid TOML" in notifications[0]

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -181,7 +181,13 @@ from vibe.core.autocompletion.path_prompt_adapter import (
     extract_image_resources,
     render_path_prompt_from_payload,
 )
-from vibe.core.config import DEFAULT_THEME, AnyVibeConfig, ModelConfig, VibeConfig
+from vibe.core.config import (
+    DEFAULT_THEME,
+    AnyVibeConfig,
+    ConfigFileError,
+    ModelConfig,
+    VibeConfig,
+)
 from vibe.core.data_retention import DATA_RETENTION_MESSAGE
 from vibe.core.hooks.models import HookStartEvent
 from vibe.core.log_reader import LogReader
@@ -1507,13 +1513,17 @@ class VibeApp(App):  # noqa: PLR0904
     async def on_mcpapp_mcptoggled(self, message: MCPApp.MCPToggled) -> None:
         from vibe.cli.textual_ui.widgets.mcp_app import MCPSourceKind
 
-        persist_mcp_toggle(
-            self.agent_loop.config,
-            name=message.name,
-            is_connector=message.kind == MCPSourceKind.CONNECTOR,
-            disabled=message.disabled,
-            tool_name=message.tool_name,
-        )
+        try:
+            persist_mcp_toggle(
+                self.agent_loop.config,
+                name=message.name,
+                is_connector=message.kind == MCPSourceKind.CONNECTOR,
+                disabled=message.disabled,
+                tool_name=message.tool_name,
+            )
+        except ConfigFileError as exc:
+            self.notify(str(exc), title="Could not save MCP setting", severity="error")
+            return
         self._refresh_config_from_disk()
         self.query_one(_get_mcp_app_class()).refresh_index()
         self._refresh_banner()

--- a/vibe/core/config/__init__.py
+++ b/vibe/core/config/__init__.py
@@ -40,6 +40,7 @@ from vibe.core.config.layers.default import DefaultConfigLayer
 from vibe.core.config.layers.discovered import DiscoveredConfigLayer
 from vibe.core.config.models import (
     THINKING_LEVELS,
+    ConfigFileError,
     ConnectorConfig,
     ExperimentsConfig,
     MCPHttp,
@@ -115,6 +116,7 @@ __all__ = [
     "ConfigChangeCallback",
     "ConfigChangeEvent",
     "ConfigDefinitionError",
+    "ConfigFileError",
     "ConfigFragment",
     "ConfigLayer",
     "ConfigLayerError",

--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -35,6 +35,7 @@ from vibe.core.config._migration import migrate_config
 from vibe.core.config.harness_files import get_harness_files_manager
 from vibe.core.config.models import (
     THINKING_LEVELS as THINKING_LEVELS,
+    ConfigFileError,
     ConnectorConfig,
     ExperimentsConfig,
     MCPServer,
@@ -123,9 +124,9 @@ class TomlFileSettingsSource(PydanticBaseSettingsSource):
         except FileNotFoundError:
             return {}
         except tomllib.TOMLDecodeError as e:
-            raise RuntimeError(f"Invalid TOML in {file}: {e}") from e
+            raise ConfigFileError(file, f"Invalid TOML in {file}: {e}") from e
         except OSError as e:
-            raise RuntimeError(f"Cannot read {file}: {e}") from e
+            raise ConfigFileError(file, f"Cannot read {file}: {e}") from e
 
     def get_field_value(
         self, field: FieldInfo, field_name: str

--- a/vibe/core/config/models.py
+++ b/vibe/core/config/models.py
@@ -26,6 +26,12 @@ from vibe.core.paths import SESSION_LOG_DIR
 from vibe.core.types import Backend
 
 
+class ConfigFileError(RuntimeError):
+    def __init__(self, path: Path, message: str) -> None:
+        super().__init__(message)
+        self.path = path
+
+
 class MissingAPIKeyError(RuntimeError):
     def __init__(self, env_key: str, provider_name: str) -> None:
         super().__init__(


### PR DESCRIPTION
Sentry: https://mistralai.sentry.io/issues/VIBE-CLI-KE

Fixes VIBE-3496

**Repro:** with an invalid `~/.vibe/config.toml`, toggling an MCP server/connector in the TUI crashed the whole app — `_load_toml` raised an unhandled error through the Textual message loop.

**Fix:** config loading now raises a typed `ConfigFileError`; the MCP toggle handler catches it and shows an error notification instead of crashing. Added a test that reproduces the crash and verifies the notification.