### PR TITLE
Fix TUI crash on permanent tool approval when config.toml is invalid

### DIFF
--- a/tests/cli/test_ui_approval_persist.py
+++ b/tests/cli/test_ui_approval_persist.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+import pytest
+
+from vibe.cli.textual_ui.app import VibeApp
+from vibe.cli.textual_ui.widgets.approval_app import ApprovalApp
+from vibe.core.config import ConfigFileError, VibeConfig
+from vibe.core.config.harness_files import get_harness_files_manager
+
+
+class _EmptyArgs(BaseModel):
+    pass
+
+
+_INVALID_MCP_CONFIG = """
+[[mcp_servers]]
+name = "legacy"
+type = "stdio"
+command = "echo"
+"""
+
+
+def _write_invalid_config() -> None:
+    config_file = get_harness_files_manager().config_file
+    assert config_file is not None
+    config_file.write_text(_INVALID_MCP_CONFIG, encoding="utf-8")
+
+
+def test_save_updates_raises_config_file_error_on_invalid_mcp_server() -> None:
+    _write_invalid_config()
+    with pytest.raises(ConfigFileError):
+        VibeConfig.save_updates({"tools": {"bash": {"permission": "always"}}})
+
+
+@pytest.mark.asyncio
+async def test_permanent_approval_notifies_instead_of_crashing_on_invalid_config(
+    vibe_app: VibeApp, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    notifications: list[str] = []
+
+    def fake_notify(message: str, **_: object) -> None:
+        notifications.append(message)
+
+    async with vibe_app.run_test():
+        monkeypatch.setattr(vibe_app, "notify", fake_notify)
+        _write_invalid_config()
+        message = ApprovalApp.ApprovalGrantedAlwaysPermanent(
+            tool_name="bash", tool_args=_EmptyArgs(), required_permissions=[]
+        )
+        await vibe_app.on_approval_app_approval_granted_always_permanent(message)
+
+    assert notifications
+    assert "Invalid configuration" in notifications[0]

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -1077,7 +1077,12 @@ class VibeApp(App):  # noqa: PLR0904
     async def on_approval_app_approval_granted_always_tool(
         self, message: ApprovalApp.ApprovalGrantedAlwaysTool
     ) -> None:
-        self.agent_loop.approve_always(message.tool_name, message.required_permissions)
+        try:
+            self.agent_loop.approve_always(
+                message.tool_name, message.required_permissions
+            )
+        except ConfigFileError as exc:
+            self.notify(str(exc), title="Could not save approval", severity="error")
 
         if self._pending_approval and not self._pending_approval.done():
             self._pending_approval.set_result((ApprovalResponse.YES, None))
@@ -1085,9 +1090,12 @@ class VibeApp(App):  # noqa: PLR0904
     async def on_approval_app_approval_granted_always_permanent(
         self, message: ApprovalApp.ApprovalGrantedAlwaysPermanent
     ) -> None:
-        self.agent_loop.approve_always(
-            message.tool_name, message.required_permissions, save_permanently=True
-        )
+        try:
+            self.agent_loop.approve_always(
+                message.tool_name, message.required_permissions, save_permanently=True
+            )
+        except ConfigFileError as exc:
+            self.notify(str(exc), title="Could not save approval", severity="error")
 
         if self._pending_approval and not self._pending_approval.done():
             self._pending_approval.set_result((ApprovalResponse.YES, None))

--- a/vibe/core/config/_settings.py
+++ b/vibe/core/config/_settings.py
@@ -7,7 +7,13 @@ import tomllib
 from typing import Any
 
 from dotenv import dotenv_values
-from pydantic import Field, PrivateAttr, field_validator, model_validator
+from pydantic import (
+    Field,
+    PrivateAttr,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 from pydantic.fields import FieldInfo
 from pydantic_core import to_jsonable_python
 from pydantic_settings import (
@@ -794,7 +800,12 @@ class VibeConfig(BaseSettings):
             toml_document = {}
         else:
             toml_document = _remove_none_values(jsonable)
-        cls.model_validate(toml_document)
+        try:
+            cls.model_validate(toml_document)
+        except ValidationError as e:
+            raise ConfigFileError(
+                target, f"Invalid configuration in {target}: {e}"
+            ) from e
         with target.open("wb") as f:
             tomli_w.dump(toml_document, f)
 


### PR DESCRIPTION
Sentry: https://mistralai.sentry.io/issues/VIBE-CLI-JN

Fixes VIBE-3498

**Repro:** with an existing invalid `~/.vibe/config.toml` (valid TOML but e.g. an `mcp_servers` entry using a legacy `type` key instead of the required `transport` discriminator), approving a tool "Allow always (permanent)" crashed the whole TUI — `dump_config` re-validates the merged config and raised an unhandled pydantic `ValidationError` through the Textual message loop.

**Fix:** `dump_config` now raises the typed `ConfigFileError` on validation failure; the approval handlers catch it and show an error notification instead of crashing. Follows the same pattern as #894 (which only covered TOML syntax errors in the MCP-toggle handler). Added a test reproducing the crash.