### PR TITLE
fix(session-picker): avoid MissingStyle when confirming session delete

### DIFF
--- a/tests/cli/textual_ui/test_session_picker.py
+++ b/tests/cli/textual_ui/test_session_picker.py
@@ -195,6 +195,7 @@ class TestSessionPickerSessionRemoval:
         assert_delete_state(picker, kind="confirmation", option_id="session-a")
         assert option_list.replaced_prompts[-1].option_id == "session-a"
         prompt = option_list.replaced_prompts[-1].prompt
+        assert isinstance(prompt, Content)
         assert "Press d again to delete" in prompt.plain
         assert any(span.style == SHORTCUT_STYLE for span in prompt.spans)
         assert posted_messages == []

--- a/tests/cli/textual_ui/test_session_picker.py
+++ b/tests/cli/textual_ui/test_session_picker.py
@@ -5,6 +5,7 @@ from typing import cast
 
 import pytest
 from rich.text import Text
+from textual.content import Content
 from textual.widgets import OptionList
 
 from vibe.cli.textual_ui.shortcut_hints import SHORTCUT_STYLE
@@ -197,6 +198,21 @@ class TestSessionPickerSessionRemoval:
         assert "Press d again to delete" in prompt.plain
         assert any(span.style == SHORTCUT_STYLE for span in prompt.spans)
         assert posted_messages == []
+
+    def test_delete_confirmation_prompt_renders_in_option_list(
+        self,
+        sample_sessions: list[ResumeSessionInfo],
+        sample_latest_messages: dict[str, str],
+    ) -> None:
+        picker = SessionPickerApp(
+            sessions=sample_sessions, latest_messages=sample_latest_messages
+        )
+        prompt = picker._delete_confirmation_option_text(sample_sessions[0])
+        assert isinstance(prompt, Content)
+
+        option_list = OptionList()
+        option_list.add_option(prompt)
+        option_list._update_lines()
 
     def test_second_delete_request_posts_delete_message(
         self,

--- a/vibe/cli/textual_ui/widgets/session_picker.py
+++ b/vibe/cli/textual_ui/widgets/session_picker.py
@@ -6,13 +6,14 @@ from typing import Any, ClassVar, Literal
 
 from rich.text import Text
 from textual.app import ComposeResult
+from textual.content import Content
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical
 from textual.message import Message
 from textual.widgets import OptionList
 from textual.widgets.option_list import Option
 
-from vibe.cli.textual_ui.shortcut_hints import SHORTCUT_STYLE, shortcut, shortcut_hint
+from vibe.cli.textual_ui.shortcut_hints import shortcut, shortcut_hint
 from vibe.cli.textual_ui.widgets.navigable_option_list import NavigableOptionList
 from vibe.cli.textual_ui.widgets.no_markup_static import NoMarkupStatic
 from vibe.core.session.resume_sessions import ResumeSessionInfo, short_session_id
@@ -151,7 +152,7 @@ class SessionPickerApp(Container):
     def _normal_option_text(self, session: ResumeSessionInfo) -> Text:
         return _build_option_text(session, self._session_message(session))
 
-    def _option_text(self, session: ResumeSessionInfo) -> Text:
+    def _option_text(self, session: ResumeSessionInfo) -> Text | Content:
         state = self._delete_state
         if state is None or state.option_id != session.option_id:
             return self._normal_option_text(session)
@@ -163,12 +164,13 @@ class SessionPickerApp(Container):
             case "pending":
                 return self._delete_pending_option_text(session)
 
-    def _delete_confirmation_option_text(self, session: ResumeSessionInfo) -> Text:
-        text = _build_option_text(session, "")
-        text.append("Press ")
-        text.append("d", style=SHORTCUT_STYLE)
-        text.append(" again to delete")
-        return text
+    def _delete_confirmation_option_text(self, session: ResumeSessionInfo) -> Content:
+        time_str = _format_relative_time(session.end_time)
+        session_id = short_session_id(session.session_id)
+        return Content.from_markup(
+            f"[dim]{time_str:10}[/]  [dim]{session_id}  [/]"
+            f"Press {shortcut('d')} again to delete"
+        )
 
     def _delete_feedback_option_text(self, session: ResumeSessionInfo) -> Text:
         text = _build_option_text(session, "")

--- a/vibe/cli/textual_ui/widgets/session_picker.py
+++ b/vibe/cli/textual_ui/widgets/session_picker.py
@@ -217,7 +217,7 @@ class SessionPickerApp(Container):
             self._restore_option_text(session)
 
     def _show_delete_state(
-        self, session: ResumeSessionInfo, kind: _DeleteStateKind, prompt: Text
+        self, session: ResumeSessionInfo, kind: _DeleteStateKind, prompt: Text | Content
     ) -> None:
         self._clear_delete_state()
         self._delete_state = _DeleteState(kind=kind, option_id=session.option_id)


### PR DESCRIPTION
## Summary

Fixes a crash when pressing `d` to delete a session in the session picker. The delete confirmation prompt now uses Textual markup (`Content.from_markup`) instead of Rich `Text.append` with `$primary` theme tokens.

## Motivation

`OptionList` renders option prompts via `Content.from_rich_text`, which cannot parse Textual theme variables like `$primary`. The delete confirmation path used `text.append("d", style=SHORTCUT_STYLE)` where `SHORTCUT_STYLE = "b not dim $primary"`, causing:

```
MissingStyle: Failed to get style 'b not dim $primary'
```

Reported in #907.

## Changes

- Build delete confirmation prompt with `Content.from_markup` and `shortcut('d')`, matching the pattern used in help text and `quit_manager.py`
- Widen `_option_text` / `_show_delete_state` prompt types to `Text | Content`
- Add regression test that exercises `OptionList._update_lines()` with the confirmation prompt

## Tests

```bash
python3 -m pytest tests/cli/textual_ui/test_session_picker.py -q -o addopts=""
```

Result: **33 passed**

## Notes

- Only the confirmation state is affected; feedback/pending prompts still use Rich `Text` without `$primary`
- Reviewed with composer-2.5: **APPROVE**

Fixes #907