### PR TITLE
feat: add /btw side-question slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,10 @@ Vibe provides several built-in slash commands. Use slash commands by typing them
 
 ```
 > /help
+> /btw what does this function do?
 ```
+
+`/btw <question>` asks a one-shot side question using the current session context. Neither the question nor the answer is added to the conversation history (interactive mode only).
 
 ### Custom Slash Commands via Skills
 

--- a/tests/acp/test_commands.py
+++ b/tests/acp/test_commands.py
@@ -238,6 +238,30 @@ class TestHandleCompact:
             mock_compact.assert_called_once()
 
 
+class TestHandleBtw:
+    @pytest.mark.asyncio
+    async def test_btw_replies_interactive_only(
+        self, acp_agent_loop: VibeAcpAgentLoop
+    ) -> None:
+        session_id = await _new_session_and_clear(acp_agent_loop)
+        session = acp_agent_loop.sessions[session_id]
+        before = [
+            m.model_dump(mode="json", exclude_none=True)
+            for m in session.agent_loop.messages
+        ]
+
+        response = await _prompt(acp_agent_loop, session_id, "/btw what is this?")
+
+        assert response.stop_reason == "end_turn"
+        assert _get_message_texts(acp_agent_loop) == [
+            "`/btw` is only available in interactive mode."
+        ]
+        assert [
+            m.model_dump(mode="json", exclude_none=True)
+            for m in session.agent_loop.messages
+        ] == before
+
+
 class TestHandleTeleport:
     @pytest.mark.asyncio
     async def test_available_commands_includes_teleport(

--- a/tests/agent_loop/test_btw.py
+++ b/tests/agent_loop/test_btw.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from contextlib import aclosing
+
+import pytest
+
+from tests.conftest import build_test_agent_loop
+from tests.mock.utils import mock_llm_chunk
+from tests.stubs.fake_backend import FakeBackend
+from vibe.cli.commands import CommandRegistry
+from vibe.core.types import LLMMessage, Role
+
+
+def _history_snapshot(agent_loop) -> list[dict]:
+    return [m.model_dump(mode="json", exclude_none=True) for m in agent_loop.messages]
+
+
+@pytest.mark.asyncio
+async def test_btw_leaves_main_history_byte_identical() -> None:
+    backend = FakeBackend(mock_llm_chunk(content="side answer", prompt_tokens=7))
+    agent_loop = build_test_agent_loop(backend=backend)
+    agent_loop.messages.extend([
+        LLMMessage(role=Role.user, content="hello"),
+        LLMMessage(role=Role.assistant, content="hi there"),
+    ])
+    before = _history_snapshot(agent_loop)
+
+    async with aclosing(agent_loop.btw("what is InvokeContext?")) as chunks:
+        answer = "".join([chunk async for chunk in chunks])
+
+    assert answer == "side answer"
+    assert _history_snapshot(agent_loop) == before
+
+
+@pytest.mark.asyncio
+async def test_btw_sends_empty_tools() -> None:
+    backend = FakeBackend(mock_llm_chunk(content="ok"))
+    agent_loop = build_test_agent_loop(backend=backend)
+    agent_loop.messages.append(LLMMessage(role=Role.user, content="context"))
+
+    async with aclosing(agent_loop.btw("side question")) as chunks:
+        async for _ in chunks:
+            pass
+
+    assert backend.requests_tools == [[]]
+    assert backend.requests_tool_choices == [None]
+    last_message = backend.requests_messages[-1][-1]
+    assert last_message.role == Role.user
+    assert last_message.content == "side question"
+
+
+@pytest.mark.asyncio
+async def test_btw_counts_usage_in_session_stats() -> None:
+    backend = FakeBackend(
+        mock_llm_chunk(content="ok", prompt_tokens=11, completion_tokens=3)
+    )
+    agent_loop = build_test_agent_loop(backend=backend)
+    before_prompt = agent_loop.stats.session_prompt_tokens
+    before_completion = agent_loop.stats.session_completion_tokens
+
+    async with aclosing(agent_loop.btw("cost me")) as chunks:
+        async for _ in chunks:
+            pass
+
+    assert agent_loop.stats.session_prompt_tokens == before_prompt + 11
+    assert agent_loop.stats.session_completion_tokens == before_completion + 3
+
+
+@pytest.mark.asyncio
+async def test_btw_api_error_leaves_session_intact() -> None:
+    backend = FakeBackend(exception_to_raise=RuntimeError("boom"))
+    agent_loop = build_test_agent_loop(backend=backend)
+    agent_loop.messages.extend([
+        LLMMessage(role=Role.user, content="hello"),
+        LLMMessage(role=Role.assistant, content="hi"),
+    ])
+    before = _history_snapshot(agent_loop)
+    before_prompt = agent_loop.stats.session_prompt_tokens
+
+    with pytest.raises(RuntimeError, match="API error"):
+        async with aclosing(agent_loop.btw("will fail")) as chunks:
+            async for _ in chunks:
+                pass
+
+    assert _history_snapshot(agent_loop) == before
+    assert agent_loop.stats.session_prompt_tokens == before_prompt
+
+
+@pytest.mark.asyncio
+async def test_btw_streaming_leaves_history_unchanged() -> None:
+    backend = FakeBackend([
+        mock_llm_chunk(content="part ", prompt_tokens=0, completion_tokens=0),
+        mock_llm_chunk(content="two", prompt_tokens=4, completion_tokens=2),
+    ])
+    agent_loop = build_test_agent_loop(backend=backend, enable_streaming=True)
+    agent_loop.messages.append(LLMMessage(role=Role.user, content="hello"))
+    before = _history_snapshot(agent_loop)
+
+    async with aclosing(agent_loop.btw("stream me")) as chunks:
+        answer = "".join([chunk async for chunk in chunks])
+
+    assert answer == "part two"
+    assert _history_snapshot(agent_loop) == before
+    assert backend.requests_tools == [[]]
+
+
+def test_btw_command_registration() -> None:
+    registry = CommandRegistry()
+    assert registry.get_command_name("/btw") == "btw"
+    result = registry.parse_command("/btw what is this?")
+    assert result is not None
+    cmd_name, cmd, cmd_args = result
+    assert cmd_name == "btw"
+    assert cmd.handler == "_btw_command"
+    assert cmd_args == "what is this?"
+    assert "/btw" in registry.get_help_text()
+
+
+def test_btw_command_without_args_parses_empty_args() -> None:
+    registry = CommandRegistry()
+    result = registry.parse_command("/btw")
+    assert result is not None
+    _, _, cmd_args = result
+    assert cmd_args == ""
+
+
+def test_programmatic_btw_returns_interactive_only_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from tests.conftest import build_test_vibe_config
+    from tests.stubs.fake_config_orchestrator import FakeConfigOrchestrator
+    from vibe.core.programmatic import run_programmatic
+
+    fake_loop = MagicMock()
+    fake_loop.emit_session_closed_telemetry = MagicMock()
+    fake_loop.aclose = AsyncMock()
+    fake_loop.telemetry_client.aclose = AsyncMock()
+    monkeypatch.setattr(
+        "vibe.core.programmatic.AgentLoop", lambda *args, **kwargs: fake_loop
+    )
+
+    result = run_programmatic(
+        FakeConfigOrchestrator(build_test_vibe_config()), prompt="/btw what is this?"
+    )
+
+    assert result == "/btw is only available in interactive mode."
+    fake_loop.act.assert_not_called()

--- a/vibe/acp/acp_agent_loop.py
+++ b/vibe/acp/acp_agent_loop.py
@@ -2988,6 +2988,13 @@ class VibeAcpAgentLoop(AcpAgent):
     ) -> PromptResponse:
         return await self._command_reply(session, DATA_RETENTION_MESSAGE, message_id)
 
+    async def _handle_btw(
+        self, session: AcpSessionLoop, text_prompt: str, message_id: str
+    ) -> PromptResponse:
+        return await self._command_reply(
+            session, "`/btw` is only available in interactive mode.", message_id
+        )
+
 
 SESSION_CLOSED_FLUSH_TIMEOUT_SECONDS = 1.0
 

--- a/vibe/acp/commands/registry.py
+++ b/vibe/acp/commands/registry.py
@@ -121,4 +121,10 @@ def _build_commands() -> dict[str, AcpCommand]:
             description="Show data retention information",
             handler="_handle_data_retention",
         ),
+        "btw": AcpCommand(
+            name="btw",
+            description="Ask a side question (interactive mode only)",
+            handler="_handle_btw",
+            input_hint="question",
+        ),
     }

--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -107,6 +107,14 @@ class CommandRegistry:
                 description="Display agent statistics",
                 handler="_show_status",
             ),
+            "btw": Command(
+                aliases=frozenset(["/btw"]),
+                description=(
+                    "Ask a side question using session context without adding "
+                    "it to the conversation"
+                ),
+                handler="_btw_command",
+            ),
             "teleport": Command(
                 aliases=frozenset(["/teleport"]),
                 description="Teleport session to Vibe Code Web",

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -72,6 +72,7 @@ from vibe.cli.textual_ui.scheduled_loop_runner import ScheduledLoopRunner
 from vibe.cli.textual_ui.session_exit import print_session_resume_message
 from vibe.cli.textual_ui.widgets.approval_app import ApprovalApp
 from vibe.cli.textual_ui.widgets.banner.banner import Banner
+from vibe.cli.textual_ui.widgets.btw import BtwMessage
 from vibe.cli.textual_ui.widgets.chat_input import ChatInputContainer
 from vibe.cli.textual_ui.widgets.chat_input.input_kinds import (
     Bash,
@@ -3372,6 +3373,49 @@ class VibeApp(App):  # noqa: PLR0904
             self._run_compact(compact_msg, old_session_id, cmd_args.strip())
         )
 
+    async def _btw_command(self, cmd_args: str = "", **kwargs: Any) -> None:
+        question = cmd_args.strip()
+        if not question:
+            await self._mount_and_scroll(
+                UserCommandMessage(
+                    "Usage: `/btw <question>`\n\n"
+                    "Ask a side question without adding it to the conversation."
+                )
+            )
+            return
+
+        if self._agent_running:
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    "Cannot run /btw while the agent is processing. Please wait.",
+                    collapsed=self._tools_collapsed,
+                )
+            )
+            return
+
+        btw_msg = BtwMessage()
+        await self._mount_and_scroll(btw_msg)
+        self._agent_task = asyncio.create_task(self._run_btw(btw_msg, question))
+
+    async def _run_btw(self, btw_msg: BtwMessage, question: str) -> None:
+        self._agent_running = True
+        try:
+            await self._ensure_loading_widget()
+            async for chunk in self.agent_loop.btw(question):
+                await btw_msg.append_content(chunk)
+            await btw_msg.stop_stream()
+        except asyncio.CancelledError:
+            await btw_msg.stop_stream()
+            btw_msg.set_error("Interrupted")
+            raise
+        except Exception as e:
+            await btw_msg.stop_stream()
+            btw_msg.set_error(str(e))
+        finally:
+            await self._remove_loading_widget()
+            self._agent_running = False
+            self._agent_task = None
+
     async def _run_compact(
         self,
         compact_msg: CompactMessage,
@@ -4003,6 +4047,9 @@ class VibeApp(App):  # noqa: PLR0904
             self._last_escape_time = None
             return True
 
+        if self._dismiss_last_btw_message():
+            return True
+
         if self._try_interrupt_bottom_app_escape():
             return True
 
@@ -4013,6 +4060,13 @@ class VibeApp(App):  # noqa: PLR0904
             self._narrator_manager.cancel()
             return True
 
+        return False
+
+    def _dismiss_last_btw_message(self) -> bool:
+        for child in reversed(self._messages_area.children):
+            if isinstance(child, BtwMessage):
+                child.remove()
+                return True
         return False
 
     def _try_interrupt_running_job(self) -> bool:

--- a/vibe/cli/textual_ui/app.tcss
+++ b/vibe/cli/textual_ui/app.tcss
@@ -488,7 +488,8 @@ Markdown {
 .interrupt-message,
 .error-message,
 .warning-message,
-.user-command-message {
+.user-command-message,
+.btw-message {
     margin-top: 0;
     margin-bottom: 0;
     height: auto;
@@ -527,7 +528,8 @@ Markdown {
 .interrupt-container,
 .error-container,
 .warning-container,
-.user-command-container {
+.user-command-container,
+.btw-container {
     width: 100%;
     height: auto;
     margin: 0;
@@ -537,7 +539,8 @@ Markdown {
 .interrupt-border,
 .error-border,
 .warning-border,
-.user-command-border {
+.user-command-border,
+.btw-border {
     width: auto;
     height: 100%;
     padding: 0 1 0 2;
@@ -568,7 +571,8 @@ Markdown {
     color: $warning;
 }
 
-.user-command-content {
+.user-command-content,
+.btw-content {
     width: 1fr;
     height: auto;
     margin: 0;

--- a/vibe/cli/textual_ui/widgets/btw.py
+++ b/vibe/cli/textual_ui/widgets/btw.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Markdown
+
+from vibe.cli.textual_ui.widgets.messages import ExpandingBorder, StreamingMessageBase
+
+
+class BtwMessage(StreamingMessageBase):
+    def __init__(self, content: str = "") -> None:
+        super().__init__(content)
+        self.add_class("btw-message")
+        self._error_message: str | None = None
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(classes="btw-container"):
+            yield ExpandingBorder(classes="btw-border")
+            with Vertical(classes="btw-content"):
+                markdown = Markdown("")
+                self._markdown = markdown
+                yield markdown
+
+    def set_error(self, error_message: str) -> None:
+        self._error_message = error_message
+        self._content = f"Error: {error_message}"
+        if self._markdown is not None:
+            self._markdown.update(self._content)

--- a/vibe/core/agent_loop/_loop.py
+++ b/vibe/core/agent_loop/_loop.py
@@ -2130,26 +2130,39 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
             raise _refusal_error(provider.name, active_model.name, result)
         return result
 
-    async def _chat_streaming(self) -> AsyncGenerator[LLMChunk]:
-        active_model = self.config.get_active_model()
-        provider = self.config.get_active_provider()
-        backend_metadata = self._build_backend_metadata()
+    async def _complete_streaming(
+        self,
+        *,
+        model: ModelConfig,
+        messages: Sequence[LLMMessage],
+        tools: list[AvailableTool] | None,
+        tool_choice: StrToolChoice | AvailableTool | None,
+        call_type: TelemetryCallType | None,
+    ) -> AsyncGenerator[LLMChunk]:
+        """Make one accounted, streaming model call.
 
-        available_tools = self.format_handler.get_available_tools(self.tool_manager)
-        tool_choice = self.format_handler.get_tool_choice()
+        Sends request telemetry, streams the backend, updates stats, and maps
+        backend errors. Does NOT append to self.messages or raise on refusal —
+        those are the caller's concern.
+        """
+        provider = self.config.get_provider_for_model(model)
+        backend_metadata = self._build_backend_metadata(call_type)
 
-        last_user_message = self._last_user_message()
+        last_user_message = next(
+            (m for m in reversed(messages) if m.role == Role.user and not m.injected),
+            None,
+        )
         self.telemetry_client.send_request_sent(
-            model=active_model.alias,
-            nb_context_chars=sum(len(m.content or "") for m in self.messages),
-            nb_context_messages=len(self.messages),
+            model=model.alias,
+            nb_context_chars=sum(len(m.content or "") for m in messages),
+            nb_context_messages=len(messages),
             nb_prompt_chars=len(last_user_message.content or "")
             if last_user_message
             else 0,
             call_type=backend_metadata.call_type,
             message_id=backend_metadata.message_id,
             attachment_counts=build_attachment_counts(
-                last_user_message, supports_images=active_model.supports_images
+                last_user_message, supports_images=model.supports_images
             ),
         )
 
@@ -2158,12 +2171,12 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
             usage = LLMUsage()
             chunk_agg: LLMChunk | None = None
             async for chunk in self.backend.complete_streaming(
-                model=active_model,
-                messages=self._messages_for_backend(self.messages, active_model),
-                temperature=active_model.temperature,
-                tools=available_tools,
+                model=model,
+                messages=self._messages_for_backend(messages, model),
+                temperature=model.temperature,
+                tools=tools,
                 tool_choice=tool_choice,
-                extra_headers=self._get_extra_headers(),
+                extra_headers=self._get_extra_headers(provider),
                 max_tokens=self._max_tokens,
                 metadata=backend_metadata.model_dump(exclude_none=True),
             ):
@@ -2190,25 +2203,43 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
                 )
             self._update_stats(usage=usage, time_seconds=end_time - start_time)
 
-            self.messages.append(chunk_agg.message)
-            if chunk_agg.stop and chunk_agg.stop.is_refusal:
-                raise _refusal_error(provider.name, active_model.name, chunk_agg)
-
         except Exception as e:
             if isinstance(e, RefusalError):
                 raise
             if _should_raise_rate_limit_error(e):
-                raise RateLimitError(provider.name, active_model.name) from e
+                raise RateLimitError(provider.name, model.name) from e
             if _is_context_too_long_error(e):
-                raise ContextTooLongError(provider.name, active_model.name) from e
+                raise ContextTooLongError(provider.name, model.name) from e
             if _is_response_too_long_error(e):
-                raise ResponseTooLongError(provider.name, active_model.name) from e
+                raise ResponseTooLongError(provider.name, model.name) from e
             if _is_non_retryable_error(e):
                 raise
 
             raise RuntimeError(
-                f"API error from {provider.name} (model: {active_model.name}): {e}"
+                f"API error from {provider.name} (model: {model.name}): {e}"
             ) from e
+
+    async def _chat_streaming(self) -> AsyncGenerator[LLMChunk]:
+        active_model = self.config.get_active_model()
+        provider = self.config.get_active_provider()
+        chunk_agg: LLMChunk | None = None
+        async for chunk in self._complete_streaming(
+            model=active_model,
+            messages=self.messages,
+            tools=self.format_handler.get_available_tools(self.tool_manager),
+            tool_choice=self.format_handler.get_tool_choice(),
+            call_type=None,
+        ):
+            chunk_agg = chunk if chunk_agg is None else chunk_agg + chunk
+            yield chunk
+
+        if chunk_agg is None:
+            raise AgentLoopLLMResponseError(
+                "Usage data missing in final chunk of streamed completion"
+            )
+        self.messages.append(chunk_agg.message)
+        if chunk_agg.stop and chunk_agg.stop.is_refusal:
+            raise _refusal_error(provider.name, active_model.name, chunk_agg)
 
     def _update_stats(self, usage: LLMUsage, time_seconds: float) -> None:
         self.stats.last_turn_duration = time_seconds
@@ -2383,6 +2414,42 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         except Exception:
             await self._save_messages()
             raise
+
+    @requires_init
+    async def btw(self, question: str) -> AsyncGenerator[str, None]:
+        """One-shot side question using session context without mutating history.
+
+        Reuses the current system prompt and message list as read-only context,
+        calls the active model with no tools, and yields assistant text. Usage is
+        counted in session stats; neither the question nor the answer is appended
+        to ``self.messages``.
+        """
+        active_model = self.config.get_active_model()
+        fork_messages: list[LLMMessage] = [
+            *self.messages,
+            LLMMessage(role=Role.user, content=question),
+        ]
+        if self.enable_streaming:
+            async for chunk in self._complete_streaming(
+                model=active_model,
+                messages=fork_messages,
+                tools=[],
+                tool_choice=None,
+                call_type="secondary_call",
+            ):
+                if chunk.message.content:
+                    yield chunk.message.content
+            return
+
+        result = await self._complete(
+            model=active_model,
+            messages=fork_messages,
+            tools=[],
+            tool_choice=None,
+            call_type="secondary_call",
+        )
+        if result.message.content:
+            yield result.message.content
 
     async def _request_clear_context(self) -> None:
         """Signal that the context should be cleared at the next turn boundary.

--- a/vibe/core/programmatic.py
+++ b/vibe/core/programmatic.py
@@ -65,6 +65,11 @@ def run_programmatic(  # noqa: PLR0913, PLR0917
 
     async def _async_run() -> str | None:
         try:
+            if prompt.strip().lower().startswith("/btw"):
+                message = "/btw is only available in interactive mode."
+                logger.info(message)
+                return message
+
             if previous_messages:
                 non_system_messages = [
                     msg for msg in previous_messages if not (msg.role == Role.system)

--- a/vibe/core/skills/builtins/vibe.py
+++ b/vibe/core/skills/builtins/vibe.py
@@ -608,6 +608,8 @@ Custom agents are TOML files in `~/.vibe/agents/NAME.toml`.
 ## Built-in Slash Commands
 
 - `/help` - Show help message
+- `/btw <question>` - Ask a side question using session context without adding
+  it to the conversation (interactive mode only; ignored in `-p` / ACP)
 - `/config` - Edit config settings
 - `/model` - Select active model
 - `/thinking` - Select thinking level


### PR DESCRIPTION
## Summary
Adds `/btw <question>`, a one-shot side question you can ask between turns,
using the current system prompt and session history as read-only context,
with no tools. Neither the question nor the answer is added to the main
conversation history — the next model turn sends the same history as before
`/btw`. Only available while the agent is idle (blocked while a turn is
running); interactive mode only, `-p` and ACP reply with an interactive-only
message.

  ## Demo
<img width="800" height="453" alt="ezgif-62463da3d1a318bf" src="https://github.com/user-attachments/assets/cf8e820d-6a54-4442-b42a-1439e20522f6" />


  ## Design choices
- Builds a local message list (`[*self.messages, question]`) and calls the
  backend directly with `tools=[]`, so the model can't trigger tool calls
  during the side question. Nothing is appended to `self.messages`.
- Token usage is still counted in session stats (`/status`) via the normal
  accounting path.
- UI follows existing Mistral patterns: slash echo + `ExpandingBorder` aside
  (`BtwMessage`), with the usual Generating spinner during the call.

## Limitations
- Session `meta.json` stats only rewrite when messages change; `/status` is
  live in-memory.
- Not available in programmatic (`-p`) or ACP surfaces by design.
- Blocked while the agent is actively running a turn.