### PR TITLE
fix: create mcp_registry on first /mcp add in a running session

### DIFF
--- a/tests/core/config/test_agent_loop_refresh_config.py
+++ b/tests/core/config/test_agent_loop_refresh_config.py
@@ -5,7 +5,7 @@ import pytest
 from tests.conftest import build_test_agent_loop, build_test_vibe_config
 from tests.stubs.fake_mcp_registry import FakeMCPRegistry
 from vibe.core.config import MCPHttp, MCPOAuth, MCPStreamableHttp, VibeConfig
-from vibe.core.tools.mcp import AuthStatus
+from vibe.core.tools.mcp import AuthStatus, MCPRegistry
 
 
 @pytest.mark.asyncio
@@ -84,3 +84,36 @@ async def test_refresh_config_does_not_mark_undiscovered_oauth_server_ok(
     await agent_loop.refresh_config()
 
     assert registry.status() == {"linear": AuthStatus.NEEDS_AUTH}
+
+
+@pytest.mark.asyncio
+async def test_refresh_config_creates_mcp_registry_for_first_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression test: a session that starts with zero MCP servers never
+    # gets an `mcp_registry` (it's only created lazily when servers exist).
+    # `/mcp add`ing the first server must make refresh_config() create the
+    # registry, otherwise the immediate `/mcp login` that follows fails with
+    # "No MCP servers configured." even though the server was just persisted.
+    agent_loop = build_test_agent_loop(
+        config=build_test_vibe_config(mcp_servers=[]),
+        mcp_registry=None,
+        defer_heavy_init=True,
+    )
+    assert agent_loop.mcp_registry is None
+
+    added = MCPStreamableHttp(
+        name="qlik-presales-iberia",
+        transport="streamable-http",
+        url="https://presales-iberia.eu.qlikcloud.com/api/ai/mcp",
+        auth=MCPOAuth(type="oauth", scopes=["user_default", "mcp:execute"]),
+    )
+    refreshed_config = build_test_vibe_config(mcp_servers=[added])
+    monkeypatch.setattr(VibeConfig, "load", staticmethod(lambda: refreshed_config))
+
+    await agent_loop.refresh_config()
+
+    assert isinstance(agent_loop.mcp_registry, MCPRegistry)
+    assert agent_loop.mcp_registry.status() == {
+        "qlik-presales-iberia": AuthStatus.NEEDS_AUTH
+    }

--- a/vibe/core/agent_loop/_loop.py
+++ b/vibe/core/agent_loop/_loop.py
@@ -604,6 +604,7 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         await self._config_orchestrator.reload()
         self._apply_forced_bypass()
         self.agent_manager.invalidate_config()
+        self._ensure_remote_registries()
         if self.mcp_registry is not None:
             self.mcp_registry.sync_active_servers(self.config.mcp_servers)
 


### PR DESCRIPTION
Fixes #910

## Summary

- `/mcp add`ing the **first** MCP server in a running session (i.e. one that started with zero `[[mcp_servers]]` entries) persisted the server to `config.toml` correctly, but the automatic OAuth login that follows failed with `Error: No MCP servers configured.` — `/mcp login`/`/mcp status` failed the same way afterward, in that same session.
- Root cause: the interactive TUI builds `AgentLoop` with `defer_heavy_init=True`, so `mcp_registry` stays `None` until `_ensure_remote_registries()` runs once at startup, and that method only creates the registry if servers already existed in the config at that time. `refresh_config()` (called by `/mcp add` right after persisting) only synced into `mcp_registry` `if self.mcp_registry is not None` — it never called `_ensure_remote_registries()` to lazily create the registry once the config gained its first server.
- Fix: `refresh_config()` now calls `self._ensure_remote_registries()` before the sync check, matching the same lazy-creation call already used at startup (`_complete_init`) and elsewhere (`vibe/core/agent_loop/_loop.py:2401`). `_ensure_remote_registries()` is idempotent (guarded by `is None` checks), so this is a no-op once the registry already exists.

## Change

- `vibe/core/agent_loop/_loop.py`: one-line addition to `refresh_config()`.
- `tests/core/config/test_agent_loop_refresh_config.py`: new regression test `test_refresh_config_creates_mcp_registry_for_first_server`, constructing an `AgentLoop` the same way the TUI does (`defer_heavy_init=True`, zero initial servers) and asserting `mcp_registry` is created and populated after `refresh_config()` adds the first server.

## Test plan

- [x] `uv run pytest tests/core/config/test_agent_loop_refresh_config.py` — all 5 tests pass (including the new regression test), verified with `--import-mode=prepend` (this machine's `--import-mode=importlib` default fails to resolve the editable install for unrelated reasons — confirmed identical failure on unmodified `main`, not introduced by this change).
- [x] Full suite (`uv run pytest --ignore tests/snapshots`) diffed branch vs. `main`: byte-identical set of 52 pre-existing failures on both (all environment-specific: missing `ripgrep` locally, subprocess env resolution, etc.) — zero new failures from this change.
- [x] `uv run pre-commit run --files vibe/core/agent_loop/_loop.py tests/core/config/test_agent_loop_refresh_config.py` — pyright, ruff check, ruff format, typos all pass.