### PR TITLE
bug: skip sessions with invalid environment metadata

### DIFF
--- a/tests/session/test_session_loader.py
+++ b/tests/session/test_session_loader.py
@@ -978,7 +978,7 @@ class TestSessionLoaderListSessions:
         result = SessionLoader.list_sessions(bad_config)
         assert result == []
 
-    def test_list_sessions_handles_missing_environment(
+    def test_list_sessions_handles_missing_and_null_environment(
         self, session_config: SessionLoggingConfig
     ) -> None:
         session_dir = Path(session_config.save_dir)
@@ -991,12 +991,57 @@ class TestSessionLoaderListSessions:
         (session_folder / "meta.json").write_text(
             '{"session_id": "noenv000", "end_time": "2024-01-01T12:00:00Z"}'
         )
+        null_environment_session = session_dir / "test_20240101_120001_nullenv0"
+        null_environment_session.mkdir()
+        (null_environment_session / "messages.jsonl").write_text(
+            '{"role": "user", "content": "Hello"}\n'
+        )
+        (null_environment_session / "meta.json").write_text(
+            '{"session_id": "nullenv0", "environment": null}'
+        )
 
         result = SessionLoader.list_sessions(session_config)
 
-        assert len(result) == 1
-        assert result[0]["session_id"] == "noenv000"
-        assert result[0]["cwd"] == ""  # Empty string when no working_directory
+        assert {session["session_id"] for session in result} == {"noenv000", "nullenv0"}
+        assert all(session["cwd"] == "" for session in result)
+
+    def test_list_sessions_skips_non_object_environment(
+        self, session_config: SessionLoggingConfig, create_test_session_with_cwd
+    ) -> None:
+        session_dir = Path(session_config.save_dir)
+        create_test_session_with_cwd(
+            session_dir, "valid-se", "/home/user/project", title="Valid Session"
+        )
+        invalid_session = create_test_session_with_cwd(
+            session_dir, "invalid-se", "/home/user/project"
+        )
+        (invalid_session / "meta.json").write_text(
+            '{"session_id": "invalid-se", "environment": "broken"}'
+        )
+
+        result = SessionLoader.list_sessions(session_config)
+
+        assert [session["session_id"] for session in result] == ["valid-se"]
+
+    def test_find_latest_session_skips_non_object_environment_with_cwd_filter(
+        self, session_config: SessionLoggingConfig, create_test_session_with_cwd
+    ) -> None:
+        session_dir = Path(session_config.save_dir)
+        valid_session = create_test_session_with_cwd(
+            session_dir, "valid-se", "/home/user/project"
+        )
+        time.sleep(0.01)
+        invalid_session = create_test_session_with_cwd(
+            session_dir, "invalid-se", "/home/user/project"
+        )
+        (invalid_session / "meta.json").write_text(
+            '{"session_id": "invalid-se", "environment": "broken"}'
+        )
+        result = SessionLoader.find_latest_session(
+            session_config, working_directory=Path("/home/user/project")
+        )
+
+        assert result == valid_session
 
     def test_list_sessions_handles_none_title(
         self, session_config: SessionLoggingConfig, create_test_session_with_cwd

--- a/vibe/core/session/session_loader.py
+++ b/vibe/core/session/session_loader.py
@@ -64,10 +64,14 @@ class SessionLoader:
             metadata = json.loads(read_safe(metadata_path).text)
             if not isinstance(metadata, dict):
                 return None
+            environment = metadata.get("environment")
+            if environment is None:
+                environment = {}
+            if not isinstance(environment, dict):
+                return None
+            metadata["environment"] = environment
             if working_directory is not None:
-                session_working_directory = (metadata.get("environment") or {}).get(
-                    "working_directory"
-                )
+                session_working_directory = environment.get("working_directory")
                 if not SessionLoader._same_working_directory(
                     session_working_directory, working_directory
                 ):
@@ -77,10 +81,7 @@ class SessionLoader:
         except (OSError, json.JSONDecodeError):
             return None
 
-        if not SessionLoader._log_is_loadable(messages, metadata):
-            return None
-
-        return metadata
+        return metadata if SessionLoader._log_is_loadable(messages, metadata) else None
 
     @staticmethod
     def _log_is_loadable(


### PR DESCRIPTION
## Summary

- validate session environment metadata before accessing it
- keep missing and null environments compatible by normalizing them to an empty object
- skip corrupted sessions without hiding valid sessions
- cover both session listing and cwd-filtered discovery

## Tests

- `uv run pytest tests/session/test_session_loader.py tests/acp/test_list_sessions.py -q`
- `uv run pyright vibe/core/session/session_loader.py tests/session/test_session_loader.py`
- `uv run pre-commit run --all-files`