### PR TITLE
Add read_image tool PoC (Mistral backend)

### DIFF
--- a/tests/backend/test_image_mapping.py
+++ b/tests/backend/test_image_mapping.py
@@ -34,6 +34,16 @@ def _user_message(image: ImageAttachment) -> LLMMessage:
     return LLMMessage(role=Role.user, content="describe this", images=[image])
 
 
+def _tool_message(image: ImageAttachment) -> LLMMessage:
+    return LLMMessage(
+        role=Role.tool,
+        content="read_image result",
+        images=[image],
+        tool_call_id="call-abc",
+        name="read_image",
+    )
+
+
 class _FakeProvider:
     name = "mistral"
     reasoning_field_name = "reasoning_content"
@@ -72,6 +82,22 @@ def test_mistral_mapper_emits_image_url_chunk(
     assert dumped["role"] == "user"
     parts = dumped["content"]
     assert parts[0] == {"type": "text", "text": "describe this"}
+    assert parts[1]["type"] == "image_url"
+    assert parts[1]["image_url"]["url"] == EXPECTED_DATA_URI
+
+
+def test_mistral_mapper_emits_image_url_chunk_for_tool_role(
+    image_attachment: ImageAttachment,
+) -> None:
+    mapper = MistralMapper()
+    prepared = mapper.prepare_message(_tool_message(image_attachment))
+
+    dumped = prepared.model_dump()
+    assert dumped["role"] == "tool"
+    assert dumped["tool_call_id"] == "call-abc"
+    assert dumped["name"] == "read_image"
+    parts = dumped["content"]
+    assert parts[0] == {"type": "text", "text": "read_image result"}
     assert parts[1]["type"] == "image_url"
     assert parts[1]["image_url"]["url"] == EXPECTED_DATA_URI
 
@@ -146,3 +172,16 @@ def test_text_only_user_message_keeps_string_content() -> None:
     text_block = anthropic_payload["messages"][0]["content"][0]
     assert text_block["type"] == "text"
     assert text_block["text"] == "hi"
+
+
+def test_text_only_tool_message_keeps_string_content() -> None:
+    text_msg = LLMMessage(
+        role=Role.tool, content="tool result", tool_call_id="call-1", name="some_tool"
+    )
+
+    mistral_prepared = MistralMapper().prepare_message(text_msg)
+    dumped = mistral_prepared.model_dump()
+    assert dumped["role"] == "tool"
+    assert dumped["content"] == "tool result"
+    assert dumped["tool_call_id"] == "call-1"
+    assert dumped["name"] == "some_tool"

--- a/tests/core/tools/builtins/test_read_image.py
+++ b/tests/core/tools/builtins/test_read_image.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.mock.utils import collect_result
+from vibe.core.scratchpad import init_scratchpad
+from vibe.core.tools.base import InvokeContext, ToolError
+from vibe.core.tools.builtins.read_image import (
+    ReadImage,
+    ReadImageArgs,
+    ReadImageConfig,
+    ReadImageResult,
+    ReadImageState,
+)
+from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay
+from vibe.core.types import (
+    FileImageSource,
+    ImageAttachment,
+    ToolResultEvent,
+    ToolStreamEvent,
+)
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def _make_read_image() -> ReadImage:
+    return ReadImage(config_getter=lambda: ReadImageConfig(), state=ReadImageState())
+
+
+# -- run() success cases ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reads_valid_png(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    img = tmp_path / "shot.png"
+    img.write_bytes(PNG_BYTES)
+    tool = _make_read_image()
+
+    result = await collect_result(tool.run(ReadImageArgs(path=str(img))))
+
+    assert isinstance(result, ReadImageResult)
+    assert result.path == str(img.resolve())
+    assert result.alias == "shot.png"
+    assert result.mime_type == "image/png"
+    assert result.image_path == str(img.resolve())
+
+
+@pytest.mark.asyncio
+async def test_reads_jpg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    img = tmp_path / "photo.jpg"
+    img.write_bytes(PNG_BYTES)
+    tool = _make_read_image()
+
+    result = await collect_result(tool.run(ReadImageArgs(path=str(img))))
+
+    assert result.alias == "photo.jpg"
+    assert result.mime_type == "image/jpeg"
+
+
+@pytest.mark.asyncio
+async def test_reads_webp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    img = tmp_path / "img.webp"
+    img.write_bytes(PNG_BYTES)
+    tool = _make_read_image()
+
+    result = await collect_result(tool.run(ReadImageArgs(path=str(img))))
+
+    assert result.alias == "img.webp"
+    assert result.mime_type == "image/webp"
+
+
+@pytest.mark.asyncio
+async def test_reads_gif(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    img = tmp_path / "anim.gif"
+    img.write_bytes(PNG_BYTES)
+    tool = _make_read_image()
+
+    result = await collect_result(tool.run(ReadImageArgs(path=str(img))))
+
+    assert result.alias == "anim.gif"
+    assert result.mime_type == "image/gif"
+
+
+@pytest.mark.asyncio
+async def test_reads_jpeg_extension(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    img = tmp_path / "photo.jpeg"
+    img.write_bytes(PNG_BYTES)
+    tool = _make_read_image()
+
+    result = await collect_result(tool.run(ReadImageArgs(path=str(img))))
+
+    assert result.alias == "photo.jpeg"
+    assert result.mime_type == "image/jpeg"
+
+
+@pytest.mark.asyncio
+async def test_relative_path_resolved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "sub").mkdir()
+    img = tmp_path / "sub" / "img.png"
+    img.write_bytes(PNG_BYTES)
+    tool = _make_read_image()
+
+    result = await collect_result(tool.run(ReadImageArgs(path="sub/img.png")))
+
+    assert result.path == str(img.resolve())
+    assert result.alias == "img.png"
+
+
+@pytest.mark.asyncio
+async def test_yields_stream_event_with_ctx(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    img = tmp_path / "shot.png"
+    img.write_bytes(PNG_BYTES)
+    tool = _make_read_image()
+    ctx = InvokeContext(tool_call_id="call-1")
+
+    events: list[ToolStreamEvent | ReadImageResult] = []
+    async for item in tool.run(ReadImageArgs(path=str(img)), ctx):
+        events.append(item)
+
+    assert len(events) == 2
+    assert isinstance(events[0], ToolStreamEvent)
+    assert events[0].message == "Reading image..."
+    assert events[0].tool_call_id == "call-1"
+    assert isinstance(events[1], ReadImageResult)
+    assert events[1].alias == "shot.png"
+
+
+@pytest.mark.asyncio
+async def test_no_stream_event_without_ctx(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    img = tmp_path / "shot.png"
+    img.write_bytes(PNG_BYTES)
+    tool = _make_read_image()
+
+    events: list[ToolStreamEvent | ReadImageResult] = []
+    async for item in tool.run(ReadImageArgs(path=str(img))):
+        events.append(item)
+
+    assert len(events) == 1
+    assert isinstance(events[0], ReadImageResult)
+
+
+# -- run() error cases -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unsupported_extension_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "doc.txt").write_text("not an image", encoding="utf-8")
+    tool = _make_read_image()
+
+    with pytest.raises(ToolError, match="Unsupported image extension"):
+        await collect_result(tool.run(ReadImageArgs(path=str(tmp_path / "doc.txt"))))
+
+
+@pytest.mark.asyncio
+async def test_file_not_found_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    tool = _make_read_image()
+
+    with pytest.raises(ToolError, match="File not found"):
+        await collect_result(tool.run(ReadImageArgs(path=str(tmp_path / "nope.png"))))
+
+
+@pytest.mark.asyncio
+async def test_directory_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pics").mkdir()
+    tool = _make_read_image()
+
+    with pytest.raises(ToolError, match="directory"):
+        await collect_result(tool.run(ReadImageArgs(path=str(tmp_path / "pics"))))
+
+
+@pytest.mark.asyncio
+async def test_empty_path_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    tool = _make_read_image()
+
+    with pytest.raises(ToolError, match="path cannot be empty"):
+        await collect_result(tool.run(ReadImageArgs(path="")))
+
+
+# -- get_result_images -----------------------------------------------------
+
+
+def test_get_result_images_returns_attachment() -> None:
+    tool = _make_read_image()
+    result = ReadImageResult(
+        path="/img/shot.png",
+        alias="shot.png",
+        mime_type="image/png",
+        image_path="/tmp/snaps/abc123.png",
+    )
+    images = tool.get_result_images(result)
+    assert images is not None
+    assert len(images) == 1
+    att = images[0]
+    assert isinstance(att, ImageAttachment)
+    assert isinstance(att.source, FileImageSource)
+    assert str(att.source.path) == "/tmp/snaps/abc123.png"
+    assert att.alias == "shot.png"
+    assert att.mime_type == "image/png"
+
+
+def test_get_result_images_returns_none_when_no_image_path() -> None:
+    tool = _make_read_image()
+    result = ReadImageResult(
+        path="/img/shot.png", alias="shot.png", mime_type="image/png", image_path=""
+    )
+    assert tool.get_result_images(result) is None
+
+
+# -- image_path excluded from model_dump -----------------------------------
+
+
+def test_image_path_excluded_from_dump() -> None:
+    result = ReadImageResult(
+        path="/img/shot.png",
+        alias="shot.png",
+        mime_type="image/png",
+        image_path="secret/path.png",
+    )
+    dumped = result.model_dump()
+    assert "image_path" not in dumped
+    assert dumped["path"] == "/img/shot.png"
+    assert dumped["alias"] == "shot.png"
+    assert dumped["mime_type"] == "image/png"
+
+
+# -- display methods -------------------------------------------------------
+
+
+def test_format_call_display() -> None:
+    args = ReadImageArgs(path="/team/logo.png")
+    display = ReadImage.format_call_display(args)
+
+    assert isinstance(display, ToolCallDisplay)
+    assert "/team/logo.png" in display.summary
+    assert display.suffix == ""
+
+
+def test_format_call_display_scratchpad_suffix() -> None:
+    sp = init_scratchpad("read-image-display")
+    assert sp is not None
+    img_path = sp / "shot.png"
+
+    display = ReadImage.format_call_display(ReadImageArgs(path=str(img_path)))
+
+    assert isinstance(display, ToolCallDisplay)
+    assert display.suffix == "(scratchpad)"
+
+
+def test_get_result_display_success() -> None:
+    result = ReadImageResult(
+        path="/img/shot.png",
+        alias="shot.png",
+        mime_type="image/png",
+        image_path="/snaps/abc.png",
+    )
+    event = ToolResultEvent(
+        tool_call_id="test", tool_name="read_image", tool_class=None, result=result
+    )
+    display = ReadImage.get_result_display(event)
+
+    assert isinstance(display, ToolResultDisplay)
+    assert display.success is True
+    assert "shot.png" in display.message
+    assert display.suffix == ""
+
+
+def test_get_result_display_scratchpad_suffix() -> None:
+    sp = init_scratchpad("read-image-result-display")
+    assert sp is not None
+    img_path = sp / "shot.png"
+    result = ReadImageResult(
+        path=str(img_path),
+        alias="shot.png",
+        mime_type="image/png",
+        image_path=str(img_path),
+    )
+    event = ToolResultEvent(
+        tool_call_id="test", tool_name="read_image", tool_class=None, result=result
+    )
+
+    display = ReadImage.get_result_display(event)
+
+    assert isinstance(display, ToolResultDisplay)
+    assert display.success is True
+    assert display.suffix == "(scratchpad)"
+
+
+def test_get_result_display_with_error() -> None:
+    event = ToolResultEvent(
+        tool_call_id="test",
+        tool_name="read_image",
+        tool_class=None,
+        result=None,
+        error="Something went wrong",
+    )
+    display = ReadImage.get_result_display(event)
+
+    assert isinstance(display, ToolResultDisplay)
+    assert display.success is False
+    assert "Something went wrong" in display.message
+
+
+def test_get_result_display_fallback() -> None:
+    event = ToolResultEvent(
+        tool_call_id="test",
+        tool_name="read_image",
+        tool_class=None,
+        result=None,
+        skip_reason="Skipped by user",
+    )
+    display = ReadImage.get_result_display(event)
+
+    assert display.success is False
+    assert "Skipped by user" in display.message
+
+
+def test_get_status_text() -> None:
+    assert ReadImage.get_status_text() == "Reading image"

--- a/vibe/core/agent_loop/_loop.py
+++ b/vibe/core/agent_loop/_loop.py
@@ -1661,6 +1661,8 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         if extra:
             text += "\n\n" + extra
 
+        images = tool_instance.get_result_images(result_model)
+
         result_cancelled = (
             isinstance(result_model, CancellableToolResult) and result_model.cancelled
         )
@@ -1682,6 +1684,7 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
             tool_output=result_dict,
             duration_ms=duration * 1000.0,
             initial_text=text,
+            tool_images=images,
         ):
             yield ev
         self.stats.tool_calls_succeeded += 1
@@ -1766,10 +1769,13 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         decision: ToolDecision | None = None,
         result: dict[str, Any] | None = None,
         span: trace.Span | None = None,
+        images: list[ImageAttachment] | None = None,
     ) -> None:
         self.messages.append(
             LLMMessage.model_validate(
-                self.format_handler.create_tool_response_message(tool_call, text)
+                self.format_handler.create_tool_response_message(
+                    tool_call, text, images=images
+                )
             )
         )
 

--- a/vibe/core/agent_loop_hooks.py
+++ b/vibe/core/agent_loop_hooks.py
@@ -43,7 +43,7 @@ from vibe.core.hooks.models import (
 )
 from vibe.core.llm.format import ResolvedToolCall
 from vibe.core.logger import logger
-from vibe.core.types import ToolResultEvent
+from vibe.core.types import ImageAttachment, ToolResultEvent
 from vibe.core.utils import (
     CANCELLATION_TAG,
     TOOL_ERROR_TAG,
@@ -92,6 +92,7 @@ class AgentLoopHooksMixin:
         decision: ToolDecision | None = None,
         result: dict[str, Any] | None = None,
         span: trace.Span | None = None,
+        images: list[ImageAttachment] | None = None,
     ) -> None: ...
 
     def _serialize_tool_input(self, tool_call: ResolvedToolCall) -> dict[str, Any]:
@@ -190,7 +191,10 @@ class AgentLoopHooksMixin:
                 events.append(ev)
         return final_text, events
 
-    async def _run_after_tool_and_finalize(
+    # Disabling PLR0913 too many arguments.
+    # All parameters are required independently downstream — grouping them
+    # into a bag object wouldn't reduce the count, just rename it.
+    async def _run_after_tool_and_finalize(  # noqa: PLR0913
         self,
         tool_call: ResolvedToolCall,
         *,
@@ -203,6 +207,7 @@ class AgentLoopHooksMixin:
         tool_error: str | None = None,
         duration_ms: float = 0.0,
         initial_text: str = "",
+        tool_images: list[ImageAttachment] | None = None,
     ) -> AsyncGenerator[HookEvent]:
         """Run after-tool hooks, apply text replacements, and record the response.
 
@@ -226,7 +231,13 @@ class AgentLoopHooksMixin:
             else:
                 yield ev
         self._handle_tool_response(
-            tool_call, final_text, response_status, decision, tool_output, span=span
+            tool_call,
+            final_text,
+            response_status,
+            decision,
+            tool_output,
+            span=span,
+            images=tool_images,
         )
 
     # ------------------------------------------------------------------

--- a/vibe/core/llm/backend/mistral.py
+++ b/vibe/core/llm/backend/mistral.py
@@ -113,6 +113,22 @@ class MistralMapper:
                     ],
                 )
             case Role.tool:
+                if msg.images:
+                    tool_parts: list[ContentChunk] = [
+                        TextChunk(type="text", text=msg.content or "")
+                    ]
+                    tool_parts.extend(
+                        ImageURLChunk(
+                            type="image_url", image_url=ImageURL(url=_to_data_uri(att))
+                        )
+                        for att in msg.images
+                    )
+                    return ToolMessage(
+                        role="tool",
+                        content=tool_parts,
+                        tool_call_id=msg.tool_call_id,
+                        name=msg.name,
+                    )
                 return ToolMessage(
                     role="tool",
                     content=msg.content,

--- a/vibe/core/llm/format.py
+++ b/vibe/core/llm/format.py
@@ -6,7 +6,13 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from vibe.core.tools.base import BaseTool
-from vibe.core.types import AvailableTool, LLMMessage, Role, StrToolChoice
+from vibe.core.types import (
+    AvailableTool,
+    ImageAttachment,
+    LLMMessage,
+    Role,
+    StrToolChoice,
+)
 
 if TYPE_CHECKING:
     from vibe.core.tools.manager import ToolManager
@@ -152,13 +158,17 @@ class APIToolFormatHandler:
         return ResolvedMessage(tool_calls=resolved_calls, failed_calls=failed_calls)
 
     def create_tool_response_message(
-        self, tool_call: ResolvedToolCall, result_text: str
+        self,
+        tool_call: ResolvedToolCall,
+        result_text: str,
+        images: list[ImageAttachment] | None = None,
     ) -> LLMMessage:
         return LLMMessage(
             role=Role.tool,
             tool_call_id=tool_call.call_id,
             name=tool_call.tool_name,
             content=result_text,
+            images=images,
         )
 
     def create_failed_tool_response_message(

--- a/vibe/core/tools/base.py
+++ b/vibe/core/tools/base.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from vibe.core.logger import logger
 from vibe.core.rewind.manager import FileSnapshot
-from vibe.core.types import ToolStreamEvent
+from vibe.core.types import ImageAttachment, ToolStreamEvent
 from vibe.core.utils.io import read_safe
 
 if TYPE_CHECKING:
@@ -414,6 +414,16 @@ class BaseTool[
             logger.warning("Failed to read file for tool snapshot: %s", file_path)
             content = None
         return FileSnapshot(path=str(file_path), content=content)
+
+    def get_result_images(self, result: ToolResult) -> list[ImageAttachment] | None:
+        """Optional images derived from a tool result for the LLM to see.
+
+        Override in subclasses to produce ``ImageAttachment`` instances that
+        will be attached to the tool-response ``LLMMessage`` so the vision
+        model can "see" the images on the next turn.  The default returns
+        ``None`` (no images).
+        """
+        return None
 
     def get_result_extra(self, result: ToolResult) -> str | None:
         """Optional extra context appended to the result text sent to the LLM.

--- a/vibe/core/tools/builtins/prompts/read_image.md
+++ b/vibe/core/tools/builtins/prompts/read_image.md
@@ -1,0 +1,1 @@
+Use `read_image` to view an image file and have the vision model see its contents.

--- a/vibe/core/tools/builtins/read_image.py
+++ b/vibe/core/tools/builtins/read_image.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import TYPE_CHECKING, final
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from vibe.core.scratchpad import is_scratchpad_path
+from vibe.core.session.image_snapshot import snapshot_image
+from vibe.core.tools.base import (
+    BaseTool,
+    BaseToolConfig,
+    BaseToolState,
+    InvokeContext,
+    ToolError,
+    ToolPermission,
+)
+from vibe.core.tools.permissions import PermissionContext
+from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
+from vibe.core.tools.utils import resolve_file_tool_permission
+from vibe.core.types import (
+    IMAGE_EXTENSIONS,
+    FileImageSource,
+    ImageAttachment,
+    ToolStreamEvent,
+)
+
+if TYPE_CHECKING:
+    from vibe.core.types import ToolResultEvent
+
+
+class ReadImageArgs(BaseModel):
+    path: str = Field(description="The absolute path to the image file to read")
+
+
+class ReadImageResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    path: str
+    alias: str
+    mime_type: str
+    image_path: str = Field(exclude=True)
+
+
+class ReadImageConfig(BaseToolConfig):
+    permission: ToolPermission = ToolPermission.ALWAYS
+    sensitive_patterns: list[str] = Field(
+        default=["**/.env", "**/.env.*"],
+        description="File patterns that trigger ASK even when permission is ALWAYS.",
+    )
+
+
+class ReadImageState(BaseToolState):
+    pass
+
+
+class ReadImage(
+    BaseTool[ReadImageArgs, ReadImageResult, ReadImageConfig, ReadImageState],
+    ToolUIData[ReadImageArgs, ReadImageResult],
+):
+    def resolve_permission(self, args: ReadImageArgs) -> PermissionContext | None:
+        return resolve_file_tool_permission(
+            args.path,
+            tool_name=self.get_name(),
+            allowlist=self.config.allowlist,
+            denylist=self.config.denylist,
+            config_permission=self.config.permission,
+            sensitive_patterns=self.config.sensitive_patterns,
+        )
+
+    def _resolve_path(self, raw_path: str) -> Path:
+        if not raw_path.strip():
+            raise ToolError("path cannot be empty")
+
+        path = Path(raw_path).expanduser()
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        path = path.resolve()
+
+        if not path.exists():
+            raise ToolError(f"File not found at: {path}")
+        if path.is_dir():
+            raise ToolError(f"Path is a directory, not a file: {path}")
+        return path
+
+    def get_result_images(
+        self, result: ReadImageResult
+    ) -> list[ImageAttachment] | None:
+        if not result.image_path:
+            return None
+        return [
+            ImageAttachment(
+                source=FileImageSource(path=Path(result.image_path)),
+                alias=result.alias,
+                mime_type=result.mime_type,
+            )
+        ]
+
+    @final
+    async def run(
+        self, args: ReadImageArgs, ctx: InvokeContext | None = None
+    ) -> AsyncGenerator[ToolStreamEvent | ReadImageResult, None]:
+        source_path = self._resolve_path(args.path)
+
+        ext = source_path.suffix.lower()
+        if ext not in IMAGE_EXTENSIONS:
+            raise ToolError(
+                f"Unsupported image extension '{ext}'. "
+                f"Supported: {', '.join(sorted(IMAGE_EXTENSIONS))}"
+            )
+
+        session_dir = ctx.session_dir if ctx is not None else None
+        att = snapshot_image(
+            source_path, alias=source_path.name, session_dir=session_dir
+        )
+
+        if ctx is not None:
+            yield ToolStreamEvent(
+                tool_name=self.get_name(),
+                tool_call_id=ctx.tool_call_id,
+                message="Reading image...",
+            )
+
+        yield ReadImageResult(
+            path=str(source_path),
+            alias=source_path.name,
+            mime_type=att.mime_type,
+            image_path=str(att.source.path)
+            if isinstance(att.source, FileImageSource)
+            else "",
+        )
+
+    @classmethod
+    def format_call_display(cls, args: ReadImageArgs) -> ToolCallDisplay:
+        suffix = "(scratchpad)" if is_scratchpad_path(args.path) else ""
+        return ToolCallDisplay(summary=f"Reading {args.path}", suffix=suffix)
+
+    @classmethod
+    def get_result_display(cls, event: ToolResultEvent) -> ToolResultDisplay:
+        if not isinstance(event.result, ReadImageResult):
+            return ToolResultDisplay(
+                success=False, message=event.error or event.skip_reason or "No result"
+            )
+        suffix = "(scratchpad)" if is_scratchpad_path(event.result.path) else ""
+        return ToolResultDisplay(
+            success=True, message=f"Read image from {event.result.alias}", suffix=suffix
+        )
+
+    @classmethod
+    def get_status_text(cls) -> str:
+        return "Reading image"


### PR DESCRIPTION
Give the agent a tool to read an image file and have the vision model "see" it in the next LLM turn. Currently the agent can only receive images via user attachment (@-mention, clipboard paste) — it has no tool to read an image itself.

## How it works

Agent calls read_image("/path/to/img.png")
  -> Tool reads file, snapshots to session attachments
  -> get_result_images() reconstructs ImageAttachment from snapshot path
  -> Pipeline threads ImageAttachment onto LLMMessage(role=Role.tool, images=[...])
  -> Mistral backend renders images in the tool message API call
  -> Vision model sees image + text in the next turn

The image persists in context across subsequent turns (not consumed) — the ReAct loop includes all message history, including tool results with images. _messages_for_backend already strips images for non-vision models, so no special handling is needed there.

## Scope: Mistral backend only (PoC)

This is a proof-of-concept targeting the Mistral backend, which is a self-contained class that does not share code with the other backends' adapters. The pipeline changes (base.py, read_image.py, _loop.py, hooks.py, format.py) are backend-agnostic; other backends silently drop images on tool messages (no errors, the image is just ignored). This is offered as a base the maintainers can adopt or adapt.

Confirmed: the Mistral API accepts images in tool messages — a direct test with mistral-medium-3.5 sent a ToolMessage with [TextChunk, ImageURLChunk] and the model accurately described the image with no API errors.

Follow-up work (deferred, not in this PoC) would extend:
- Anthropic (docs confirm tool-result images are supported)
- Generic (OpenAI-compatible, untested)
- OpenAI Responses (untested)
- ReasoningAdapter (untested)

## Provenance

This implementation was produced by evaluating two AI-generated drafts against a shared plan, then merging the strongest aspects of each: the snapshot-path data flow (which keeps the LLM message pointing at the stable persisted snapshot, so session resume and file relocation stay safe) combined with scratchpad display-suffix handling that matches the existing read_file tool convention.

## Files changed (9)

- vibe/core/tools/base.py — add get_result_images hook on BaseTool (non-abstract, default None; zero existing subclasses break)
- vibe/core/tools/builtins/read_image.py — new tool
- vibe/core/tools/builtins/prompts/read_image.md — tool prompt
- vibe/core/agent_loop/_loop.py — extract images in _invoke_tool, accept in _handle_tool_response
- vibe/core/agent_loop_hooks.py — thread images through _run_after_tool_and_finalize
- vibe/core/llm/format.py — accept images in create_tool_response_message
- vibe/core/llm/backend/mistral.py — render images on Role.tool messages (same pattern as the existing Role.user handler)
- tests/core/tools/builtins/test_read_image.py — unit tests
- tests/backend/test_image_mapping.py — backend mapping tests

## Known limitations (PoC)

- ToolResultEvent has no image field — the UI can't display a thumbnail of what read_image read. The model still sees the image.
- Other backends silently drop images on tool messages.
- image_path leaks into the result text dump — harmless but noisy.
- No width/height in result — Pillow is not a project dependency.

## Testing

- uv run pytest tests/core/tools/builtins/test_read_image.py tests/backend/test_image_mapping.py  (30 passed)
- uv run ruff check --fix . && uv run ruff format .
- uv run pyright  (0 errors)
- uv run pytest  (full suite: no new failures; 2 pre-existing unrelated failures in tests/tools/test_grep.py and an e2e TUI test)