### PR TITLE
Add plot_metrics builtin: braille line charts of JSONL streams in the conversation

### DIFF
--- a/vibe/core/tools/builtins/plot_metrics.py
+++ b/vibe/core/tools/builtins/plot_metrics.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from vibe.cli.textual_ui.widgets.braille_renderer import render_braille
+from vibe.core.tools.base import (
+    BaseTool,
+    BaseToolConfig,
+    BaseToolState,
+    InvokeContext,
+    ToolError,
+    ToolPermission,
+)
+from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
+from vibe.core.types import ToolStreamEvent
+
+
+class PlotMetricsArgs(BaseModel):
+    source: str = Field(
+        description=(
+            "JSONL file to plot: one flat JSON object per line "
+            '(e.g. {"epoch": 3, "loss": 0.42, "accuracy": 0.88}). '
+            "Numeric fields are auto-detected."
+        )
+    )
+    x: str | None = Field(
+        default=None, description="x-axis key (default: first numeric key)"
+    )
+    y: list[str] | None = Field(
+        default=None,
+        description="series to plot (default: every other numeric key, max 4)",
+    )
+    title: str | None = Field(default=None, description="Chart title")
+    width: int = Field(default=60, description="Chart width in terminal columns")
+    height: int = Field(default=10, description="Height of each chart in rows")
+
+
+class PlotMetricsResult(BaseModel):
+    chart: str = Field(description="Rendered chart, already shown to the user")
+    series: list[str]
+    points: int
+
+
+class PlotMetricsConfig(BaseToolConfig):
+    permission: ToolPermission = ToolPermission.ALWAYS  # read-only rendering
+
+
+class PlotMetricsState(BaseToolState):
+    pass
+
+
+def _numeric_keys(rows: list[dict]) -> list[str]:
+    keys: list[str] = []
+    for row in rows:
+        for key, value in row.items():
+            if (
+                isinstance(value, (int, float))
+                and not isinstance(value, bool)
+                and key not in keys
+            ):
+                keys.append(key)
+    return keys
+
+
+def _series_chart(
+    points: list[tuple[float, float]], key: str, width: int, height: int
+) -> str:
+    dot_w, dot_h = width * 2, height * 4
+    xs, ys = [p[0] for p in points], [p[1] for p in points]
+    x0, x1, y0, y1 = min(xs), max(xs), min(ys), max(ys)
+    span_x, span_y = (x1 - x0) or 1.0, (y1 - y0) or 1.0
+
+    def to_dot(x: float, y: float) -> complex:
+        dx = (x - x0) / span_x * (dot_w - 1)
+        dy = (dot_h - 1) - (y - y0) / span_y * (dot_h - 1)
+        return complex(dx, dy)
+
+    # dedupe per dot cell: render_braille sums dot indices, duplicates would
+    # overflow past the braille block
+    seen: set[tuple[int, int]] = set()
+    coords = []
+    for (ax, ay), (bx, by) in zip(points, points[1:]):
+        steps = max(2, int(abs(to_dot(bx, by).real - to_dot(ax, ay).real)) + 1)
+        for i in range(steps + 1):
+            t = i / steps
+            dot = to_dot(ax + (bx - ax) * t, ay + (by - ay) * t)
+            cell = (int(dot.real), int(dot.imag))
+            if cell not in seen:
+                seen.add(cell)
+                coords.append(complex(*cell))
+
+    body = render_braille(coords, dot_w, dot_h).split("\n")
+    gutter = max(len(f"{v:.4g}") for v in (y0, y1))
+    lines = []
+    for i, row in enumerate(body):
+        if i == 0:
+            label = f"{y1:>{gutter}.4g} ┤"
+        elif i == len(body) - 1:
+            label = f"{y0:>{gutter}.4g} ┤"
+        else:
+            label = " " * gutter + " │"
+        lines.append(label + row)
+    footer = f"{' ' * gutter} └ {key}: x ∈ [{x0:.4g}, {x1:.4g}]"
+    return "\n".join([*lines, footer])
+
+
+class PlotMetrics(
+    BaseTool[PlotMetricsArgs, PlotMetricsResult, PlotMetricsConfig, PlotMetricsState],
+    ToolUIData[PlotMetricsArgs, PlotMetricsResult],
+):
+    @classmethod
+    def format_call_display(cls, args: PlotMetricsArgs) -> ToolCallDisplay:
+        return ToolCallDisplay(summary=f"Plotting {args.source}")
+
+    @classmethod
+    def format_result_display(cls, result: PlotMetricsResult) -> ToolResultDisplay:
+        return ToolResultDisplay(
+            success=True,
+            message=result.chart,
+            suffix=f"({result.points} points)",
+        )
+
+    @classmethod
+    def get_status_text(cls) -> str:
+        return "Rendering chart"
+
+    async def run(
+        self, args: PlotMetricsArgs, ctx: InvokeContext | None = None
+    ) -> AsyncGenerator[ToolStreamEvent | PlotMetricsResult, None]:
+        source = Path(args.source).expanduser()
+        if not source.is_absolute():
+            source = Path.cwd() / source
+        if not source.is_file():
+            raise ToolError(f"source file not found: {source}")
+
+        rows = []
+        for line in source.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(row, dict):
+                rows.append(row)
+        if not rows:
+            raise ToolError(f"no JSONL rows found in {source}")
+
+        keys = _numeric_keys(rows)
+        if not keys:
+            raise ToolError("no numeric fields found to plot")
+        x_key = args.x or keys[0]
+        y_keys = args.y or [k for k in keys if k != x_key][:4]
+
+        charts = []
+        if args.title:
+            charts.append(args.title)
+        total = 0
+        for key in y_keys:
+            points = [
+                (float(r[x_key]), float(r[key]))
+                for r in rows
+                if isinstance(r.get(x_key), (int, float))
+                and isinstance(r.get(key), (int, float))
+            ]
+            if len(points) < 2:
+                continue
+            total += len(points)
+            charts.append(_series_chart(points, key, args.width, args.height))
+        if not charts:
+            raise ToolError("not enough numeric data to plot (need >= 2 points)")
+
+        yield PlotMetricsResult(
+            chart="\n\n".join(charts), series=y_keys, points=total
+        )

--- a/vibe/core/tools/builtins/prompts/plot_metrics.md
+++ b/vibe/core/tools/builtins/prompts/plot_metrics.md
@@ -1,0 +1,14 @@
+Render a braille line chart of a JSONL data stream directly in the
+conversation. Use it whenever the user wants to see numeric data over time
+without leaving the terminal: ML training metrics (loss/accuracy per epoch),
+benchmark timings, monitoring series, or any numeric log.
+
+Input: a JSONL file with one flat JSON object per line, e.g.
+`{"epoch": 3, "loss": 0.42, "accuracy": 0.88}`. Numeric fields are
+auto-detected; pass `x` and `y` to select specific fields.
+
+The chart is displayed to the user automatically — do not repeat it in your
+reply. Comment on what it shows instead (trend, convergence, anomalies).
+
+For live monitoring of a training run: call the tool again after new lines
+are appended — each call renders the current state of the file.


### PR DESCRIPTION
## Motivation

Vibe Work (web) can chart data in Canvas; Vibe Code (CLI) cannot. Terminal-first data/ML users still have to leave their environment (Jupyter, TensorBoard) just to see whether a training run converges — no terminal coding agent offers this natively today.

This PR adds a minimal, dependency-free visualization capability to the CLI.

## What it does

New builtin tool **`plot_metrics`**: reads a JSONL stream (one flat JSON object per line, e.g. `{"epoch": 3, "loss": 0.42, "accuracy": 0.88}`), auto-detects numeric fields, and renders per-series braille line charts directly in the conversation. Read-only (`permission = ALWAYS`), zero new dependencies.

```
 2.314 ┤⠣
       │ ⠑⠄
       │  ⠈⠢⡀
       │    ⠈⠢⢄
       │      ⠈⠑⠤⣀⡀
       │          ⠈⠑⠒⠢⠤⣀⣀⡀
0.0238 ┤                 ⠈⠉⠉⠉⠑⠒⠒⠒⠒⠒⠒⠒⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⢄
       └ loss: x ∈ [1, 40]
```

```mermaid
sequenceDiagram
    participant U as User
    participant V as Vibe agent
    participant T as plot_metrics tool
    U->>V: "train this model, show me the curve"
    V->>V: run training, stream metrics.jsonl
    V->>T: plot_metrics(source="metrics.jsonl")
    T-->>U: braille chart in the conversation
    V-->>U: commentary (trend, convergence)
```

## The fun part

The rendering reuses `render_braille` from `vibe/cli/textual_ui/widgets/braille_renderer.py` — until now used only to animate the mascot and the spinner. This gives that primitive its first product feature. 🐱

**Open question for maintainers:** this imports `cli` code from a `core` tool, which inverts the usual layering. Happy to move `render_braille` into e.g. `vibe/core/utils/` if you'd prefer — kept the diff minimal for review.

## Scope & design notes

- Line charts only, intentionally minimal for a first pass. The dot-cell dedup matters: `render_braille` sums dot indices, so duplicate dots would overflow past the braille block.
- Richer kinds (scatter, histograms, bar charts, ANSI-colored heatmaps, live `--follow` streaming, a colored Textual result widget) are demonstrated out-of-tree in **Vibe Pulse**, built at the Vibe Hackathon Paris (July 18, 2026) via `tool_paths` + a skill. A natural follow-up here would be a `PlotextPlot`-based result widget using [textual-plotext](https://github.com/Textualize/textual-plotext), since the TUI is already Textual.

## Testing

- Tool discovered by `ToolManager._load_tools_from_file`, prompt file loaded.
- Invoked against a real 40-epoch training stream: both series render, output contains only valid braille + box-drawing characters.

