### PR TITLE
Add requests dependency without version pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dependencies = [
     "pywin32-ctypes==0.2.3 ; sys_platform == 'win32'",
     "pyyaml==6.0.3",
     "referencing==0.37.0",
-    "requests==2.34.2",
+    "requests",
     "rich==15.0.0",
     "rpds-py==0.30.0",
     "secretstorage==3.5.0 ; sys_platform == 'linux'",


### PR DESCRIPTION
## Summary

Added `requests` to project dependencies in `pyproject.toml` without pinning the version. This allows installations to use the latest compatible release instead of the fixed v2.34.2.

## Changes

- Modified `pyproject.toml`: Changed `requests==2.34.2` to `requests`

## Rationale

Unpinned versions in dependencies allow for more flexible update cycles, enabling the project to receive security patches and bug fixes automatically when compatible versions are released.