### PR TITLE
fix(deps): bump soupsieve 2.8.3 -> 2.8.4 (security fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ dependencies = [
     "six==1.17.0",
     "smmap==5.0.3",
     "sounddevice==0.5.5",
-    "soupsieve==2.8.3",
+    "soupsieve==2.8.4",
     "sse-starlette==3.4.1",
     "starlette==1.3.1",
     "textual==8.2.8",

--- a/uv.lock
+++ b/uv.lock
@@ -683,7 +683,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1042,7 +1042,7 @@ requires-dist = [
     { name = "six", specifier = "==1.17.0" },
     { name = "smmap", specifier = "==5.0.3" },
     { name = "sounddevice", specifier = "==0.5.5" },
-    { name = "soupsieve", specifier = "==2.8.3" },
+    { name = "soupsieve", specifier = "==2.8.4" },
     { name = "sse-starlette", specifier = "==3.4.1" },
     { name = "starlette", specifier = "==1.3.1" },
     { name = "textual", specifier = "==8.2.8" },
@@ -1977,8 +1977,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -2043,11 +2043,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

`soupsieve==2.8.3` (currently pinned) has **2 known vulnerabilities**, both fixed in the semver-compatible patch **2.8.4** (each is tracked under both a GHSA and a PYSEC identifier):

- `GHSA-2wc2-fm75-p42x` / `PYSEC-2026-3071` — memory exhaustion via large comma-separated selector lists
- `GHSA-836r-79rf-4m37` / `PYSEC-2026-3072` — ReDoS via the selector parser

Because `mistral-vibe` hard-pins `soupsieve==2.8.3`, every downstream consumer inherits the vulnerable version and cannot upgrade without a `uv` override. This bump fixes it at the source. (Surfaced by a downstream `uv audit` gate in the `mistralai/mistral` monorepo when adding a new project that depends on `mistral-vibe`.)

## Summary

- `pyproject.toml`: `soupsieve==2.8.3` → `soupsieve==2.8.4`.
- `uv.lock`: regenerated — only the `soupsieve` entry changes (version + hashes).

2.8.4 is compatible with the pinned `beautifulsoup4==4.14.3` (which requires `soupsieve>=1.6.1`), so nothing else moves.

## Test plan

- `uv lock` regenerates cleanly; diff is limited to the `soupsieve` entry.
- `uv audit` no longer reports any `soupsieve` findings.
