### PR TITLE
Permission-check bash output redirect targets

### DIFF
--- a/tests/tools/test_bash_redirect_targets.py
+++ b/tests/tools/test_bash_redirect_targets.py
@@ -41,6 +41,22 @@ class TestExtractRedirectTargets:
     def test_no_redirect_yields_nothing(self) -> None:
         assert _extract_redirect_targets("ls -la /tmp") == []
 
+    def test_input_redirect_is_not_a_write_target(self) -> None:
+        assert _extract_redirect_targets("cat < /etc/hosts") == []
+
+    def test_stderr_redirect_is_collected(self) -> None:
+        assert _extract_redirect_targets("make 2> err.log") == ["err.log"]
+
+    def test_ampersand_redirect_is_collected(self) -> None:
+        assert _extract_redirect_targets("python3 x.py &> all.log") == ["all.log"]
+
+    def test_process_substitution_is_not_a_write_target(self) -> None:
+        assert _extract_redirect_targets("tee log > >(grep x)") == []
+        assert _extract_redirect_targets("diff <(ls a) <(ls b)") == []
+
+    def test_herestring_yields_nothing(self) -> None:
+        assert _extract_redirect_targets("sort <<< 'b\na'") == []
+
     def test_experimental_bash_extraction_matches(self) -> None:
         command = "cat > /parent/file.py << 'EOF'\nx\nEOF"
         assert _extract_redirect_targets_experimental(command) == ["/parent/file.py"]

--- a/tests/tools/test_bash_redirect_targets.py
+++ b/tests/tools/test_bash_redirect_targets.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vibe.core.tools.base import BaseToolState, ToolPermission
+from vibe.core.tools.builtins.bash import (
+    Bash,
+    BashArgs,
+    BashToolConfig,
+    _collect_outside_dirs,
+    _extract_redirect_targets,
+)
+from vibe.core.tools.builtins.experimental_bash import (
+    _extract_redirect_targets as _extract_redirect_targets_experimental,
+)
+from vibe.core.tools.permissions import PermissionScope
+from vibe.core.utils import is_windows
+
+pytestmark = pytest.mark.skipif(
+    is_windows(), reason="redirect analysis applies to POSIX shell semantics"
+)
+
+
+class TestExtractRedirectTargets:
+    def test_simple_overwrite_redirect(self) -> None:
+        assert _extract_redirect_targets("cat > /tmp/out.txt") == ["/tmp/out.txt"]
+
+    def test_append_redirect(self) -> None:
+        assert _extract_redirect_targets("echo hi >> notes.txt") == ["notes.txt"]
+
+    def test_heredoc_with_file_redirect(self) -> None:
+        command = "cat > /parent/file.py << 'EOF'\nprint('hi')\nEOF"
+        assert _extract_redirect_targets(command) == ["/parent/file.py"]
+
+    def test_stderr_dup_and_dev_null_have_targets_but_are_skipped_later(self) -> None:
+        targets = _extract_redirect_targets("cmd > /dev/null 2>&1")
+        assert "/dev/null" in targets
+
+    def test_no_redirect_yields_nothing(self) -> None:
+        assert _extract_redirect_targets("ls -la /tmp") == []
+
+    def test_experimental_bash_extraction_matches(self) -> None:
+        command = "cat > /parent/file.py << 'EOF'\nx\nEOF"
+        assert _extract_redirect_targets_experimental(command) == ["/parent/file.py"]
+
+
+class TestCollectOutsideDirsRedirects:
+    def test_redirect_outside_workdir_is_collected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        dirs = _collect_outside_dirs(
+            ["cat <redirect>"], ["/private/tmp/parent/file.py"]
+        )
+
+        assert dirs
+        assert any("parent" in d for d in dirs)
+
+    def test_redirect_inside_workdir_is_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        assert _collect_outside_dirs(["cat <redirect>"], ["out.txt"]) == set()
+
+    def test_dev_null_and_fd_dup_are_ignored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        dirs = _collect_outside_dirs(["cmd <redirect>"], ["/dev/null", "&1", "1"])
+
+        assert dirs == set()
+
+    def test_variable_target_requires_approval(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        dirs = _collect_outside_dirs(["cat <redirect>"], ["$HOME/evil.txt"])
+
+        assert dirs == {"$HOME/evil.txt"}
+
+
+class TestBashResolvePermissionWithRedirects:
+    def make_bash(self) -> Bash:
+        return Bash(config_getter=lambda: BashToolConfig(), state=BaseToolState())
+
+    def test_allowlisted_command_redirecting_outside_workdir_asks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workdir = tmp_path / "wt"
+        workdir.mkdir()
+        monkeypatch.chdir(workdir)
+        outside = tmp_path / "parent" / "file.py"
+        bash = self.make_bash()
+
+        ctx = bash.resolve_permission(
+            BashArgs(command=f"cat > {outside} << 'EOF'\nx\nEOF")
+        )
+
+        assert ctx is not None
+        assert ctx.permission is ToolPermission.ASK
+        assert any(
+            rp.scope is PermissionScope.OUTSIDE_DIRECTORY
+            for rp in ctx.required_permissions
+        )
+
+    def test_allowlisted_command_redirecting_inside_workdir_runs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workdir = tmp_path / "wt"
+        workdir.mkdir()
+        monkeypatch.chdir(workdir)
+        bash = self.make_bash()
+
+        ctx = bash.resolve_permission(
+            BashArgs(command="cat > out.txt << 'EOF'\nx\nEOF")
+        )
+
+        assert ctx is not None
+        assert ctx.permission is ToolPermission.ALWAYS
+
+    def test_redirect_to_dev_null_stays_allowlisted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        bash = self.make_bash()
+
+        ctx = bash.resolve_permission(BashArgs(command="ls . > /dev/null 2>&1"))
+
+        assert ctx is not None
+        assert ctx.permission is ToolPermission.ALWAYS

--- a/tests/tools/test_bash_redirect_targets.py
+++ b/tests/tools/test_bash_redirect_targets.py
@@ -57,6 +57,15 @@ class TestExtractRedirectTargets:
     def test_herestring_yields_nothing(self) -> None:
         assert _extract_redirect_targets("sort <<< 'b\na'") == []
 
+    def test_read_write_redirect_is_collected(self) -> None:
+        assert _extract_redirect_targets("echo x 1<> /tmp/evil") == ["/tmp/evil"]
+        assert _extract_redirect_targets("cmd <> /tmp/evil") == ["/tmp/evil"]
+
+    def test_experimental_bash_read_write_redirect_matches(self) -> None:
+        assert _extract_redirect_targets_experimental("echo x 1<> /tmp/evil") == [
+            "/tmp/evil"
+        ]
+
     def test_experimental_bash_extraction_matches(self) -> None:
         command = "cat > /parent/file.py << 'EOF'\nx\nEOF"
         assert _extract_redirect_targets_experimental(command) == ["/parent/file.py"]
@@ -150,3 +159,21 @@ class TestBashResolvePermissionWithRedirects:
 
         assert ctx is not None
         assert ctx.permission is ToolPermission.ALWAYS
+
+    def test_read_write_redirect_outside_workdir_asks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workdir = tmp_path / "wt"
+        workdir.mkdir()
+        monkeypatch.chdir(workdir)
+        outside = tmp_path / "parent" / "evil.txt"
+        bash = self.make_bash()
+
+        ctx = bash.resolve_permission(BashArgs(command=f"echo x 1<> {outside}"))
+
+        assert ctx is not None
+        assert ctx.permission is ToolPermission.ASK
+        assert any(
+            rp.scope is PermissionScope.OUTSIDE_DIRECTORY
+            for rp in ctx.required_permissions
+        )

--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -77,29 +77,34 @@ def _extract_commands(command: str) -> list[str]:
     return commands
 
 
-_WRITE_REDIRECT_OPERATORS = {">", ">>", "&>", "&>>", ">|", ">&", "<>"}
-
-
 def _extract_redirect_targets(command: str) -> list[str]:
-    """Collect the file targets of output redirections (``>``, ``>>``, ``&>``).
+    """Collect the file targets of redirections that can write.
 
     Redirections write through *any* binary — including read-only allowlisted
     ones like ``cat`` — so their targets must be permission-checked like the
-    path arguments of file-manipulating commands. Input redirections (``<``)
-    only read and stay out of scope, and process substitutions are not file
-    targets (their inner command is permission-checked as a command).
+    path arguments of file-manipulating commands. A redirect writes when its
+    operator contains ``>`` (``>``, ``>>``, ``&>``, ``>|``, ``>&``, and the
+    read-write ``<>``, which tree-sitter tokenizes as ``<`` plus an ERROR
+    node holding ``>``). Pure input redirections (``<``) stay out of scope,
+    and process substitutions are not file targets (their inner command is
+    permission-checked as a command). Bare fd duplications (``2>&1``) are
+    collected here and skipped downstream by the digit check.
     """
     parser = _get_parser()
     tree = parser.parse(command.encode("utf-8"))
     targets: list[str] = []
 
     def find_redirects(node: Node) -> None:
-        if node.type == "file_redirect" and any(
-            child.type in _WRITE_REDIRECT_OPERATORS for child in node.children
-        ):
+        if node.type == "file_redirect":
             destination = node.child_by_field_name("destination")
+            writes = any(
+                b">" in (child.text or b"")
+                for child in node.children
+                if child is not destination
+            )
             if (
-                destination is not None
+                writes
+                and destination is not None
                 and destination.type != "process_substitution"
                 and destination.text is not None
             ):

--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from functools import lru_cache
 import os
 from pathlib import Path
@@ -75,6 +75,42 @@ def _extract_commands(command: str) -> list[str]:
 
     find_commands(tree.root_node)
     return commands
+
+
+def _extract_redirect_targets(command: str) -> list[str]:
+    """Collect the file targets of output redirections (``>``, ``>>``).
+
+    Redirections write through *any* binary — including read-only allowlisted
+    ones like ``cat`` — so their targets must be permission-checked like the
+    path arguments of file-manipulating commands.
+    """
+    parser = _get_parser()
+    tree = parser.parse(command.encode("utf-8"))
+    targets: list[str] = []
+
+    def find_redirects(node: Node) -> None:
+        if node.type == "file_redirect":
+            destination = node.child_by_field_name("destination")
+            if destination is not None and destination.text is not None:
+                targets.append(destination.text.decode("utf-8"))
+        for child in node.children:
+            find_redirects(child)
+
+    find_redirects(tree.root_node)
+    return targets
+
+
+_QUOTE_PAIR_LEN = 2
+
+
+def _unquote(token: str) -> str:
+    if (
+        len(token) >= _QUOTE_PAIR_LEN
+        and token[0] == token[-1]
+        and token[0] in {'"', "'"}
+    ):
+        return token[1:-1]
+    return token
 
 
 def _get_shell_executable() -> str | None:
@@ -287,7 +323,9 @@ def _normalize_bash_path_token(token: str) -> str:
     return f"{drive.upper()}:{suffix or '/'}"
 
 
-def _collect_outside_dirs(command_parts: list[str]) -> set[str]:
+def _collect_outside_dirs(
+    command_parts: list[str], redirect_targets: Sequence[str] = ()
+) -> set[str]:
     """Collect parent directories referenced outside the workdir.
 
     Iterates file-manipulating commands (see _PATH_COMMANDS) and inspects
@@ -337,6 +375,31 @@ def _collect_outside_dirs(command_parts: list[str]) -> set[str]:
             # For a directory target use the dir itself; for a file use its parent
             parent = str(resolved) if resolved.is_dir() else str(resolved.parent)
             dirs.add(parent)
+
+    return dirs | _redirect_outside_dirs(redirect_targets)
+
+
+def _redirect_outside_dirs(redirect_targets: Sequence[str]) -> set[str]:
+    dirs: set[str] = set()
+    for raw_target in redirect_targets:
+        target = _unquote(raw_target)
+        # File-descriptor duplication (2>&1) and the null device never write
+        # to project files.
+        if not target or target.startswith(("&", "/dev/")) or target.isdigit():
+            continue
+        if "$" in target or "`" in target:
+            # The shell expands this to a path we cannot resolve statically:
+            # require approval rather than guess.
+            dirs.add(target)
+            continue
+        path_token = _normalize_bash_path_token(target)
+        if is_path_within_workdir(path_token) or is_scratchpad_path(path_token):
+            continue
+        resolved = Path(path_token).expanduser()
+        if not resolved.is_absolute():
+            resolved = Path.cwd() / resolved
+        resolved = resolved.resolve()
+        dirs.add(str(resolved) if resolved.is_dir() else str(resolved.parent))
     return dirs
 
 
@@ -564,7 +627,9 @@ class Bash(
             and guardrail_permission.permission == ToolPermission.NEVER
         ):
             return guardrail_permission
-        outside_dirs = _collect_outside_dirs(command_parts)
+        outside_dirs = _collect_outside_dirs(
+            command_parts, _extract_redirect_targets(args.command)
+        )
         if (
             self._is_unconditionally_allowed(command_parts, outside_dirs)
             and not guardrail_permission

--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -77,21 +77,32 @@ def _extract_commands(command: str) -> list[str]:
     return commands
 
 
+_WRITE_REDIRECT_OPERATORS = {">", ">>", "&>", "&>>", ">|", ">&", "<>"}
+
+
 def _extract_redirect_targets(command: str) -> list[str]:
-    """Collect the file targets of output redirections (``>``, ``>>``).
+    """Collect the file targets of output redirections (``>``, ``>>``, ``&>``).
 
     Redirections write through *any* binary — including read-only allowlisted
     ones like ``cat`` — so their targets must be permission-checked like the
-    path arguments of file-manipulating commands.
+    path arguments of file-manipulating commands. Input redirections (``<``)
+    only read and stay out of scope, and process substitutions are not file
+    targets (their inner command is permission-checked as a command).
     """
     parser = _get_parser()
     tree = parser.parse(command.encode("utf-8"))
     targets: list[str] = []
 
     def find_redirects(node: Node) -> None:
-        if node.type == "file_redirect":
+        if node.type == "file_redirect" and any(
+            child.type in _WRITE_REDIRECT_OPERATORS for child in node.children
+        ):
             destination = node.child_by_field_name("destination")
-            if destination is not None and destination.text is not None:
+            if (
+                destination is not None
+                and destination.type != "process_substitution"
+                and destination.text is not None
+            ):
                 targets.append(destination.text.decode("utf-8"))
         for child in node.children:
             find_redirects(child)

--- a/vibe/core/tools/builtins/experimental_bash.py
+++ b/vibe/core/tools/builtins/experimental_bash.py
@@ -199,29 +199,34 @@ def _extract_commands(command: str) -> list[str]:
     return commands
 
 
-_WRITE_REDIRECT_OPERATORS = {">", ">>", "&>", "&>>", ">|", ">&", "<>"}
-
-
 def _extract_redirect_targets(command: str) -> list[str]:
-    """Collect the file targets of output redirections (``>``, ``>>``, ``&>``).
+    """Collect the file targets of redirections that can write.
 
     Redirections write through *any* binary — including read-only allowlisted
     ones like ``cat`` — so their targets must be permission-checked like the
-    path arguments of file-manipulating commands. Input redirections (``<``)
-    only read and stay out of scope, and process substitutions are not file
-    targets (their inner command is permission-checked as a command).
+    path arguments of file-manipulating commands. A redirect writes when its
+    operator contains ``>`` (``>``, ``>>``, ``&>``, ``>|``, ``>&``, and the
+    read-write ``<>``, which tree-sitter tokenizes as ``<`` plus an ERROR
+    node holding ``>``). Pure input redirections (``<``) stay out of scope,
+    and process substitutions are not file targets (their inner command is
+    permission-checked as a command). Bare fd duplications (``2>&1``) are
+    collected here and skipped downstream by the digit check.
     """
     parser = _get_parser()
     tree = parser.parse(command.encode("utf-8"))
     targets: list[str] = []
 
     def find_redirects(node: Node) -> None:
-        if node.type == "file_redirect" and any(
-            child.type in _WRITE_REDIRECT_OPERATORS for child in node.children
-        ):
+        if node.type == "file_redirect":
             destination = node.child_by_field_name("destination")
+            writes = any(
+                b">" in (child.text or b"")
+                for child in node.children
+                if child is not destination
+            )
             if (
-                destination is not None
+                writes
+                and destination is not None
                 and destination.type != "process_substitution"
                 and destination.text is not None
             ):

--- a/vibe/core/tools/builtins/experimental_bash.py
+++ b/vibe/core/tools/builtins/experimental_bash.py
@@ -199,21 +199,32 @@ def _extract_commands(command: str) -> list[str]:
     return commands
 
 
+_WRITE_REDIRECT_OPERATORS = {">", ">>", "&>", "&>>", ">|", ">&", "<>"}
+
+
 def _extract_redirect_targets(command: str) -> list[str]:
-    """Collect the file targets of output redirections (``>``, ``>>``).
+    """Collect the file targets of output redirections (``>``, ``>>``, ``&>``).
 
     Redirections write through *any* binary — including read-only allowlisted
     ones like ``cat`` — so their targets must be permission-checked like the
-    path arguments of file-manipulating commands.
+    path arguments of file-manipulating commands. Input redirections (``<``)
+    only read and stay out of scope, and process substitutions are not file
+    targets (their inner command is permission-checked as a command).
     """
     parser = _get_parser()
     tree = parser.parse(command.encode("utf-8"))
     targets: list[str] = []
 
     def find_redirects(node: Node) -> None:
-        if node.type == "file_redirect":
+        if node.type == "file_redirect" and any(
+            child.type in _WRITE_REDIRECT_OPERATORS for child in node.children
+        ):
             destination = node.child_by_field_name("destination")
-            if destination is not None and destination.text is not None:
+            if (
+                destination is not None
+                and destination.type != "process_substitution"
+                and destination.text is not None
+            ):
                 targets.append(destination.text.decode("utf-8"))
         for child in node.children:
             find_redirects(child)

--- a/vibe/core/tools/builtins/experimental_bash.py
+++ b/vibe/core/tools/builtins/experimental_bash.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 import errno
@@ -199,6 +199,42 @@ def _extract_commands(command: str) -> list[str]:
     return commands
 
 
+def _extract_redirect_targets(command: str) -> list[str]:
+    """Collect the file targets of output redirections (``>``, ``>>``).
+
+    Redirections write through *any* binary — including read-only allowlisted
+    ones like ``cat`` — so their targets must be permission-checked like the
+    path arguments of file-manipulating commands.
+    """
+    parser = _get_parser()
+    tree = parser.parse(command.encode("utf-8"))
+    targets: list[str] = []
+
+    def find_redirects(node: Node) -> None:
+        if node.type == "file_redirect":
+            destination = node.child_by_field_name("destination")
+            if destination is not None and destination.text is not None:
+                targets.append(destination.text.decode("utf-8"))
+        for child in node.children:
+            find_redirects(child)
+
+    find_redirects(tree.root_node)
+    return targets
+
+
+_QUOTE_PAIR_LEN = 2
+
+
+def _unquote(token: str) -> str:
+    if (
+        len(token) >= _QUOTE_PAIR_LEN
+        and token[0] == token[-1]
+        and token[0] in {'"', "'"}
+    ):
+        return token[1:-1]
+    return token
+
+
 def _get_shell_executable() -> str | None:
     if is_windows():
         return None
@@ -325,7 +361,9 @@ def _looks_like_path(token: str) -> bool:
 
 
 def _collect_outside_dirs(
-    command_parts: list[str], command_cwd: Path | None = None
+    command_parts: list[str],
+    command_cwd: Path | None = None,
+    redirect_targets: Sequence[str] = (),
 ) -> set[str]:
     command_cwd = Path.cwd() if command_cwd is None else command_cwd
     dirs: set[str] = set()
@@ -359,6 +397,32 @@ def _collect_outside_dirs(
 
             parent = str(resolved) if resolved.is_dir() else str(resolved.parent)
             dirs.add(parent)
+
+    return dirs | _redirect_outside_dirs(redirect_targets, command_cwd)
+
+
+def _redirect_outside_dirs(
+    redirect_targets: Sequence[str], command_cwd: Path
+) -> set[str]:
+    dirs: set[str] = set()
+    for raw_target in redirect_targets:
+        target = _unquote(raw_target)
+        # File-descriptor duplication (2>&1) and the null device never write
+        # to project files.
+        if not target or target.startswith(("&", "/dev/")) or target.isdigit():
+            continue
+        if "$" in target or "`" in target:
+            # The shell expands this to a path we cannot resolve statically:
+            # require approval rather than guess.
+            dirs.add(target)
+            continue
+        resolved = Path(target).expanduser()
+        if not resolved.is_absolute():
+            resolved = command_cwd / resolved
+        resolved = resolved.resolve()
+        if is_path_within_workdir(str(resolved)) or is_scratchpad_path(str(resolved)):
+            continue
+        dirs.add(str(resolved) if resolved.is_dir() else str(resolved.parent))
     return dirs
 
 
@@ -1435,7 +1499,9 @@ class ExperimentalBash(
             if args.cwd is not None
             else Path.cwd()
         )
-        outside_dirs = _collect_outside_dirs(command_parts, command_cwd)
+        outside_dirs = _collect_outside_dirs(
+            command_parts, command_cwd, _extract_redirect_targets(args.command)
+        )
         context_required = self._build_context_permissions(args)
         if (
             self._is_unconditionally_allowed(


### PR DESCRIPTION
## Summary

Allowlisted read-only commands (`cat`, `echo`, …) can currently write or overwrite arbitrary files through shell redirectionswithout any prompt — e.g. `cat > ~/.bashrc << 'EOF2'` — because only the path *arguments* of file-manipulating commands are
checked against the workdir boundary, never the redirect target.

This PR extracts redirect destinations from the existing tree-sitter parse in both `bash` and `experimental_bash`, and routesthem through the same outside-directory permission flow already used for path arguments:

- A redirect is treated as writing when its operator contains `>` (`>`, `>>`, `&>`, `>|`, `>&`, and the read-write `<>` —
which tree-sitter tokenizes as `<` plus an ERROR node holding `>`). Pure input redirections (`<`) stay out of scope.
- Targets inside the workdir or scratchpad stay allowlisted; `/dev/null` and fd duplication (`2>&1`) are ignored; process
substitutions are treated as commands, not file targets.
- Statically unresolvable targets (`$VAR`, backticks) always require approval rather than being guessed.

The change is one-directional: it can only *add* permission prompts, never remove one or auto-approve. Commands without a
write redirect behave identically to before.

This closes the escape at the permission layer, which is the right level for Vibe since there is no OS-level sandbox. Fully-
shell-embedded writes (`bash -c "..."`, a script that writes, `python -c 'open(...)'`) remain out of scope — the same
boundary as the rest of the existing bash permission system.

Fixes #558 

## Test plan

- [x] New `tests/tools/test_bash_redirect_targets.py` covering: simple/append/heredoc write targets, inside vs outside
workdir, `/dev/null`, fd duplication, `$VAR` targets, **input redirects (`<`) not treated as writes**, **stderr (`2>`) and
`&>` variants**, **process substitution excluded**, and the **read-write `<>` / `1<>` bypass**.
- [x] `bash` and `experimental_bash` extraction verified byte-identical.
- [x] Full suite passes (7948 tests), pyright strict 0 errors, ruff + pre-commit clean.