### PR TITLE
Add /calm mode: paced block-by-block text reveal

### DIFF
--- a/tests/cli/textual_ui/test_calm_reveal.py
+++ b/tests/cli/textual_ui/test_calm_reveal.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from tests.conftest import build_test_vibe_app, build_test_vibe_config
+from vibe.cli.textual_ui.app import VibeApp
+from vibe.cli.textual_ui.widgets.calm_reveal import (
+    DIMMED_OPACITY,
+    FOCUSED_OPACITY,
+    CalmRevealContainer,
+)
+from vibe.cli.textual_ui.widgets.calm_status import CalmStatus
+from vibe.cli.textual_ui.widgets.chat_input.container import ChatInputContainer
+from vibe.cli.textual_ui.widgets.messages import AssistantMessage
+
+MULTI_BLOCK = "First paragraph here.\n\nSecond paragraph now.\n\nThird and final block."
+
+
+def _calm_app(*, motion: bool = False, pace: str = "Swift") -> VibeApp:
+    config = build_test_vibe_config(
+        calm_mode_enabled=True, calm_motion_enabled=motion, calm_pace_label=pace
+    )
+    return build_test_vibe_app(config=config)
+
+
+async def _mount_calm(
+    pilot, content: str = MULTI_BLOCK
+) -> tuple[AssistantMessage, CalmRevealContainer]:
+    app = pilot.app
+    messages = app.query_one("#messages")
+    msg = AssistantMessage(content, calm_mode=True)
+    await messages.mount(msg)
+    container = await msg.build_calm_reveal()
+    assert container is not None
+    await pilot.pause()
+    return msg, container
+
+
+@pytest.mark.asyncio
+async def test_only_first_block_revealed_and_focused() -> None:
+    async with _calm_app().run_test() as pilot:
+        _, container = await _mount_calm(pilot)
+        blocks = container._blocks
+
+        assert len(blocks) == 3
+        assert blocks[0]._revealed is True
+        assert blocks[0].styles.display == "block"
+        assert blocks[0].styles.opacity == FOCUSED_OPACITY
+        for block in blocks[1:]:
+            assert block._revealed is False
+            assert block.styles.display == "none"
+        assert container.cursor == 0
+
+
+@pytest.mark.asyncio
+async def test_motion_on_opacity_climbs_to_full() -> None:
+    async with _calm_app(motion=True, pace="Swift").run_test() as pilot:
+        _, container = await _mount_calm(pilot)
+        first = container._blocks[0]
+
+        await pilot.pause(0.3)
+        assert first.styles.opacity == pytest.approx(FOCUSED_OPACITY, abs=0.05)
+
+
+@pytest.mark.asyncio
+async def test_next_reveals_and_dims_previous() -> None:
+    async with _calm_app().run_test() as pilot:
+        _, container = await _mount_calm(pilot)
+        blocks = container._blocks
+
+        container.calm_next()
+        await pilot.pause()
+
+        assert container.cursor == 1
+        assert blocks[1]._revealed is True
+        assert blocks[1].styles.opacity == FOCUSED_OPACITY
+        assert blocks[0].styles.opacity == DIMMED_OPACITY
+
+
+@pytest.mark.asyncio
+async def test_prev_refocuses_without_hiding() -> None:
+    async with _calm_app().run_test() as pilot:
+        _, container = await _mount_calm(pilot)
+        blocks = container._blocks
+
+        container.calm_next()
+        await pilot.pause()
+        container.calm_prev()
+        await pilot.pause()
+
+        assert container.cursor == 0
+        assert blocks[0].styles.opacity == FOCUSED_OPACITY
+        assert blocks[1]._revealed is True
+        assert blocks[1].styles.opacity == DIMMED_OPACITY
+
+
+@pytest.mark.asyncio
+async def test_arrows_navigate_only_when_input_empty() -> None:
+    async with _calm_app().run_test() as pilot:
+        app = cast(VibeApp, pilot.app)
+        _, container = await _mount_calm(pilot)
+        input_container = app.query_one("#input-container", ChatInputContainer)
+        text_area = input_container.input_widget
+        assert text_area is not None
+        text_area.focus()
+
+        text_area.text = "typing"
+        await pilot.pause()
+        await pilot.press("right")
+        await pilot.pause()
+        assert container.cursor == 0
+
+        text_area.text = ""
+        await pilot.pause()
+        await pilot.press("right")
+        await pilot.pause()
+        assert container.cursor == 1
+
+
+@pytest.mark.asyncio
+async def test_escape_reveals_all() -> None:
+    async with _calm_app().run_test() as pilot:
+        _, container = await _mount_calm(pilot)
+        blocks = container._blocks
+
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+
+        for block in blocks:
+            assert block._revealed is True
+            assert block.styles.display == "block"
+        assert container.cursor == len(blocks) - 1
+
+
+@pytest.mark.asyncio
+async def test_motion_off_reveals_are_instant() -> None:
+    async with _calm_app(motion=True, pace="Calm").run_test() as pilot:
+        app = cast(VibeApp, pilot.app)
+        _, container = await _mount_calm(pilot)
+        blocks = container._blocks
+
+        await pilot.pause(0.7)
+        await app.action_calm_toggle_motion()
+        await pilot.pause()
+        container.calm_next()
+        await pilot.pause()
+
+        assert blocks[1].styles.opacity == FOCUSED_OPACITY
+        assert blocks[0].styles.opacity == DIMMED_OPACITY
+
+
+@pytest.mark.asyncio
+async def test_calm_off_renders_original_path() -> None:
+    config = build_test_vibe_config(calm_mode_enabled=False)
+    async with build_test_vibe_app(config=config).run_test() as pilot:
+        app = pilot.app
+        messages = app.query_one("#messages")
+        msg = AssistantMessage("Just one paragraph.")
+        await messages.mount(msg)
+        await msg.write_initial_content()
+        await pilot.pause()
+
+        assert msg.calm_mode is False
+        assert msg.calm_container is None
+        assert msg._markdown is not None
+        assert list(app.query(CalmRevealContainer)) == []
+
+
+def test_calm_status_shows_label_only_when_enabled() -> None:
+    status = CalmStatus()
+    assert status.display is False
+
+    status.set_enabled(True)
+    assert status.display is True
+    assert "calm mode" in str(status.render())
+
+    status.set_enabled(False)
+    assert status.display is False
+
+
+@pytest.mark.asyncio
+async def test_slash_calm_command_toggles_mode() -> None:
+    config = build_test_vibe_config(calm_mode_enabled=False)
+    async with build_test_vibe_app(config=config).run_test() as pilot:
+        app = pilot.app
+
+        assert app.calm_mode_enabled is False
+
+        text_area = app.query_one("#input-container", ChatInputContainer).input_widget
+        assert text_area is not None
+        text_area.focus()
+        await pilot.pause()
+
+        await pilot.press("/")
+        await pilot.pause()
+        await pilot.press("c", "a", "l", "m")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert app.calm_mode_enabled is True

--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -182,6 +182,14 @@ class CommandRegistry:
                 description="Select theme",
                 handler="_show_theme",
             ),
+            "calm": Command(
+                aliases=frozenset(["/calm"]),
+                description=(
+                    "Toggle calm mode (paced block-by-block text reveal). "
+                    "Subcommands: pace, motion, off"
+                ),
+                handler="_calm_command",
+            ),
         }
 
     @property

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -72,6 +72,12 @@ from vibe.cli.textual_ui.scheduled_loop_runner import ScheduledLoopRunner
 from vibe.cli.textual_ui.session_exit import print_session_resume_message
 from vibe.cli.textual_ui.widgets.approval_app import ApprovalApp
 from vibe.cli.textual_ui.widgets.banner.banner import Banner
+from vibe.cli.textual_ui.widgets.calm_reveal import (
+    CalmRevealContainer,
+    next_pace_label,
+    pace_duration,
+)
+from vibe.cli.textual_ui.widgets.calm_status import CalmStatus
 from vibe.cli.textual_ui.widgets.chat_input import ChatInputContainer
 from vibe.cli.textual_ui.widgets.chat_input.input_kinds import (
     Bash,
@@ -482,6 +488,8 @@ class VibeApp(App):  # noqa: PLR0904
             "ctrl+g", "open_plan_in_editor", "Edit Plan", show=False, priority=False
         ),
         Binding("ctrl+backslash", "toggle_debug_console", "Debug Console", show=False),
+        Binding("left", "calm_prev", "Calm Prev", show=False),
+        Binding("right", "calm_next", "Calm Next", show=False),
     ]
 
     def get_driver_class(self) -> type[Driver]:
@@ -564,6 +572,7 @@ class VibeApp(App):  # noqa: PLR0904
         self._cached_loading_area: Widget | None = None
         self._log_reader = LogReader()
         self._debug_console: DebugConsole | None = None
+        self._calm_status: CalmStatus | None = None
         self._desired_agent: str | None = None
         self._agent_switch_active = False
         self._narrator_manager: NarratorManagerPort = (
@@ -599,6 +608,121 @@ class VibeApp(App):  # noqa: PLR0904
     @property
     def config(self) -> VibeConfigSchema:
         return self.agent_loop.config
+
+    @property
+    def calm_mode_enabled(self) -> bool:
+        return getattr(self.config, "calm_mode_enabled", False)
+
+    @property
+    def calm_pace_label(self) -> str:
+        return getattr(self.config, "calm_pace_label", "Calm")
+
+    @property
+    def calm_motion_enabled(self) -> bool:
+        return getattr(self.config, "calm_motion_enabled", True)
+
+    @property
+    def calm_duration(self) -> float:
+        return pace_duration(self.calm_pace_label)
+
+    def _active_calm_reveal(self) -> CalmRevealContainer | None:
+        containers = list(self.query(CalmRevealContainer))
+        if not containers:
+            return None
+        for container in reversed(containers):
+            if container.has_unrevealed():
+                return container
+        return containers[-1]
+
+    def _calm_reveal_all_if_active(self) -> bool:
+        if not self.calm_mode_enabled:
+            return False
+        container = self._active_calm_reveal()
+        if container is None or not container.has_unrevealed():
+            return False
+        container.reveal_all()
+        self._refresh_calm_status()
+        return True
+
+    def action_calm_next(self) -> None:
+        if not self.calm_mode_enabled:
+            return
+        container = self._active_calm_reveal()
+        if container is not None:
+            container.calm_next()
+        self._refresh_calm_status()
+
+    def action_calm_prev(self) -> None:
+        if not self.calm_mode_enabled:
+            return
+        container = self._active_calm_reveal()
+        if container is not None:
+            container.calm_prev()
+        self._refresh_calm_status()
+
+    async def action_calm_cycle_pace(self) -> None:
+        new_label = next_pace_label(self.calm_pace_label)
+        await self._persist_config_changes({"calm_pace_label": new_label})
+        await self._refresh_config_from_disk()
+        self._refresh_calm_status()
+
+    async def action_calm_toggle_motion(self) -> None:
+        await self._persist_config_changes(
+            {"calm_motion_enabled": not self.calm_motion_enabled}
+        )
+        await self._refresh_config_from_disk()
+        self._refresh_calm_status()
+
+    async def action_calm_toggle_mode(self) -> None:
+        await self._persist_config_changes(
+            {"calm_mode_enabled": not self.calm_mode_enabled}
+        )
+        await self._refresh_config_from_disk()
+        self._refresh_calm_status()
+
+    async def _calm_command(self, cmd_args: str = "") -> None:
+        sub = cmd_args.strip().lower()
+        match sub:
+            case "pace":
+                await self.action_calm_cycle_pace()
+                label = self.calm_pace_label
+                await self._mount_and_scroll(
+                    UserCommandMessage(f"Calm pace: **{label}**")
+                )
+            case "motion":
+                await self.action_calm_toggle_motion()
+                state = "on" if self.calm_motion_enabled else "off"
+                await self._mount_and_scroll(
+                    UserCommandMessage(f"Calm motion: **{state}**")
+                )
+            case "off":
+                if self.calm_mode_enabled:
+                    await self.action_calm_toggle_mode()
+                await self._mount_and_scroll(UserCommandMessage("Calm mode **off**."))
+            case "":
+                if not self.calm_mode_enabled:
+                    await self.action_calm_toggle_mode()
+                state = "on" if self.calm_mode_enabled else "off"
+                pace = self.calm_pace_label
+                motion = "on" if self.calm_motion_enabled else "off"
+                await self._mount_and_scroll(
+                    UserCommandMessage(
+                        f"Calm mode **{state}** — pace: {pace}, motion: {motion}. "
+                        "Use **->** / **<-** to navigate blocks, **Esc** to reveal all. "
+                        "`/calm pace` cycles speed, `/calm motion` toggles animation, `/calm off` disables."
+                    )
+                )
+            case _:
+                await self._mount_and_scroll(
+                    UserCommandMessage(
+                        f"Unknown calm subcommand: `{sub}`. "
+                        "Use `/calm`, `/calm pace`, `/calm motion`, or `/calm off`."
+                    )
+                )
+
+    def _refresh_calm_status(self) -> None:
+        if self._calm_status is not None:
+            self._calm_status.set_enabled(self.calm_mode_enabled)
 
     @property
     def _input_queue(self) -> MessageQueue:
@@ -759,6 +883,8 @@ class VibeApp(App):  # noqa: PLR0904
 
         with Horizontal(id="bottom-bar"):
             yield PathDisplay(self.config.displayed_workdir or Path.cwd())
+            self._calm_status = CalmStatus()
+            yield self._calm_status
             yield NoMarkupStatic(id="spacer")
             yield ContextProgress()
 
@@ -791,6 +917,7 @@ class VibeApp(App):  # noqa: PLR0904
             get_tools_collapsed=lambda: self._tools_collapsed,
             on_profile_changed=self._on_profile_changed,
             on_context_cleared=self._on_context_cleared,
+            get_calm_mode=lambda: self.calm_mode_enabled,
         )
 
         self._chat_input_container = self.query_one(ChatInputContainer)
@@ -811,6 +938,7 @@ class VibeApp(App):  # noqa: PLR0904
 
         chat_input_container = self.query_one(ChatInputContainer)
         chat_input_container.focus_input()
+        self._refresh_calm_status()
         await self._show_dangerous_directory_warning()
         self.run_worker(self._deferred_resume_and_start(), exclusive=False)
 
@@ -2316,6 +2444,7 @@ class VibeApp(App):  # noqa: PLR0904
             if self.event_handler:
                 await self.event_handler.finalize_streaming()
                 self.event_handler.escalate_unresolved_errors()
+            self._refresh_calm_status()
             self._queue.notify_busy_changed()
             self._queue.start_drain_if_needed()
             await self._refresh_windowing_from_history()
@@ -4044,6 +4173,8 @@ class VibeApp(App):  # noqa: PLR0904
         return interrupted
 
     def action_interrupt(self) -> None:
+        if self._calm_reveal_all_if_active():
+            return
         self._try_interrupt()
 
     async def on_history_load_more_requested(self, _: HistoryLoadMoreRequested) -> None:

--- a/vibe/cli/textual_ui/app.tcss
+++ b/vibe/cli/textual_ui/app.tcss
@@ -45,6 +45,17 @@ TextArea > .text-area--cursor {
     align: left middle;
 }
 
+.calm-status {
+    width: auto;
+    height: 1;
+    margin-left: 2;
+    color: $text-muted;
+
+    &:ansi {
+        text-style: dim;
+    }
+}
+
 #clipboard-notice {
     width: auto;
     height: 1;
@@ -411,6 +422,30 @@ Markdown {
         & > MarkdownBlock:last-child {
             margin-bottom: 0;
         }
+    }
+}
+
+.calm-reveal-container {
+    width: 100%;
+    height: auto;
+    layout: vertical;
+}
+
+.calm-block {
+    width: 100%;
+    height: auto;
+    padding: 0;
+    margin: 0;
+}
+
+.calm-progress {
+    color: $text-muted;
+    text-style: italic;
+    height: 1;
+    margin-top: 0;
+
+    &:ansi {
+        text-style: dim;
     }
 }
 

--- a/vibe/cli/textual_ui/handlers/event_handler.py
+++ b/vibe/cli/textual_ui/handlers/event_handler.py
@@ -56,11 +56,13 @@ class EventHandler:
         get_tools_collapsed: Callable[[], bool],
         on_profile_changed: Callable[[], None] | None = None,
         on_context_cleared: Callable[[Path | None], Awaitable[None]] | None = None,
+        get_calm_mode: Callable[[], bool] | None = None,
     ) -> None:
         self.mount_callback = mount_callback
         self.get_tools_collapsed = get_tools_collapsed
         self.on_profile_changed = on_profile_changed
         self.on_context_cleared = on_context_cleared
+        self.get_calm_mode = get_calm_mode or (lambda: False)
         self.tool_calls: dict[str, ToolCallMessage] = {}
         self.current_compact: CompactMessage | None = None
         self.current_streaming_message: AssistantMessage | None = None
@@ -271,7 +273,7 @@ class EventHandler:
             self.current_streaming_reasoning = None
 
         if self.current_streaming_message is None:
-            msg = AssistantMessage(event.content)
+            msg = AssistantMessage(event.content, calm_mode=self.get_calm_mode())
             self.current_streaming_message = msg
             await self.mount_callback(msg)
         else:
@@ -313,7 +315,11 @@ class EventHandler:
             await self.current_streaming_reasoning.stop_stream()
             self.current_streaming_reasoning = None
         if self.current_streaming_message is not None:
-            await self.current_streaming_message.stop_stream()
+            msg = self.current_streaming_message
+            if msg.calm_mode:
+                await msg.build_calm_reveal()
+            else:
+                await msg.stop_stream()
             self.current_streaming_message = None
 
     def stop_current_tool_call(

--- a/vibe/cli/textual_ui/widgets/calm_reveal.py
+++ b/vibe/cli/textual_ui/widgets/calm_reveal.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Markdown, Static
+
+FOCUSED_OPACITY = 1.0
+DIMMED_OPACITY = 0.5
+EASING = "out_cubic"
+
+FADE_PRESETS: dict[str, float] = {
+    "Zen": 0.9,
+    "Calm": 0.55,
+    "Normal": 0.3,
+    "Swift": 0.15,
+    "Instant": 0.0,
+}
+DEFAULT_PACE_LABEL = "Calm"
+PACE_ORDER: list[str] = list(FADE_PRESETS)
+
+
+def pace_duration(label: str) -> float:
+    return FADE_PRESETS.get(label, FADE_PRESETS[DEFAULT_PACE_LABEL])
+
+
+def next_pace_label(label: str) -> str:
+    try:
+        idx = PACE_ORDER.index(label)
+    except ValueError:
+        idx = PACE_ORDER.index(DEFAULT_PACE_LABEL)
+    return PACE_ORDER[(idx + 1) % len(PACE_ORDER)]
+
+
+def split_blocks(text: str) -> list[str]:
+    blocks: list[str] = []
+    current: list[str] = []
+    in_fence = False
+    for line in text.split("\n"):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            current.append(line)
+            continue
+        if not line.strip() and not in_fence:
+            if current:
+                blocks.append("\n".join(current).strip())
+                current = []
+        else:
+            current.append(line)
+    if current:
+        blocks.append("\n".join(current).strip())
+    return [b for b in blocks if b]
+
+
+class CalmBlock(Markdown):
+    def __init__(self, text: str) -> None:
+        super().__init__(text)
+        self.add_class("calm-block")
+        self.styles.display = "none"
+        self.styles.opacity = 0.0
+        self._revealed = False
+
+    def reveal(self, *, focused: bool, duration: float) -> None:
+        self._revealed = True
+        self.styles.display = "block"
+        target = FOCUSED_OPACITY if focused else DIMMED_OPACITY
+        if duration > 0:
+            self.styles.opacity = 0.0
+            self.styles.animate("opacity", target, duration=duration, easing=EASING)
+        else:
+            self.styles.opacity = target
+        self.scroll_visible(animate=duration > 0, top=False)
+
+    def set_focus(self, focused: bool, *, duration: float) -> None:
+        if not self._revealed:
+            return
+        target = FOCUSED_OPACITY if focused else DIMMED_OPACITY
+        if duration > 0:
+            self.styles.animate("opacity", target, duration=duration, easing=EASING)
+        else:
+            self.styles.opacity = target
+        if focused:
+            self.scroll_visible(animate=duration > 0, top=False)
+
+
+class CalmRevealContainer(Vertical):
+    def __init__(
+        self,
+        blocks: list[str],
+        *,
+        duration: float | None = None,
+        motion: bool | None = None,
+    ) -> None:
+        super().__init__()
+        self.add_class("calm-reveal-container")
+        self._block_texts = blocks
+        self._blocks: list[CalmBlock] = []
+        self._cursor = -1
+        self._duration_override = duration
+        self._motion_override = motion
+        self._progress: Static | None = None
+
+    def compose(self) -> ComposeResult:
+        for text in self._block_texts:
+            block = CalmBlock(text)
+            self._blocks.append(block)
+            yield block
+        self._progress = Static("", classes="calm-progress")
+        yield self._progress
+
+    def _resolve_settings(self) -> tuple[float, bool]:
+        app = self.app
+        if self._duration_override is not None:
+            duration = self._duration_override
+        else:
+            label = getattr(app, "calm_pace_label", DEFAULT_PACE_LABEL)
+            duration = pace_duration(label)
+        if self._motion_override is not None:
+            motion = self._motion_override
+        else:
+            motion = getattr(app, "calm_motion_enabled", False)
+        if not motion:
+            duration = 0.0
+        return duration, motion
+
+    def on_mount(self) -> None:
+        self.calm_advance(0)
+
+    @property
+    def block_count(self) -> int:
+        return len(self._blocks)
+
+    @property
+    def cursor(self) -> int:
+        return self._cursor
+
+    def has_unrevealed(self) -> bool:
+        return any(not b._revealed for b in self._blocks)
+
+    def calm_next(self) -> None:
+        if self._cursor < len(self._blocks) - 1:
+            self.calm_advance(self._cursor + 1)
+
+    def calm_prev(self) -> None:
+        if self._cursor > 0:
+            self.calm_advance(self._cursor - 1)
+
+    def calm_advance(self, target: int) -> None:
+        if not self._blocks:
+            return
+        target = max(0, min(target, len(self._blocks) - 1))
+        prev = self._cursor
+        self._cursor = target
+        duration, _ = self._resolve_settings()
+        if 0 <= prev < len(self._blocks) and prev != target:
+            self._blocks[prev].set_focus(False, duration=duration)
+        self._blocks[target].reveal(focused=True, duration=duration)
+        self._update_progress()
+
+    def reveal_all(self) -> None:
+        if not self._blocks:
+            return
+        duration, _ = self._resolve_settings()
+        for block in self._blocks:
+            block.reveal(focused=True, duration=duration)
+        self._cursor = len(self._blocks) - 1
+        self._update_progress()
+
+    def _update_progress(self) -> None:
+        if self._progress is None:
+            return
+        total = len(self._blocks)
+        pos = min(self._cursor + 1, total) if total else 0
+        self._progress.update(f"\u00b6 {pos}/{total}")

--- a/vibe/cli/textual_ui/widgets/calm_status.py
+++ b/vibe/cli/textual_ui/widgets/calm_status.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from textual.widgets import Static
+
+
+class CalmStatus(Static):
+    def __init__(self) -> None:
+        super().__init__("")
+        self.add_class("calm-status")
+        self.display = False
+
+    def set_enabled(self, enabled: bool) -> None:
+        self.display = enabled
+        self.update("[$primary]☾[/] calm mode" if enabled else "")

--- a/vibe/cli/textual_ui/widgets/chat_input/text_area.py
+++ b/vibe/cli/textual_ui/widgets/chat_input/text_area.py
@@ -75,6 +75,15 @@ class ChatTextArea(TextArea):
 
     DEFAULT_MODE: ClassVar[Literal[">"]] = ">"
 
+    def check_action(self, action: str, parameters: Any) -> bool | None:
+        if (
+            action in {"cursor_left", "cursor_right"}
+            and not self.text
+            and getattr(self.app, "calm_mode_enabled", False)
+        ):
+            return False
+        return True
+
     class Submitted(Message):
         def __init__(self, value: str) -> None:
             self.value = value

--- a/vibe/cli/textual_ui/widgets/messages.py
+++ b/vibe/cli/textual_ui/widgets/messages.py
@@ -25,6 +25,7 @@ from textual.widgets._markdown import MarkdownStream
 from watchfiles import awatch
 
 from vibe.cli.textual_ui.shortcut_hints import shortcut, shortcut_hint
+from vibe.cli.textual_ui.widgets.calm_reveal import CalmRevealContainer, split_blocks
 from vibe.cli.textual_ui.widgets.collapsible import (
     ClickWithoutDragMixin,
     CollapsibleSection,
@@ -306,14 +307,40 @@ class StreamingMessageBase(Static):
 
 
 class AssistantMessage(StreamingMessageBase):
-    def __init__(self, content: str) -> None:
+    def __init__(self, content: str, *, calm_mode: bool = False) -> None:
         super().__init__(content)
         self.add_class("assistant-message")
+        self._calm_mode = calm_mode
+        self._calm_container: CalmRevealContainer | None = None
+
+    @property
+    def calm_mode(self) -> bool:
+        return self._calm_mode
+
+    @property
+    def calm_container(self) -> CalmRevealContainer | None:
+        return self._calm_container
+
+    def _should_write_content(self) -> bool:
+        return not self._calm_mode
 
     def compose(self) -> ComposeResult:
+        if self._calm_mode:
+            return
         markdown = Markdown("")
         self._markdown = markdown
         yield markdown
+
+    async def build_calm_reveal(self) -> CalmRevealContainer | None:
+        if self._calm_container is not None:
+            return self._calm_container
+        blocks = split_blocks(self._content)
+        if not blocks:
+            return None
+        container = CalmRevealContainer(blocks)
+        self._calm_container = container
+        await self.mount(container)
+        return container
 
 
 class ReasoningMessage(ClickWithoutDragMixin, SpinnerMixin, StreamingMessageBase):

--- a/vibe/core/config/vibe_schema.py
+++ b/vibe/core/config/vibe_schema.py
@@ -438,6 +438,9 @@ class VibeConfigSchema(ConfigSchema):
     context_warnings: Annotated[bool, WithReplaceMerge()] = False
     voice_mode_enabled: Annotated[bool, WithReplaceMerge()] = False
     narrator_enabled: Annotated[bool, WithReplaceMerge()] = False
+    calm_mode_enabled: Annotated[bool, WithReplaceMerge()] = False
+    calm_pace_label: Annotated[str, WithReplaceMerge()] = "Calm"
+    calm_motion_enabled: Annotated[bool, WithReplaceMerge()] = True
     bypass_tool_permissions: Annotated[bool, WithReplaceMerge()] = False
     raise_on_compaction_failure: Annotated[bool, WithReplaceMerge()] = False
     enable_telemetry: Annotated[bool, WithReplaceMerge()] = True

--- a/vibe/core/skills/builtins/vibe.py
+++ b/vibe/core/skills/builtins/vibe.py
@@ -152,6 +152,13 @@ voice_mode_enabled = false
 narrator_enabled = false
 active_transcribe_model = "voxtral-realtime"
 active_tts_model = "voxtral-tts"
+
+# Calm mode (paced, block-by-block text reveal)
+calm_mode_enabled = false       # Route assistant text through a fading block-by-block reveal
+calm_pace_label = "Calm"        # Zen | Calm | Normal | Swift | Instant (fade duration preset)
+calm_motion_enabled = true      # Animate fades; false snaps instantly (reduced motion)
+# Toggle at runtime: /calm (on/off), /calm pace (cycle speed), /calm motion (toggle animation)
+# Navigate: -> next block, <- prev block, Esc reveal all
 ```
 
 ### Providers


### PR DESCRIPTION
## Why

Long assistant replies land as a wall of text that's already fully rendered by the time you start reading. I wanted something that feels a bit more designed for humans — this is a sketch of what I came up with!

`/calm` mode turns a reply into a paced, block-by-block read: one block in focus, the rest dimmed or hidden, advanced at your own speed with the arrow keys. Opt-in, off by default.

## What it does

- `/calm` toggles the mode; `/calm pace` cycles fade speed (Zen → Instant), `/calm motion` toggles animation (reduced-motion friendly), `/calm off` disables.
- Assistant text is split into blocks (fence-aware, so code blocks stay intact). The current block is at full opacity; earlier blocks dim, later blocks stay hidden until revealed.
- Navigate with **→ / ←**; **Esc** reveals the whole message at once.
- A `☾ calm mode` marker sits in the bottom bar after the working dir while active.
- Three persisted config fields: `calm_mode_enabled`, `calm_pace_label`, `calm_motion_enabled`.

## Reviewer guide

**Core logic — review closely**
- `widgets/calm_reveal.py` *(new)* — the reveal engine: `split_blocks` (fence-aware splitting), `CalmBlock`, and `CalmRevealContainer` (cursor tracking, reveal/dim/animate, `¶ n/total` progress), plus the pace/fade presets.
- `widgets/messages.py` — `AssistantMessage` defers rendering in calm mode and builds the reveal container instead of writing content directly.
- `app.py` — calm state properties, actions (`calm_next/prev/cycle_pace/toggle_motion/toggle_mode`), `/calm` routing, ←/→ bindings, and bottom-bar wiring. Persistence goes through the async config orchestrator (`_persist_config_changes`).

**Small, self-contained**
- `handlers/event_handler.py` — threads a `get_calm_mode` callback through; on stream end, builds the reveal in calm mode instead of the normal `stop_stream`.
- `chat_input/text_area.py` — `check_action` only releases ←/→ to the app when the input is empty and calm mode is on, so arrows don't fight cursor movement while typing.
- `commands.py` — registers `/calm`.
- `app.tcss` — calm styles + bottom-bar marker.

**Config / docs**
- `config/vibe_schema.py` — the three `calm_*` fields.
- `skills/builtins/vibe.py` — documents them in the config skill.

**Tests**
- `tests/cli/textual_ui/test_calm_reveal.py` *(new)* — reveal/focus/dim, navigation, arrow gating while typing, Esc-reveal-all, motion on/off, `/calm` toggle, and the bottom-bar indicator.
