### PR TITLE
fix: memoize edit hunk decomposition per-edit to end CI test timeout

### DIFF
--- a/tests/core/test_history_properties.py
+++ b/tests/core/test_history_properties.py
@@ -226,6 +226,53 @@ def _disk_lines(state: FileState) -> list[str]:
     return (state.data or b"").decode("utf-8").splitlines()
 
 
+def test_edit_decomposition_is_memoized_across_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each edit's hunk decomposition is computed at most once and reused across
+    the many fresh ``History`` instances a review session spins up (every
+    ``view``/``content``/``decide`` builds a new one over the same immutable log).
+
+    This guards a *performance* regression, not a wrong answer: caching the
+    decomposition per-History instead of per-edit re-runs ``SequenceMatcher`` on
+    every edit for every read, an O(reads x edits) blowup that timed CI out. A
+    call-count assertion pins the invariant deterministically, without depending
+    on wall-clock (the flaky pytest-timeout it replaces).
+    """
+    from vibe.core.checkpoints._events import _Edit
+    import vibe.core.checkpoints.history as history_mod
+    from vibe.core.checkpoints.models import OpaqueChange, Region
+
+    calls = 0
+    real = history_mod._compute_changes
+
+    def counting(edit: _Edit) -> list[tuple[int, Region | OpaqueChange]]:
+        nonlocal calls
+        calls += 1
+        return real(edit)
+
+    monkeypatch.setattr(history_mod, "_compute_changes", counting)
+
+    chain: Chain = [
+        (1, st("a\n"), st("a\nb\n")),
+        (2, st("a\nb\n"), st("a\nB\nc\n")),
+    ]
+    cur = st("a\nB\nc\n")
+    cp = build(chain)
+
+    # Warm the memo, then hammer the read model over the same log.
+    cp.view({P: cur}).regions(P)
+    warmed = calls
+    for _ in range(50):
+        cp.view({P: cur}).content(P)
+        cp.view({P: cur}).regions(P)
+        cp.view({P: cur}).accepted_baseline(P)
+    assert calls == warmed, (
+        f"decomposition recomputed on reads: {calls - warmed} extra calls "
+        "(cache is per-History, not per-edit)"
+    )
+
+
 def test_manual_edits_during_review_stay_projectable() -> None:
     """A review session that interleaves decisions (persisted, like the manager's
     decide-then-write flow) with genuine manual disk edits.

--- a/vibe/core/checkpoints/_events.py
+++ b/vibe/core/checkpoints/_events.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from vibe.core.checkpoints.models import FileState, Owner, RegionId
+from vibe.core.checkpoints.models import (
+    FileState,
+    OpaqueChange,
+    Owner,
+    Region,
+    RegionId,
+)
 
 
 @dataclass(slots=True)
@@ -28,6 +34,15 @@ class _Edit:
     before: FileState
     after: FileState
     deps: dict[int, tuple[RegionId, ...]]
+    # Memoized hunk decomposition (line regions, or one opaque whole-file unit),
+    # filled lazily by ``History._changes_of``. An edit's ``before``/``after`` are
+    # fixed at construction, so this is a pure function of the edit and is shared
+    # across every History built over the same log — a fresh History per read
+    # would otherwise recompute every edit's SequenceMatcher diff. Excluded from
+    # equality/repr: it is a derived cache, not identity.
+    _changes: list[tuple[int, Region | OpaqueChange]] | None = field(
+        default=None, compare=False, repr=False
+    )
 
 
 @dataclass(slots=True)

--- a/vibe/core/checkpoints/history.py
+++ b/vibe/core/checkpoints/history.py
@@ -192,21 +192,23 @@ class History:
     hands one out through ``view(current)``.
     """
 
-    __slots__ = ("_changes_cache", "_edits_cache", "_effective_cache", "_events")
+    __slots__ = ("_edits_cache", "_effective_cache", "_events")
 
     def __init__(self, events: list[_Event]) -> None:
         # Copy so the memo caches can assume a frozen event list, even if the
         # caller keeps mutating the list it was handed (the Checkpointer does).
         self._events = list(events)
         self._edits_cache: dict[str, list[_Edit]] = {}
-        self._changes_cache: dict[int, list[tuple[int, Region | OpaqueChange]]] = {}
         self._effective_cache: dict[str, dict[RegionId, Decision]] = {}
 
     def _changes_of(self, edit: _Edit) -> list[tuple[int, Region | OpaqueChange]]:
-        cached = self._changes_cache.get(edit.seq)
+        # Cache on the edit itself, not this History instance: the Checkpointer
+        # builds a fresh History per read over the same immutable edits, so an
+        # instance-scoped cache would recompute every edit's diff on every call.
+        cached = edit._changes
         if cached is None:
             cached = _compute_changes(edit)
-            self._changes_cache[edit.seq] = cached
+            edit._changes = cached
         return cached
 
     def has_edits(self, path: str) -> bool:


### PR DESCRIPTION
## Summary
- `tests/core/test_history_properties.py::test_manual_edits_during_review_stay_projectable` timed out on CI (pytest-timeout, 10s) — **not an assertion and not a hang/flake**. It's a real, deterministic performance regression: no single seed dominates (worst ~14ms, total ~2.0s locally), but the whole suite of 400 seeds was heavy enough to cross the 10s wall on a slower CI runner.
- **Root cause:** every `Checkpointer` read (`view`/`content`/`decide_region`/`reconcile`) builds a **fresh** `History` over the same immutable event log, and the hunk-decomposition memo (`_changes_cache`) lived on the `History` instance. So `_compute_changes` — a `SequenceMatcher` diff — re-ran for every edit on every read: **O(reads × edits)**. Over the 400 seeds that was **145,765 `SequenceMatcher` runs across 22,108 `History` instances**.
- **Fix:** an `_Edit`'s `before`/`after` are fixed at construction, so its decomposition is a pure function of the edit. Memoize it **on the `_Edit` object** (a `compare=False`/`repr=False` cache field), shared across every `History` built over the same log. This is correctly scoped — different `Checkpointer`s build different `_Edit` instances — with no GC id-reuse hazard and no cross-contamination. `SequenceMatcher` runs drop to **3,544 (41× fewer)**; test wall-clock **2.0s → 0.8s**.
- Replaced reliance on the flaky wall-clock timeout with a deterministic guard, `test_edit_decomposition_is_memoized_across_reads`, asserting reads recompute nothing (fails on the pre-fix code, passes after).

## Test plan
- [x] `pytest tests/core/test_history_properties.py` — 2211 passed
- [x] Adjacent checkpoint suites (`test_checkpointer_per_turn`, `test_checkpoint_recorder`, `test_file_store`) — all green
- [x] New guard fails on unfixed code, passes after the fix (verified via `git stash`)
- [x] `ruff check` + `pyright` clean on changed files
- [x] `_Edit` is package-internal and never serialized/hashed/`==`-compared, so the cache field is inert to equality and on-disk formats

## Review gate
PASS — 0 Important, 2 nits (fresh-context reviewer, diff vs main)
- Nit: inline `# type: ignore` in the new test violated AGENTS.md — fixed by typing the wrapper against `_Edit`.
- Nit: shared `edit._changes` is mutable state; concurrent threaded reads could redundantly recompute — benign (writes are idempotent, value-identical, GIL-atomic), not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)