### PR TITLE
Fix NoneType crash in voice stop_recording drain-timeout race

### DIFF
--- a/tests/voice_manager/test_voice_manager.py
+++ b/tests/voice_manager/test_voice_manager.py
@@ -179,6 +179,47 @@ class TestStopRecording:
         assert manager.transcribe_state == TranscribeState.IDLE
 
     @pytest.mark.asyncio
+    async def test_stop_survives_task_cleared_during_drain(self) -> None:
+        import asyncio
+
+        class HangingTranscribeClient:
+            def __init__(self, provider=None, model=None) -> None:
+                pass
+
+            async def transcribe(self, audio_stream):
+                await asyncio.Event().wait()
+                return
+                yield
+
+            async def close(self) -> None:
+                pass
+
+        recorder = FakeAudioRecorder()
+        config = build_test_vibe_config(voice_mode_enabled=True)
+        manager = VoiceManager(
+            config_getter=lambda: config,
+            audio_recorder=recorder,
+            transcribe_client=HangingTranscribeClient(),
+        )
+        manager.start_recording()
+        task = manager._transcribe_task
+        assert task is not None
+
+        async def clear_task_during_drain() -> None:
+            await asyncio.sleep(0)
+            manager._transcribe_task = None
+
+        clearer = asyncio.create_task(clear_task_during_drain())
+        with patch(
+            "vibe.cli.voice_manager.voice_manager.TRANSCRIPTION_DRAIN_TIMEOUT", 0.01
+        ):
+            await manager.stop_recording()
+        await clearer
+        task.cancel()
+
+        assert manager.transcribe_state == TranscribeState.IDLE
+
+    @pytest.mark.asyncio
     async def test_stop_recovers_when_no_audio_was_sent(self) -> None:
         client = FakeTranscribeClient(
             events=[

--- a/vibe/cli/voice_manager/voice_manager.py
+++ b/vibe/cli/voice_manager/voice_manager.py
@@ -116,14 +116,13 @@ class VoiceManager:
         recording = self._audio_recorder.stop(wait_for_queue_drained=should_flush_queue)
         self._tracking.set_recording_duration(recording.duration)
 
-        if self._transcribe_task is not None:
+        task = self._transcribe_task
+        if task is not None:
             try:
-                await wait_for(
-                    self._transcribe_task, timeout=TRANSCRIPTION_DRAIN_TIMEOUT
-                )
+                await wait_for(task, timeout=TRANSCRIPTION_DRAIN_TIMEOUT)
             except TimeoutError:
                 logger.warning("Transcription task timed out, cancelling")
-                self._transcribe_task.cancel()
+                task.cancel()
                 self._on_audio_transcription_error("Transcription timed out")
             except CancelledError:
                 pass


### PR DESCRIPTION
Sentry: https://mistralai.sentry.io/issues/VIBE-CLI-JD

Fixes VIBE-3499

**Repro:** while a recording's transcription is still draining, a concurrent `cancel_recording`/`close` nulls `_transcribe_task` during the `await wait_for(...)`; when the drain then times out, the timeout branch calls `.cancel()` on `None` and crashes the TUI.

**Fix:** capture the task in a local before awaiting and use that reference in the timeout branch. Added a regression test that fails before and passes after.