### PR TITLE
fix: save profile-merged config in session meta.json

### DIFF
--- a/vibe/core/agent_loop/_loop.py
+++ b/vibe/core/agent_loop/_loop.py
@@ -842,7 +842,7 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         await self.session_logger.save_interaction(
             self.messages,
             self.stats,
-            self.base_config,
+            self.config,
             self.tool_manager,
             self.agent_profile,
             allow_empty=allow_empty,
@@ -2311,7 +2311,7 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         await forked.session_logger.save_interaction(
             forked.messages,
             forked.stats,
-            forked.base_config,
+            forked.config,
             forked.tool_manager,
             forked.agent_profile,
         )
@@ -2349,7 +2349,7 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         await self.session_logger.save_interaction(
             self.messages,
             self.stats,
-            self.base_config,
+            self.config,
             self.tool_manager,
             self.agent_profile,
         )
@@ -2444,7 +2444,7 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         await self.session_logger.save_interaction(
             self.messages,
             self.stats,
-            self.base_config,
+            self.config,
             self.tool_manager,
             self.agent_profile,
         )


### PR DESCRIPTION
## Root Cause

All `save_interaction()` calls passed `self.base_config` (orchestrator-only config, without agent profile overrides) instead of `self.config` (profile-merged config). This caused `meta.json["config"]["active_model"]` to always report the global default model — never the agent profile's model override.

Runtime model resolution was unaffected — `_chat` already uses `self.config.get_active_model()`. Only persisted logging was wrong.

## Fix

`base_config` → `config` in all 4 `save_interaction()` call sites:

| Method | Line (after fix) | Why |
|--------|-----------------|-----|
| `_save_messages` | 845 | Primary log-every-turn path (most impactful) |
| `fork()` | 2314 | Saves the forked session's opening interaction |
| `clear_history()` | 2352 | Saves current interaction before reset |
| `reload()` | 2447 | Saves current interaction before switching agents |

## Verification

After fix, running a session with an agent profile that overrides `active_model` (e.g. `active_model="deepseek-v4-flash-exec"`) produces `meta.json["config"]["active_model"]` equal to the override value, not the global default.

## Testing

- [x] All existing tests should pass — no behavior changed beyond what gets written to the log file
- [x] Confirm `_teleport_service` constructor (line 938) correctly keeps `self.base_config` — that's a runtime service, not a logging path, and should receive the unmerged config
