### PR TITLE
bug: enforce bash and grep output limits in UTF-8 bytes

### DIFF
--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -155,6 +155,21 @@ async def test_truncates_output_to_max_bytes(bash):
     assert result.returncode == 0
 
 
+@pytest.mark.asyncio
+async def test_truncates_multibyte_stdout_and_stderr_to_max_bytes(bash):
+    config = BashToolConfig(max_output_bytes=5)
+    bash_tool = Bash(config_getter=lambda: config, state=BaseToolState())
+
+    result = await collect_result(
+        bash_tool.run(BashArgs(command="printf 'ééé'; printf 'ééé' >&2"))
+    )
+
+    assert result.stdout == "éé"
+    assert result.stderr == "éé"
+    assert len(result.stdout.encode("utf-8")) <= 5
+    assert len(result.stderr.encode("utf-8")) <= 5
+
+
 @pytest.mark.skipif(is_windows(), reason="managed bash requires a POSIX-like platform")
 @pytest.mark.asyncio
 async def test_experimental_bash_keeps_compatibility_stderr_empty():

--- a/tests/tools/test_grep.py
+++ b/tests/tools/test_grep.py
@@ -163,11 +163,11 @@ async def test_truncates_to_max_output_bytes(grep, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     config = GrepToolConfig(max_output_bytes=100)
     grep_tool = Grep(config_getter=lambda: config, state=BaseToolState())
-    (tmp_path / "test.py").write_text("\n".join("x" * 100 for _ in range(10)))
+    (tmp_path / "test.py").write_text("é" * 100)
 
-    result = await collect_result(grep_tool.run(GrepArgs(pattern="x")))
+    result = await collect_result(grep_tool.run(GrepArgs(pattern="é")))
 
-    assert len(result.matches) <= 100
+    assert len(result.matches.encode("utf-8")) <= 100
     assert result.was_truncated
 
 

--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -28,7 +28,7 @@ from vibe.core.tools.permissions import (
     RequiredPermission,
 )
 from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
-from vibe.core.tools.utils import is_path_within_workdir
+from vibe.core.tools.utils import is_path_within_workdir, truncate_utf8_bytes
 from vibe.core.types import ToolResultEvent, ToolStreamEvent
 from vibe.core.utils import (
     WindowsShellKind,
@@ -621,12 +621,16 @@ class Bash(
                 raise self._build_timeout_error(args.command, timeout)
 
             stdout = (
-                decode_safe(stdout_bytes, from_subprocess=True).text[:max_bytes]
+                truncate_utf8_bytes(
+                    decode_safe(stdout_bytes, from_subprocess=True).text, max_bytes
+                )[0]
                 if stdout_bytes
                 else ""
             )
             stderr = (
-                decode_safe(stderr_bytes, from_subprocess=True).text[:max_bytes]
+                truncate_utf8_bytes(
+                    decode_safe(stderr_bytes, from_subprocess=True).text, max_bytes
+                )[0]
                 if stderr_bytes
                 else ""
             )

--- a/vibe/core/tools/builtins/grep.py
+++ b/vibe/core/tools/builtins/grep.py
@@ -19,7 +19,7 @@ from vibe.core.tools.base import (
 )
 from vibe.core.tools.permissions import PermissionContext
 from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
-from vibe.core.tools.utils import resolve_file_tool_permission
+from vibe.core.tools.utils import resolve_file_tool_permission, truncate_utf8_bytes
 from vibe.core.types import ToolStreamEvent
 from vibe.core.utils import kill_async_subprocess
 from vibe.core.utils.io import decode_safe, read_safe
@@ -319,13 +319,11 @@ class Grep(
 
         truncated_lines = output_lines[:max_matches]
         truncated_output = "\n".join(truncated_lines)
-
-        was_truncated = (
-            len(output_lines) > max_matches
-            or len(truncated_output) > self.config.max_output_bytes
+        final_output, output_was_truncated = truncate_utf8_bytes(
+            truncated_output, self.config.max_output_bytes
         )
 
-        final_output = truncated_output[: self.config.max_output_bytes]
+        was_truncated = len(output_lines) > max_matches or output_was_truncated
 
         return GrepResult(
             matches=final_output,

--- a/vibe/core/tools/utils.py
+++ b/vibe/core/tools/utils.py
@@ -12,6 +12,13 @@ from vibe.core.tools.permissions import (
 )
 
 
+def truncate_utf8_bytes(text: str, max_bytes: int) -> tuple[str, bool]:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text, False
+    return encoded[:max_bytes].decode("utf-8", errors="ignore"), True
+
+
 def _make_absolute(path_str: str) -> Path:
     path = Path(path_str).expanduser()
     if not path.is_absolute():


### PR DESCRIPTION
## Summary

- truncate decoded tool output by its UTF-8 byte length
- avoid returning partial trailing code points
- apply the same byte-limit behavior to grep, bash stdout, and bash stderr
- cover multibyte output at truncation boundaries

## Tests

- `uv run pytest tests/tools/test_grep.py tests/tools/test_bash.py -q`
- `uv run pyright vibe/core/tools/utils.py vibe/core/tools/builtins/grep.py vibe/core/tools/builtins/bash.py tests/tools/test_grep.py tests/tools/test_bash.py`
- `uv run pre-commit run --all-files`
- `uv run pytest -q`