### PR TITLE
fix: use public connector tool-call endpoint instead of internal gateway

### DIFF
--- a/tests/tools/test_connectors.py
+++ b/tests/tools/test_connectors.py
@@ -303,7 +303,7 @@ class TestConnectorProxyToolRun:
         return cast(MCPTool, tool_cls.from_config(lambda: BaseToolConfig()))
 
     @pytest.mark.asyncio
-    async def test_run_calls_mcp_proxy(self) -> None:
+    async def test_run_calls_connector_tool(self) -> None:
         cls = self._make_tool_class()
         tool = self._make_tool(cls)
         expected = MCPToolResult(
@@ -311,17 +311,19 @@ class TestConnectorProxyToolRun:
         )
 
         with patch(
-            "vibe.core.tools.connectors.connector_registry.call_tool_http",
+            "vibe.core.tools.connectors.connector_registry.call_connector_tool",
             new_callable=AsyncMock,
             return_value=expected,
         ) as mock_call:
             results = [r async for r in tool.invoke(query="hello")]
 
         mock_call.assert_awaited_once()
-        call_args = mock_call.call_args
-        assert "/v1/connectors-gateway/conn-123/mcp" in call_args.args[0]
-        assert call_args.args[1] == "search"
-        assert call_args.kwargs["headers"]["Authorization"] == "Bearer test-key"
+        call_kwargs = mock_call.call_args.kwargs
+        assert call_kwargs["base_url"] == "https://custom.api.example.com"
+        assert call_kwargs["api_key"] == "test-key"
+        assert call_kwargs["connector_id"] == "conn-123"
+        assert call_kwargs["tool_name"] == "search"
+        assert call_kwargs["arguments"] == {"query": "hello"}
 
         assert len(results) == 1
         assert results[0] == expected
@@ -344,14 +346,13 @@ class TestConnectorProxyToolRun:
         expected = MCPToolResult(ok=True, server="s", tool="ping", text="pong")
 
         with patch(
-            "vibe.core.tools.connectors.connector_registry.call_tool_http",
+            "vibe.core.tools.connectors.connector_registry.call_connector_tool",
             new_callable=AsyncMock,
             return_value=expected,
         ) as mock_call:
             [_ async for _ in tool.invoke()]
 
-        url = mock_call.call_args.args[0]
-        assert url.startswith("https://api.mistral.ai/")
+        assert mock_call.call_args.kwargs["base_url"] == "https://api.mistral.ai"
 
     @pytest.mark.asyncio
     async def test_run_surfaces_timeout_error(self) -> None:
@@ -360,7 +361,7 @@ class TestConnectorProxyToolRun:
 
         with (
             patch(
-                "vibe.core.tools.connectors.connector_registry.call_tool_http",
+                "vibe.core.tools.connectors.connector_registry.call_connector_tool",
                 new_callable=AsyncMock,
                 side_effect=httpx.ReadTimeout("timed out"),
             ),
@@ -375,13 +376,37 @@ class TestConnectorProxyToolRun:
 
         with (
             patch(
-                "vibe.core.tools.connectors.connector_registry.call_tool_http",
+                "vibe.core.tools.connectors.connector_registry.call_connector_tool",
                 new_callable=AsyncMock,
                 side_effect=httpx.ConnectError("refused"),
             ),
             pytest.raises(ToolError, match="network"),
         ):
             [_ async for _ in tool.invoke(query="hello")]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_run_hits_public_connector_tool_call_endpoint(self) -> None:
+        """Regression test: must call the public /tools/{name}/call endpoint,
+        not the internal /v1/connectors-gateway/{id}/mcp path (which 502s).
+        """
+        cls = self._make_tool_class()
+        tool = self._make_tool(cls)
+        route = respx.post(
+            "https://custom.api.example.com/v1/connectors/conn-123/tools/search/call"
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"content": [{"type": "text", "text": "result text"}]}
+            )
+        )
+
+        results = [r async for r in tool.invoke(query="hello")]
+
+        assert route.called
+        assert len(results) == 1
+        result = results[0]
+        assert isinstance(result, MCPToolResult)
+        assert result.text == "result text"
 
 
 # ---------------------------------------------------------------------------

--- a/vibe/core/tools/connectors/connector_registry.py
+++ b/vibe/core/tools/connectors/connector_registry.py
@@ -34,16 +34,41 @@ _BOOTSTRAP_TIMEOUT = 30.0
 _BOOTSTRAP_CACHE_TTL_SECONDS = 10 * 60
 
 
-async def call_tool_http(
-    url: str,
+def _parse_connector_tool_result(server: str, tool: str, result: Any) -> MCPToolResult:
+    parts = [
+        block.text
+        for block in result.content
+        if getattr(block, "type", None) == "text"
+        and isinstance(getattr(block, "text", None), str)
+    ]
+    text = "\n".join(parts) if parts else None
+    return MCPToolResult(server=server, tool=tool, text=text, structured=None)
+
+
+async def call_connector_tool(
+    *,
+    base_url: str,
+    api_key: str,
+    connector_id: str,
     tool_name: str,
     arguments: dict[str, Any],
-    *,
-    headers: dict[str, str] | None = None,
 ) -> MCPToolResult:
-    from vibe.core.tools.mcp.tools import call_tool_http as call_mcp_tool_http
+    from mistralai.client import Mistral
 
-    return await call_mcp_tool_http(url, tool_name, arguments, headers=headers)
+    http_client = VibeAsyncHTTPClient(verify=build_ssl_context())
+    try:
+        sdk_client = Mistral(
+            api_key=api_key, server_url=base_url, async_client=http_client
+        )
+        async with sdk_client as client:
+            result = await client.beta.connectors.call_tool_async(
+                connector_id_or_name=connector_id,
+                tool_name=tool_name,
+                arguments=arguments,
+            )
+        return _parse_connector_tool_result(connector_id, tool_name, result)
+    finally:
+        await http_client.aclose()
 
 
 class ConnectorAuthAction(StrEnum):
@@ -200,6 +225,11 @@ def _format_http_status_error(
                 f"Connector {connector_ref} not found (HTTP 404). "
                 "It may have been deleted or is not accessible."
             )
+        case 502 | 503 | 504:
+            detail = (
+                f"Connector {connector_ref} gateway is temporarily unavailable "
+                f"(HTTP {status}). Try again in a moment."
+            )
         case _:
             detail = f"Connector {connector_ref} request failed (HTTP {status})."
 
@@ -284,12 +314,14 @@ def create_connector_proxy_tool_class(
         async def run(
             self, args: _OpenArgs, ctx: InvokeContext | None = None
         ) -> AsyncGenerator[ToolStreamEvent | MCPToolResult, None]:
-            url = f"{self._base_url}/v1/connectors-gateway/{self._connector_id}/mcp"
-            headers = {"Authorization": f"Bearer {self._api_key}"}
             payload = args.model_dump(exclude_none=True)
             try:
-                yield await call_tool_http(
-                    url, self._remote_name, payload, headers=headers
+                yield await call_connector_tool(
+                    base_url=self._base_url,
+                    api_key=self._api_key,
+                    connector_id=self._connector_id,
+                    tool_name=self._remote_name,
+                    arguments=payload,
                 )
             except Exception as exc:
                 msg = _connector_error_message(


### PR DESCRIPTION
Fixes #917

## Summary
- `ConnectorProxyTool.run` was POSTing raw MCP streamable-HTTP requests to `/v1/connectors-gateway/{id}/mcp`, an internal/experimental path never backed by an SDK operation, which 502s for API-key callers even though `/mcp` reports the connector as connected (discovery uses the separate, working `/v1/connectors/bootstrap` endpoint).
- Switches the tool-call path to `client.beta.connectors.call_tool_async`, the `mistralai` SDK's public operation for `POST /v1/connectors/{id}/tools/{name}/call`, using the same Bearer auth already in use and mirroring the existing `get_auth_url` pattern in the same file.
- Adds a `502 | 503 | 504` case to the connector error formatter with actionable text for genuine transient gateway errors.

## Test plan
- [x] `pytest tests/tools/test_connectors.py` — 67 passed, including a new regression test (`test_run_hits_public_connector_tool_call_endpoint`) that asserts the tool call hits `/v1/connectors/{id}/tools/{name}/call` via `respx`, not the old gateway path.
- [x] `pytest tests/tools/test_mcp.py tests/tools/test_mcp_registry_oauth.py` — unaffected, 95 passed.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `pyright` clean on the changed file.