### PR TITLE
Agent loop: send per-completion idempotency keys

### DIFF
--- a/tests/agent_loop/test_agent_backend.py
+++ b/tests/agent_loop/test_agent_backend.py
@@ -76,7 +76,7 @@ def _make_sampling_params() -> CreateMessageRequestParams:
 async def test_passes_distinct_idempotency_keys_for_each_completion(
     vibe_config: VibeConfigSchema, enable_streaming: bool
 ) -> None:
-    vibe_config.get_active_provider().extra_headers["idempotency-key"] = "configured"
+    vibe_config.get_active_provider().extra_headers["Idempotency-Key"] = "configured"
     backend = FakeBackend([
         [mock_llm_chunk(content="First response")],
         [mock_llm_chunk(content="Second response")],
@@ -94,10 +94,10 @@ async def test_passes_distinct_idempotency_keys_for_each_completion(
     assert second_headers is not None
     assert first_headers["x-affinity"] == agent.session_id
     assert second_headers["x-affinity"] == agent.session_id
-    assert "idempotency-key" not in first_headers
-    assert "idempotency-key" not in second_headers
-    assert first_headers["Idempotency-Key"] != "configured"
-    assert first_headers["Idempotency-Key"] != second_headers["Idempotency-Key"]
+    assert "Idempotency-Key" not in first_headers
+    assert "Idempotency-Key" not in second_headers
+    assert first_headers["idempotency-key"] != "configured"
+    assert first_headers["idempotency-key"] != second_headers["idempotency-key"]
 
 
 @pytest.mark.asyncio

--- a/tests/agent_loop/test_agent_backend.py
+++ b/tests/agent_loop/test_agent_backend.py
@@ -72,37 +72,32 @@ def _make_sampling_params() -> CreateMessageRequestParams:
 
 
 @pytest.mark.asyncio
-async def test_passes_x_affinity_header_when_asking_an_answer(
-    vibe_config: VibeConfigSchema,
-):
-    backend = FakeBackend([mock_llm_chunk(content="Response")])
-    agent = build_test_agent_loop(config=vibe_config, backend=backend)
-
-    [_ async for _ in agent.act("Hello")]
-
-    assert len(backend.requests_extra_headers) > 0
-    headers = backend.requests_extra_headers[0]
-    assert headers is not None
-    assert "x-affinity" in headers
-    assert headers["x-affinity"] == agent.session_id
-
-
-@pytest.mark.asyncio
-async def test_passes_x_affinity_header_when_asking_an_answer_streaming(
-    vibe_config: VibeConfigSchema,
-):
-    backend = FakeBackend([mock_llm_chunk(content="Response")])
+@pytest.mark.parametrize("enable_streaming", [False, True])
+async def test_passes_distinct_idempotency_keys_for_each_completion(
+    vibe_config: VibeConfigSchema, enable_streaming: bool
+) -> None:
+    vibe_config.get_active_provider().extra_headers["idempotency-key"] = "configured"
+    backend = FakeBackend([
+        [mock_llm_chunk(content="First response")],
+        [mock_llm_chunk(content="Second response")],
+    ])
     agent = build_test_agent_loop(
-        config=vibe_config, backend=backend, enable_streaming=True
+        config=vibe_config, backend=backend, enable_streaming=enable_streaming
     )
 
-    [_ async for _ in agent.act("Hello")]
+    [_ async for _ in agent.act("First request")]
+    [_ async for _ in agent.act("Second request")]
 
-    assert len(backend.requests_extra_headers) > 0
-    headers = backend.requests_extra_headers[0]
-    assert headers is not None
-    assert "x-affinity" in headers
-    assert headers["x-affinity"] == agent.session_id
+    assert len(backend.requests_extra_headers) == 2
+    first_headers, second_headers = backend.requests_extra_headers
+    assert first_headers is not None
+    assert second_headers is not None
+    assert first_headers["x-affinity"] == agent.session_id
+    assert second_headers["x-affinity"] == agent.session_id
+    assert "idempotency-key" not in first_headers
+    assert "idempotency-key" not in second_headers
+    assert first_headers["Idempotency-Key"] != "configured"
+    assert first_headers["Idempotency-Key"] != second_headers["Idempotency-Key"]
 
 
 @pytest.mark.asyncio

--- a/vibe/core/agent_loop/_loop.py
+++ b/vibe/core/agent_loop/_loop.py
@@ -1250,9 +1250,14 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         self, provider: ProviderConfig | None = None
     ) -> dict[str, str]:
         provider = self.config.get_active_provider() if provider is None else provider
-        headers: dict[str, str] = {**provider.extra_headers}
+        headers = {
+            name: value
+            for name, value in provider.extra_headers.items()
+            if name.lower() != "idempotency-key"
+        }
         headers["user-agent"] = get_user_agent(provider.backend)
         headers["x-affinity"] = self.session_id
+        headers["Idempotency-Key"] = uuid4().hex
         return headers
 
     async def _open_user_turn(

--- a/vibe/core/agent_loop/_loop.py
+++ b/vibe/core/agent_loop/_loop.py
@@ -1257,7 +1257,7 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         }
         headers["user-agent"] = get_user_agent(provider.backend)
         headers["x-affinity"] = self.session_id
-        headers["Idempotency-Key"] = uuid4().hex
+        headers["idempotency-key"] = uuid4().hex
         return headers
 
     async def _open_user_turn(


### PR DESCRIPTION
## Why

Orchestral currently cannot distinguish a transport retry from a second intentional completion when both requests have the same body. [mistral#25055](https://github.com/mistralai/mistral/pull/25055) adds explicit per-call identity on the server; Vibe must supply one stable key per logical completion so retries reuse a response while independent completions remain independent.

This is the client half of a two-PR rollout. Merge the backward-compatible server support first, then merge and release this Vibe change. `x-affinity` remains unchanged and continues to control routing rather than request identity.

## Summary

- Generate a fresh `idempotency-key` for each streaming or non-streaming AgentLoop completion.
- Generate the header above the backend retry layers so transport retries reuse the same key.
- Replace any statically configured idempotency header case-insensitively to prevent duplicate or reused keys.
- Preserve the existing `x-affinity` header for session routing.

## Reviewer guide

- `vibe/core/agent_loop/_loop.py` contains the logic change at the shared AgentLoop header boundary.
- `tests/agent_loop/test_agent_backend.py` consolidates the existing streaming and non-streaming header checks and verifies fresh keys plus configured-header replacement.

## Test plan

- `env -u PYTHON_KEYRING_BACKEND uv run pytest -q tests/agent_loop/test_agent_backend.py` — 21 passed.
- `uv run ruff check --fix .` — passed.
- `uv run ruff format .` — passed; reformatted the focused test file.
- `uv run pyright` — 0 errors.
- `env -u PYTHON_KEYRING_BACKEND uv run pre-commit run --all-files` — passed.
