### PR TITLE
fix(compaction): keep the summary request off a trailing tool result

### DIFF
--- a/tests/core/compaction/test_compaction_manager.py
+++ b/tests/core/compaction/test_compaction_manager.py
@@ -336,3 +336,67 @@ async def test_terminal_failure_reports_empty_when_primary_empty() -> None:
 
     assert summary == "(no summary available)"
     assert telemetry.failures == ["empty_summary"]
+
+
+def _mid_generation_conversation() -> MessageList:
+    """Conversation captured mid-turn: the tool results are in, but the
+    assistant has not replied to them yet (auto-compaction's trigger point).
+    """
+    return MessageList([
+        LLMMessage(role=Role.system, content="sys"),
+        LLMMessage(role=Role.user, content="run the tests"),
+        LLMMessage(
+            role=Role.assistant,
+            content="",
+            tool_calls=[
+                ToolCall(
+                    id="t1", index=0, function=FunctionCall(name="bash", arguments="{}")
+                )
+            ],
+        ),
+        LLMMessage(role=Role.tool, content="tests passed", tool_call_id="t1"),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_primary_never_sends_user_after_tool() -> None:
+    # Regression: auto-compaction fires mid-turn, so the snapshot can end on a
+    # tool result. Appending the summary request verbatim produced
+    # `tool -> user`, which strict backends reject with
+    # "Unexpected role 'user' after role 'tool'".
+    messages = _mid_generation_conversation()
+    stats = AgentStats()
+    manager, complete, _ = _build_manager(
+        [mock_llm_chunk(content="<summary>done</summary>")],
+        messages=messages,
+        stats=stats,
+    )
+
+    await manager.compact()
+
+    sent = complete.calls[0]["messages"]
+    roles = [m.role for m in sent]
+    for previous, current in zip(roles, roles[1:], strict=False):
+        assert not (previous == Role.tool and current == Role.user), (
+            f"invalid role sequence sent to backend: {[r.value for r in roles]}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_tool_round_closer_does_not_leak_into_fallback_transcript() -> None:
+    # The closer exists only to keep the primary call's role sequence valid; it
+    # is not part of the conversation, so the fallback transcript must not
+    # attribute it to the assistant.
+    messages = _mid_generation_conversation()
+    stats = AgentStats()
+    manager, complete, _ = _build_manager(
+        [_tool_call_chunk(), mock_llm_chunk(content="<summary>recovered</summary>")],
+        messages=messages,
+        stats=stats,
+    )
+
+    summary = await manager.compact()
+
+    assert summary == "recovered"
+    fallback_prompt = complete.calls[1]["messages"][-1].content or ""
+    assert "Tool results received." not in fallback_prompt

--- a/vibe/core/compaction/context.py
+++ b/vibe/core/compaction/context.py
@@ -26,6 +26,8 @@ _PREVIOUS_USER_MESSAGE_RE = re.compile(
     re.DOTALL,
 )
 
+_TOOL_ROUND_CLOSER = "(Tool results received.)"
+
 _SUMMARY_OPEN = "<summary>"
 _SUMMARY_CLOSE = "</summary>"
 _SUMMARY_RE = re.compile(
@@ -38,6 +40,21 @@ def extract_summary(text: str) -> str | None:
     if match is None:
         return None
     return match.group(1).strip() or None
+
+
+def close_incomplete_tool_round(messages: Sequence[LLMMessage]) -> list[LLMMessage]:
+    """Copy of ``messages`` that never ends on a tool result.
+
+    Auto-compaction fires mid-turn, so the snapshot can end on a tool message
+    the assistant has not answered yet. Appending the summary request to that
+    history yields ``tool -> user``, which strict chat templates reject
+    ("Unexpected role 'user' after role 'tool'"). Closing the round with a
+    short assistant turn keeps every tool payload available to the summarizer
+    while restoring the ``assistant -> user`` sequence backends expect.
+    """
+    if not messages or messages[-1].role != Role.tool:
+        return list(messages)
+    return [*messages, LLMMessage(role=Role.assistant, content=_TOOL_ROUND_CLOSER)]
 
 
 def drop_oldest_round(messages: Sequence[LLMMessage]) -> list[LLMMessage] | None:

--- a/vibe/core/compaction/manager.py
+++ b/vibe/core/compaction/manager.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Literal, Protocol
 
 from vibe.core.compaction.context import (
+    close_incomplete_tool_round,
     collect_prior_user_messages,
     drop_oldest_round,
     extract_summary,
@@ -142,7 +143,7 @@ class CompactionManager:
         request_message = LLMMessage(role=Role.user, content=request)
         result, working = await self._summarize_call(
             list(snapshot),
-            lambda history: [*history, request_message],
+            lambda history: [*close_incomplete_tool_round(history), request_message],
             model=self._config().get_compaction_model(),
             tools=self._available_tools(),
             tool_choice=self._tool_choice(),


### PR DESCRIPTION
Fixes #902.

## The bug

Auto-compaction fires mid-turn, so the snapshot it summarizes can end on a `tool` message the assistant has not answered yet. `CompactionManager._primary` appended the summary request as a `user` message directly onto that history:

```python
lambda history: [*history, request_message]
```

which yields:

```
assistant(tool_calls) -> tool -> user
```

Strict chat templates reject that sequence, so auto-compaction failed consistently against vLLM-served Devstral with the error from the issue:

```
Unexpected role 'user' after role 'tool'
```

This also explains the asymmetry the reporter noticed: manual `/compact` is unaffected because the user triggers it at a turn boundary, where the history already ends on an assistant message.

## The fix

`close_incomplete_tool_round` closes the open round with a short assistant turn before the request is appended, restoring `assistant -> user`. Every tool payload stays visible to the summarizer — nothing is dropped, so the summary still covers the freshest results.

The closer is built inside `build_messages` rather than in `working`, so it never enters the history that `_fallback` renders, and the live `MessageList` is untouched as before. It is also recomputed after each `drop_oldest_round` retry, so the overflow path stays valid too.

## Tests

`test_primary_never_sends_user_after_tool` fails on `main` with exactly the reported sequence:

```
AssertionError: invalid role sequence sent to backend:
['system', 'user', 'assistant', 'tool', 'user']
```

`test_tool_round_closer_does_not_leak_into_fallback_transcript` pins the containment property, so the closer cannot start showing up as real assistant dialogue in the fallback summarizer prompt.

## Verification

- 5977 passed, 2 skipped across `tests/core`, `tests/agent_loop`, `tests/cli`, `tests/acp`
- `ruff check` and `ruff format` clean
- `mypy` unchanged from baseline (the 98 pre-existing errors are all in other modules; none in `vibe/core/compaction/`)

One unrelated failure, `tests/core/test_history_properties.py::test_manual_edits_during_review_stay_projectable`, is a pre-existing flake sitting right on its 10s `pytest-timeout` limit. It passes in isolation both with my change (10.11s) and without it (10.58s) — same category of slow-environment flakiness that #884 is addressing.