### PR TITLE
feat: per-model cost tracking and message attribution

### DIFF
--- a/vibe/core/agent_loop/_loop.py
+++ b/vibe/core/agent_loop/_loop.py
@@ -2082,7 +2082,11 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
                 raise AgentLoopLLMResponseError(
                     "Usage data missing in non-streaming completion response"
                 )
-            self._update_stats(usage=result.usage, time_seconds=end_time - start_time)
+            self._update_stats(
+                usage=result.usage,
+                time_seconds=end_time - start_time,
+                model_name=model.name,
+            )
 
             if result.correlation_id:
                 self.telemetry_client.last_correlation_id = result.correlation_id
@@ -2090,6 +2094,8 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
             processed_message = self.format_handler.process_api_response_message(
                 result.message
             )
+            processed_message.model = model.name
+            processed_message.provider = provider.name
             return LLMChunk(
                 message=processed_message, usage=result.usage, stop=result.stop
             )
@@ -2188,7 +2194,14 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
                 raise AgentLoopLLMResponseError(
                     "Usage data missing in final chunk of streamed completion"
                 )
-            self._update_stats(usage=usage, time_seconds=end_time - start_time)
+            self._update_stats(
+                usage=usage,
+                time_seconds=end_time - start_time,
+                model_name=active_model.name,
+            )
+
+            chunk_agg.message.model = active_model.name
+            chunk_agg.message.provider = provider.name
 
             self.messages.append(chunk_agg.message)
             if chunk_agg.stop and chunk_agg.stop.is_refusal:
@@ -2210,7 +2223,9 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
                 f"API error from {provider.name} (model: {active_model.name}): {e}"
             ) from e
 
-    def _update_stats(self, usage: LLMUsage, time_seconds: float) -> None:
+    def _update_stats(
+        self, usage: LLMUsage, time_seconds: float, *, model_name: str | None = None
+    ) -> None:
         self.stats.last_turn_duration = time_seconds
         self.stats.last_turn_prompt_tokens = usage.prompt_tokens
         self.stats.last_turn_completion_tokens = usage.completion_tokens
@@ -2219,6 +2234,9 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         self.stats.context_tokens = usage.prompt_tokens + usage.completion_tokens
         if time_seconds > 0 and usage.completion_tokens > 0:
             self.stats.tokens_per_second = usage.completion_tokens / time_seconds
+        self.stats.add_tokens_for_model(
+            usage.prompt_tokens, usage.completion_tokens, model_name=model_name
+        )
 
     def _clean_message_history(self) -> None:
         ACCEPTABLE_HISTORY_SIZE = 2

--- a/vibe/core/types.py
+++ b/vibe/core/types.py
@@ -46,6 +46,15 @@ class Backend(StrEnum):
     GENERIC = auto()
 
 
+class PerModelTokenUsage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    input_price_per_million: float = 0.0
+    output_price_per_million: float = 0.0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+
 class AgentStats(BaseModel):
     steps: int = 0
     session_prompt_tokens: int = 0
@@ -65,6 +74,10 @@ class AgentStats(BaseModel):
 
     input_price_per_million: float = 0.0
     output_price_per_million: float = 0.0
+
+    # Per-model token and pricing breakdown for accurate cost when models
+    # change mid-session. Keyed by model name (e.g. "deepseek-chat").
+    per_model: dict[str, PerModelTokenUsage] = Field(default_factory=dict)
 
     _listeners: dict[str, Callable[[AgentStats], None]] = PrivateAttr(
         default_factory=dict
@@ -105,10 +118,31 @@ class AgentStats(BaseModel):
     def session_cost(self) -> float:
         """Calculate the total session cost in dollars based on token usage and pricing.
 
-        NOTE: This is a rough estimate and is worst-case scenario.
-        The actual cost may be lower due to prompt caching.
-        If the model changes mid-session, this uses current pricing for all tokens.
+        Uses per-model breakdown when available for accurate cost across model
+        switches. Falls back to single-model estimate for legacy sessions.
+
+        Each turn reports the full context prompt_tokens the API billed for,
+        not just the incremental delta. When a model switch occurs mid-session,
+        the new model's turn includes the cost of re-encoding the entire
+        conversation history at that model's rate -- so the per-model total
+        correctly reflects what each model was actually charged, including the
+        re-processing premium on switch.
+
+        Prompt caching discounts and cross-model tokenization differences are
+        provider-side optimisations not reflected in the usage API response,
+        so they cannot be factored in here.
         """
+        if self.per_model:
+            total = 0.0
+            for usage in self.per_model.values():
+                total += (
+                    usage.prompt_tokens / 1_000_000
+                ) * usage.input_price_per_million
+                total += (
+                    usage.completion_tokens / 1_000_000
+                ) * usage.output_price_per_million
+            return total
+        # Fallback to old single-model calculation for legacy sessions
         input_cost = (
             self.session_prompt_tokens / 1_000_000
         ) * self.input_price_per_million
@@ -117,16 +151,40 @@ class AgentStats(BaseModel):
         ) * self.output_price_per_million
         return input_cost + output_cost
 
+    def _ensure_per_model(self, model_name: str | None) -> PerModelTokenUsage:
+        """Get or create per-model tracking entry.
+
+        Uses ``input_price_per_million`` / ``output_price_per_million`` as
+        defaults when the model is unnamed (legacy caller).
+        """
+        key = model_name or "__default__"
+        if key not in self.per_model:
+            self.per_model[key] = PerModelTokenUsage(
+                input_price_per_million=self.input_price_per_million,
+                output_price_per_million=self.output_price_per_million,
+            )
+        return self.per_model[key]
+
     def update_pricing(self, input_price: float, output_price: float) -> None:
         """Update pricing info when model changes.
 
-        NOTE: session_cost will be recalculated using new pricing for all
-        accumulated tokens. This is a known approximation when models change.
-        This should not be a big issue, pricing is only used for max_price which is in
-        programmatic mode, so user should not update models there.
+        Stores the current pricing so future token attributions use the
+        correct rate. Past tokens attributed to earlier models are preserved.
         """
         self.input_price_per_million = input_price
         self.output_price_per_million = output_price
+
+    def add_tokens_for_model(
+        self,
+        prompt_tokens: int,
+        completion_tokens: int,
+        *,
+        model_name: str | None = None,
+    ) -> None:
+        """Attribute token usage to a specific model for accurate cost tracking."""
+        entry = self._ensure_per_model(model_name)
+        entry.prompt_tokens += prompt_tokens
+        entry.completion_tokens += completion_tokens
 
     def reset_context_state(self) -> None:
         """Reset context-related fields while preserving cumulative session stats.
@@ -306,6 +364,10 @@ class LLMMessage(BaseModel):
     tool_call_id: str | None = None
     message_id: str | None = None
     user_display_content: UserDisplayContentMetadata | None = None
+    # Model attribution — set on assistant messages so each message records
+    # which model generated it. Empty on user/tool/system messages.
+    model: str | None = None
+    provider: str | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -335,6 +397,8 @@ class LLMMessage(BaseModel):
             "message_id": getattr(v, "message_id", None)
             or (str(uuid4()) if role != "tool" else None),
             "user_display_content": getattr(v, "user_display_content", None),
+            "model": getattr(v, "model", None),
+            "provider": getattr(v, "provider", None),
         }
 
     def __add__(self, other: LLMMessage) -> LLMMessage:
@@ -408,6 +472,8 @@ class LLMMessage(BaseModel):
             user_display_content=self.user_display_content
             if self.user_display_content is not None
             else other.user_display_content,
+            model=self.model or other.model,
+            provider=self.provider or other.provider,
         )
 
 


### PR DESCRIPTION
## Problem

`AgentStats.session_cost` uses a single flat pricing pair for the entire session. When `/model` switches the active model mid-session, all accumulated tokens are retroactively re-priced — `update_pricing()` even documents this as "a known approximation." Additionally, session transcripts (`messages.jsonl`) have no way to identify which model generated each message.

## Solution

Two changes:

### 1. Per-model cost tracking in `AgentStats`

- New `PerModelTokenUsage` model tracks `prompt_tokens`, `completion_tokens`, and per-model pricing
- `AgentStats.per_model: dict[str, PerModelTokenUsage]` accumulates usage keyed by model name
- `session_cost` sums across all models at their respective rates (falls back to legacy single-model calc when `per_model` is empty)
- `add_tokens_for_model()` attributes each turn's usage to the active model; `_ensure_per_model()` snapshots the pricing at first attribution so switching A→B→A preserves correct rates
- `update_pricing()` now only sets the current-model default — past tokens are untouched

### 2. Model attribution on `LLMMessage`

- New optional `model` and `provider` fields (default `None`, omitted via `exclude_none` in serialization)
- Set on assistant messages in both streaming (`_chat_streaming`) and non-streaming (`_complete`) paths
- Propagated through chunk accumulation (`LLMMessage.__add__`) and `model_dump`

## Before / after (cost example)

```
Session: 1M prompt + 50K completion on deepseek ($0.14/$0.28/M)
Switch to claude ($3.00/$15.00/M), one turn: 1.5M prompt + 30K completion

Before:  $1.45  (all tokens at claude pricing — wrong)
After:   $0.15 + $4.95 = $5.10  (each model at its own rate — correct)
```

## Backward compatibility

- Old `messages.jsonl` (no `model`/`provider`): fields default to `None`, serialization omits them
- Old `meta.json` (no `per_model`): defaults to empty dict, `session_cost` falls back to legacy calculation
- No migration needed — `per_model` populates lazily on next turn

## Token attribution note

Each turn reports the full context `prompt_tokens` the API billed for, not just the incremental delta. When a model switch occurs, the new model's turn includes the cost of re-encoding the entire history — so per-model totals correctly reflect what each model was actually charged. Prompt caching discounts and tokenization differences are provider-side and not reflected in usage responses.

## Files changed

- `vibe/core/types.py`: +80/-8 (PerModelTokenUsage, AgentStats.per_model + methods, LLMMessage.model/provider)
- `vibe/core/agent_loop/_loop.py`: +24/-2 (message stamping, model_name param on _update_stats)