### PR TITLE
fix(autocompletion): preserve # in gitignore patterns like *#*#

### DIFF
--- a/tests/autocompletion/test_ignore_rules.py
+++ b/tests/autocompletion/test_ignore_rules.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from vibe.core.autocompletion.file_indexer.ignore_rules import IgnoreRules
+
+
+def test_gitignore_pattern_with_hash_is_not_treated_as_comment(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("*#*#\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("hello", encoding="utf-8")
+    (tmp_path / "foo#bar#").write_text("autosave", encoding="utf-8")
+
+    rules = IgnoreRules()
+    rules.ensure_for_root(tmp_path)
+
+    assert not rules.should_ignore("README.md", "README.md", is_dir=False)
+    assert rules.should_ignore("foo#bar#", "foo#bar#", is_dir=False)
+
+
+def test_gitignore_inline_comment_after_whitespace_is_still_stripped(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".gitignore").write_text("*.log  # build artifacts\n", encoding="utf-8")
+    (tmp_path / "app.log").write_text("log", encoding="utf-8")
+    (tmp_path / "app.txt").write_text("text", encoding="utf-8")
+
+    rules = IgnoreRules()
+    rules.ensure_for_root(tmp_path)
+
+    assert rules.should_ignore("app.log", "app.log", is_dir=False)
+    assert not rules.should_ignore("app.txt", "app.txt", is_dir=False)

--- a/vibe/core/autocompletion/file_indexer/ignore_rules.py
+++ b/vibe/core/autocompletion/file_indexer/ignore_rules.py
@@ -122,7 +122,8 @@ class IgnoreRules:
                 if not raw or raw.startswith("#"):
                     continue
 
-                if "#" in raw:
+                hash_index = raw.find("#")
+                if hash_index > 0 and raw[hash_index - 1].isspace():
                     raw = raw.split("#", 1)[0].rstrip()
                     if not raw:
                         continue


### PR DESCRIPTION
## Summary

Fix gitignore parsing so patterns containing `#` (e.g. Emacs autosave `*#*#`) are not truncated into `*`, which was causing the file indexer to ignore every file and break `@` filepath autocompletion.

## Motivation

Fixes #887. When `.gitignore` contains `*#*#`, the parser treated the first `#` as an inline comment delimiter and reduced the pattern to `*`, matching all files. The file indexer then returned zero entries, so `@` autocompletion showed no suggestions.

## Changes

- In `ignore_rules.py`, only strip text after `#` when `#` is preceded by whitespace (inline comment), preserving patterns like `*#*#` and `test#file.txt`.
- Add unit tests in `tests/autocompletion/test_ignore_rules.py` covering the regression and inline-comment behavior.

## Tests

```bash
uv run pytest tests/autocompletion/test_ignore_rules.py -v
uv run ruff check vibe/core/autocompletion/file_indexer/ignore_rules.py tests/autocompletion/test_ignore_rules.py
```

All tests pass (2/2).

## Notes

Inline comments with whitespace before `#` (e.g. `*.log  # build artifacts`) continue to be stripped, matching the prior behavior for comment-style lines.