### PR TITLE
fix(auth): continue browser sign-in in headless environments

### DIFF
--- a/tests/acp/test_authenticate.py
+++ b/tests/acp/test_authenticate.py
@@ -5,7 +5,12 @@ from typing import Any
 
 import pytest
 
+from tests.stubs.fake_browser_sign_in_gateway import (
+    FakeBrowserSignInGateway,
+    build_sign_in_process,
+)
 from vibe.acp.agent import VibeAcpAgent as VibeAcpAgentLoop
+import vibe.acp.auth as acp_auth_module
 from vibe.acp.exceptions import InternalError, InvalidRequestError
 from vibe.core.config import ProviderConfig
 from vibe.core.types import Backend
@@ -14,6 +19,7 @@ from vibe.setup.auth import (
     BrowserSignInError,
     BrowserSignInErrorCode,
 )
+import vibe.setup.auth.browser_sign_in as browser_sign_in_module
 from vibe.setup.onboarding.context import OnboardingContext
 
 
@@ -162,6 +168,29 @@ class TestACPAuthenticate:
         }
         assert api_key_persister.saved == [(provider, "api-key")]
         assert browser_sign_in.close_count == 1
+
+    @pytest.mark.asyncio
+    async def test_authenticate_keeps_browser_open_failure_strict_by_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        gateway = FakeBrowserSignInGateway(
+            process=build_sign_in_process(datetime(2026, 3, 16, tzinfo=UTC))
+        )
+        monkeypatch.setattr(
+            acp_auth_module, "HttpBrowserSignInGateway", lambda **_: gateway
+        )
+        monkeypatch.setattr(browser_sign_in_module.webbrowser, "open", lambda _: False)
+        acp_agent_loop = VibeAcpAgentLoop(
+            onboarding_context_loader=lambda: OnboardingContext(
+                provider=build_mistral_provider()
+            )
+        )
+
+        with pytest.raises(InternalError, match="Failed to open browser"):
+            await acp_agent_loop.authenticate("browser-auth")
+
+        assert gateway.polled_urls == []
+        assert gateway.closed is True
 
     @pytest.mark.asyncio
     async def test_authenticate_starts_delegated_browser_sign_in(self) -> None:

--- a/tests/setup/auth/test_browser_sign_in.py
+++ b/tests/setup/auth/test_browser_sign_in.py
@@ -11,8 +11,8 @@ from urllib.parse import urlencode
 
 import pytest
 
-from tests.browser_sign_in.stubs import (
-    StubBrowserSignInGateway,
+from tests.stubs.fake_browser_sign_in_gateway import (
+    FakeBrowserSignInGateway,
     build_poll_failed_error,
     build_sign_in_process,
     noop_sleep,
@@ -48,20 +48,24 @@ def build_code_challenge(verifier: str) -> str:
 def build_test_service(
     *,
     poll_results: list[BrowserSignInPollResult | BrowserSignInError],
+    start_error: BrowserSignInError | None = None,
     exchange_error: BrowserSignInError | None = None,
     open_browser: Callable[[str], bool] | None = None,
+    raise_on_browser_open_failure: bool = True,
     sleep: Callable[[float], Awaitable[None]] = noop_sleep,
     now: Callable[[], datetime] | None = None,
     process_time: datetime = TEST_NOW,
-) -> tuple[StubBrowserSignInGateway, BrowserSignInService]:
-    gateway = StubBrowserSignInGateway(
+) -> tuple[FakeBrowserSignInGateway, BrowserSignInService]:
+    gateway = FakeBrowserSignInGateway(
         process=build_sign_in_process(process_time),
+        start_error=start_error,
         poll_results=poll_results,
         exchange_error=exchange_error,
     )
     service = BrowserSignInService(
         gateway,
         open_browser=open_browser or (lambda _: True),
+        raise_on_browser_open_failure=raise_on_browser_open_failure,
         sleep=sleep,
         now=now or (lambda: process_time),
         poll_interval=0,
@@ -147,12 +151,40 @@ async def test_authenticate_raises_when_polling_expires() -> None:
     _, service = build_test_service(
         poll_results=[BrowserSignInPollResult(status="expired")],
         open_browser=lambda url: opened_urls.append(url) or True,
+        raise_on_browser_open_failure=False,
     )
 
     with pytest.raises(BrowserSignInError, match="expired"):
         await service.authenticate()
 
     assert opened_urls == [TEST_SIGN_IN_URL]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("poll_result", "expected_code"),
+    [
+        (BrowserSignInPollResult(status="denied"), BrowserSignInErrorCode.DENIED),
+        (
+            BrowserSignInPollResult(
+                status="error", message="Provider rejected sign-in."
+            ),
+            BrowserSignInErrorCode.PROVIDER_ERROR,
+        ),
+    ],
+    ids=["denied", "provider_error"],
+)
+async def test_tolerant_browser_policy_preserves_terminal_poll_errors(
+    poll_result: BrowserSignInPollResult, expected_code: BrowserSignInErrorCode
+) -> None:
+    _, service = build_test_service(
+        poll_results=[poll_result], raise_on_browser_open_failure=False
+    )
+
+    with pytest.raises(BrowserSignInError) as err:
+        await service.authenticate()
+
+    assert err.value.code is expected_code
 
 
 @pytest.mark.asyncio
@@ -177,7 +209,8 @@ async def test_authenticate_fails_after_three_consecutive_poll_failures() -> Non
             build_poll_failed_error(),
             build_poll_failed_error(),
             build_poll_failed_error(),
-        ]
+        ],
+        raise_on_browser_open_failure=False,
     )
 
     with pytest.raises(
@@ -245,11 +278,13 @@ async def test_authenticate_raises_on_unknown_poll_state() -> None:
 @pytest.mark.asyncio
 async def test_authenticate_raises_when_browser_cannot_be_opened() -> None:
     events: list[BrowserSignInEvent] = []
-    _, service = build_test_service(poll_results=[], open_browser=lambda _: False)
+    gateway, service = build_test_service(poll_results=[], open_browser=lambda _: False)
 
-    with pytest.raises(BrowserSignInError, match="open browser"):
+    with pytest.raises(BrowserSignInError, match="open browser") as err:
         await service.authenticate(event_callback=events.append)
 
+    assert err.value.code is BrowserSignInErrorCode.OPEN_BROWSER_FAILED
+    assert gateway.polled_urls == []
     assert events == [
         BrowserSignInAttemptStarted(
             sign_in_url=TEST_SIGN_IN_URL,
@@ -260,18 +295,87 @@ async def test_authenticate_raises_when_browser_cannot_be_opened() -> None:
 
 
 @pytest.mark.asyncio
+async def test_authenticate_chains_browser_open_exception_by_default() -> None:
+    browser_error = OSError("no browser controller")
+
+    def raise_browser_error(_: str) -> bool:
+        raise browser_error
+
+    gateway, service = build_test_service(
+        poll_results=[], open_browser=raise_browser_error
+    )
+
+    with pytest.raises(BrowserSignInError, match="open browser") as err:
+        await service.authenticate()
+
+    assert err.value.code is BrowserSignInErrorCode.OPEN_BROWSER_FAILED
+    assert err.value.__cause__ is browser_error
+    assert gateway.polled_urls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "browser_error",
+    [None, OSError("no browser controller")],
+    ids=["false_result", "exception"],
+)
+async def test_authenticate_continues_after_tolerated_browser_open_failure(
+    browser_error: OSError | None,
+) -> None:
+    def open_browser(_: str) -> bool:
+        if browser_error is not None:
+            raise browser_error
+        return False
+
+    gateway, service = build_test_service(
+        poll_results=[
+            BrowserSignInPollResult(status="completed", exchange_token="exchange-1")
+        ],
+        open_browser=open_browser,
+        raise_on_browser_open_failure=False,
+    )
+
+    api_key = await service.authenticate()
+
+    assert api_key == "sk-browser-key"
+    assert gateway.process_number == 1
+    assert gateway.polled_urls == [TEST_POLL_URL]
+    assert gateway.exchange_requests[0].process_id == TEST_PROCESS_ID
+
+
+@pytest.mark.asyncio
+async def test_tolerant_browser_policy_preserves_start_failure() -> None:
+    start_error = BrowserSignInError(
+        "Failed to start browser sign-in.", code=BrowserSignInErrorCode.START_FAILED
+    )
+    _, service = build_test_service(
+        poll_results=[], start_error=start_error, raise_on_browser_open_failure=False
+    )
+
+    with pytest.raises(BrowserSignInError) as err:
+        await service.authenticate()
+
+    assert err.value is start_error
+
+
+@pytest.mark.asyncio
 async def test_authenticate_raises_when_exchange_fails() -> None:
+    exchange_error = BrowserSignInError(
+        "Failed to exchange browser sign-in for an API key.",
+        code=BrowserSignInErrorCode.EXCHANGE_FAILED,
+    )
     _, service = build_test_service(
         poll_results=[
             BrowserSignInPollResult(status="completed", exchange_token="exchange-1")
         ],
-        exchange_error=BrowserSignInError(
-            "Failed to exchange browser sign-in for an API key."
-        ),
+        exchange_error=exchange_error,
+        raise_on_browser_open_failure=False,
     )
 
-    with pytest.raises(BrowserSignInError, match="exchange"):
+    with pytest.raises(BrowserSignInError, match="exchange") as err:
         await service.authenticate()
+
+    assert err.value is exchange_error
 
 
 @pytest.mark.asyncio
@@ -349,7 +453,7 @@ async def test_authenticate_caps_sleep_to_remaining_sign_in_lifetime(
         sleep_durations.append(duration)
         current_time += timedelta(seconds=duration)
 
-    gateway = StubBrowserSignInGateway(
+    gateway = FakeBrowserSignInGateway(
         process=BrowserSignInProcess(
             process_id=TEST_PROCESS_ID,
             sign_in_url=TEST_SIGN_IN_URL,

--- a/tests/setup/onboarding/_test_helpers.py
+++ b/tests/setup/onboarding/_test_helpers.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from textual.pilot import Pilot
+
+from tests.conftest import build_test_vibe_config
+from vibe.core.config import ModelConfig, ProviderConfig, VibeConfigSchema
+from vibe.core.paths import GLOBAL_ENV_FILE
+from vibe.core.types import Backend
+from vibe.setup.auth import BrowserSignInService
+from vibe.setup.onboarding import OnboardingApp
+from vibe.setup.onboarding.screens.api_key import ApiKeyScreen
+from vibe.setup.onboarding.screens.auth_method import AuthMethodScreen
+from vibe.setup.onboarding.screens.browser_sign_in import BrowserSignInScreen
+from vibe.setup.onboarding.screens.theme_selection import ThemeSelectionScreen
+from vibe.utils.io import read_safe
+
+CONSOLE_URL = "https://console.mistral.ai"
+BROWSER_AUTH_API_URL = "https://console.mistral.ai/api"
+
+
+async def wait_for(
+    condition: Callable[[], bool],
+    pilot: Pilot,
+    timeout: float = 5.0,
+    interval: float = 0.05,
+) -> None:
+    elapsed = 0.0
+    while not condition():
+        await pilot.pause(interval)
+        if (elapsed := elapsed + interval) >= timeout:
+            raise AssertionError("Timed out waiting for condition.")
+
+
+def build_onboarding_config(
+    *,
+    provider_name: str = "mistral",
+    model_provider: str | None = None,
+    backend: Backend = Backend.MISTRAL,
+    api_key_env_var: str = "MISTRAL_API_KEY",
+    browser_auth_base_url: str | None = None,
+    browser_auth_api_base_url: str | None = None,
+    vibe_base_url: str = "https://chat.mistral.ai",
+) -> VibeConfigSchema:
+    provider = ProviderConfig(
+        name=provider_name,
+        api_base="https://api.mistral.ai/v1",
+        api_key_env_var=api_key_env_var,
+        browser_auth_base_url=browser_auth_base_url,
+        browser_auth_api_base_url=browser_auth_api_base_url,
+        backend=backend,
+    )
+    model = ModelConfig(
+        name="mistral-vibe-cli-latest",
+        provider=model_provider or provider_name,
+        alias="devstral-2",
+    )
+    return build_test_vibe_config(
+        providers=[provider], models=[model], vibe_base_url=vibe_base_url
+    )
+
+
+def build_browser_onboarding_app(
+    *,
+    browser_sign_in_service_factory: Callable[[], BrowserSignInService] | None = None,
+    browser_sign_in_success_delay: float = 0,
+    browser_sign_in_url_help_delay: float = 0,
+    copy_sign_in_url: Callable[[str], bool] | None = None,
+) -> OnboardingApp:
+    return OnboardingApp(
+        config=build_onboarding_config(
+            browser_auth_base_url=CONSOLE_URL,
+            browser_auth_api_base_url=BROWSER_AUTH_API_URL,
+        ),
+        browser_sign_in_service_factory=browser_sign_in_service_factory,
+        browser_sign_in_success_delay=browser_sign_in_success_delay,
+        browser_sign_in_url_help_delay=browser_sign_in_url_help_delay,
+        copy_sign_in_url=copy_sign_in_url,
+    )
+
+
+def saved_env_contents() -> str:
+    return read_safe(GLOBAL_ENV_FILE.path).text
+
+
+async def pass_welcome_screen(pilot: Pilot) -> None:
+    welcome_screen = pilot.app.get_screen("welcome")
+    await wait_for(
+        lambda: not welcome_screen.query_one("#enter-hint").has_class("hidden"), pilot
+    )
+    await pilot.press("enter")
+    await wait_for(lambda: isinstance(pilot.app.screen, ThemeSelectionScreen), pilot)
+
+
+async def pass_theme_selection_screen(pilot: Pilot) -> None:
+    await pilot.press("enter")
+
+
+async def show_auth_method(pilot: Pilot) -> None:
+    await pass_welcome_screen(pilot)
+    await pass_theme_selection_screen(pilot)
+    await wait_for(lambda: isinstance(pilot.app.screen, AuthMethodScreen), pilot)
+
+
+async def show_browser_sign_in(pilot: Pilot) -> None:
+    await show_auth_method(pilot)
+    await pilot.press("enter")
+    await wait_for(lambda: isinstance(pilot.app.screen, BrowserSignInScreen), pilot)
+
+
+async def show_manual_api_key_screen(pilot: Pilot) -> None:
+    await show_auth_method(pilot)
+    await pilot.press("down", "enter")
+    await wait_for(lambda: isinstance(pilot.app.screen, ApiKeyScreen), pilot)

--- a/tests/setup/onboarding/conftest.py
+++ b/tests/setup/onboarding/conftest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import keyring
+from keyring.errors import KeyringError
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def disable_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unavailable(service: str, username: str, password: str) -> None:
+        raise KeyringError("keyring disabled in tests")
+
+    monkeypatch.setattr(keyring, "set_password", unavailable)
+    monkeypatch.setattr(keyring, "delete_password", lambda service, username: None)

--- a/tests/setup/onboarding/screens/test_browser_sign_in.py
+++ b/tests/setup/onboarding/screens/test_browser_sign_in.py
@@ -1,61 +1,50 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock
 
-import keyring
-from keyring.errors import KeyringError
 import pytest
 from textual.content import Content
-from textual.events import Resize
-from textual.geometry import Size
-from textual.pilot import Pilot
 from textual.screen import Screen
 from textual.widget import Widget
-from textual.widgets import Input, Link, Static
+from textual.widgets import Static
 
-from tests.browser_sign_in.stubs import (
+from tests.setup.onboarding._test_helpers import (
+    BROWSER_AUTH_API_URL,
+    CONSOLE_URL,
+    build_browser_onboarding_app as _build_browser_onboarding_app,
+    build_onboarding_config as _build_onboarding_config,
+    saved_env_contents as _saved_env_contents,
+    show_browser_sign_in as _show_browser_sign_in,
+    wait_for as _wait_for,
+)
+from tests.stubs.fake_browser_sign_in_gateway import (
+    BrowserSignInPollScript,
+    FakeBrowserSignInGateway,
     build_browser_sign_in_service_factory,
+    build_completed_poll_script,
+    build_expired_poll_script,
+    build_poll_failed_script,
     build_sign_in_process,
 )
-from tests.conftest import build_test_vibe_config
 from vibe.cli.textual_ui.shortcut_hints import SHORTCUT_STYLE
 from vibe.cli.textual_ui.widgets.no_markup_static import NoMarkupStatic
-from vibe.core.config import (
-    AUTO_THEME,
-    DEFAULT_MISTRAL_BROWSER_AUTH_API_BASE_URL,
-    DEFAULT_MISTRAL_BROWSER_AUTH_BASE_URL,
-    ModelConfig,
-    ProviderConfig,
-    VibeConfigSchema,
-)
-from vibe.core.config.harness_files import (
-    init_harness_files_manager,
-    reset_harness_files_manager,
-)
-from vibe.core.paths import GLOBAL_ENV_FILE
-from vibe.core.telemetry.build_metadata import build_launch_context
-from vibe.core.telemetry.send import TelemetryClient
-from vibe.core.telemetry.types import TerminalEmulator
+from vibe.core.config import ProviderConfig
 from vibe.core.types import Backend
 from vibe.setup.auth import (
-    BrowserSignInError,
-    BrowserSignInErrorCode,
     BrowserSignInEvent,
+    BrowserSignInPollResult,
     BrowserSignInService,
     BrowserSignInStatus,
     BrowserSignInStatusChanged,
 )
-from vibe.setup.auth.api_key_persistence import persist_api_key
-import vibe.setup.onboarding as onboarding_module
 from vibe.setup.onboarding import OnboardingApp
 from vibe.setup.onboarding.context import OnboardingContext
 from vibe.setup.onboarding.screens.api_key import ApiKeyScreen
-from vibe.setup.onboarding.screens.auth_method import AuthMethodScreen
 from vibe.setup.onboarding.screens.browser_sign_in import (
     SIGN_IN_URL_HELP_PREFIX,
     BrowserSignInScreen,
@@ -63,123 +52,16 @@ from vibe.setup.onboarding.screens.browser_sign_in import (
     BrowserSignInStepWidgets,
     BrowserSignInViewState,
 )
-from vibe.setup.onboarding.screens.theme_selection import THEMES, ThemeSelectionScreen
-from vibe.setup.onboarding.screens.welcome import HIGHLIGHT_END, WelcomeScreen
 
-CONSOLE_URL = "https://console.mistral.ai"
-BROWSER_AUTH_API_URL = "https://console.mistral.ai/api"
 TEST_NOW = datetime(2026, 3, 16, tzinfo=UTC)
-
-
-@pytest.fixture(autouse=True)
-def disable_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Force the .env fallback so persist tests never touch the real OS keyring."""
-
-    def _unavailable(service: str, username: str, password: str) -> None:
-        raise KeyringError("keyring disabled in tests")
-
-    monkeypatch.setattr(keyring, "set_password", _unavailable)
-    monkeypatch.setattr(keyring, "delete_password", lambda service, username: None)
 
 
 def _expected_browser_sign_in_url(process_id: str = "process-1") -> str:
     return build_sign_in_process(TEST_NOW, process_id=process_id).sign_in_url
 
 
-async def _wait_for(
-    condition: Callable[[], bool],
-    pilot: Pilot,
-    timeout: float = 5.0,
-    interval: float = 0.05,
-) -> None:
-    elapsed = 0.0
-    while not condition():
-        await pilot.pause(interval)
-        if (elapsed := elapsed + interval) >= timeout:
-            raise AssertionError("Timed out waiting for condition.")
-
-
-def _build_onboarding_config(
-    *,
-    provider_name: str = "mistral",
-    model_provider: str | None = None,
-    backend: Backend = Backend.MISTRAL,
-    api_key_env_var: str = "MISTRAL_API_KEY",
-    browser_auth_base_url: str | None = None,
-    browser_auth_api_base_url: str | None = None,
-    vibe_base_url: str = "https://chat.mistral.ai",
-) -> VibeConfigSchema:
-    provider = ProviderConfig(
-        name=provider_name,
-        api_base="https://api.mistral.ai/v1",
-        api_key_env_var=api_key_env_var,
-        browser_auth_base_url=browser_auth_base_url,
-        browser_auth_api_base_url=browser_auth_api_base_url,
-        backend=backend,
-    )
-    model = ModelConfig(
-        name="mistral-vibe-cli-latest",
-        provider=model_provider or provider_name,
-        alias="devstral-2",
-    )
-    return build_test_vibe_config(
-        providers=[provider], models=[model], vibe_base_url=vibe_base_url
-    )
-
-
-def _build_browser_onboarding_app(
-    *,
-    browser_sign_in_service_factory: Callable[[], BrowserSignInService] | None = None,
-    browser_sign_in_success_delay: float = 0,
-    browser_sign_in_url_help_delay: float = 0,
-    copy_sign_in_url: Callable[[str], bool] | None = None,
-) -> OnboardingApp:
-    return OnboardingApp(
-        config=_build_onboarding_config(
-            browser_auth_base_url=CONSOLE_URL,
-            browser_auth_api_base_url=BROWSER_AUTH_API_URL,
-        ),
-        browser_sign_in_service_factory=browser_sign_in_service_factory,
-        browser_sign_in_success_delay=browser_sign_in_success_delay,
-        browser_sign_in_url_help_delay=browser_sign_in_url_help_delay,
-        copy_sign_in_url=copy_sign_in_url,
-    )
-
-
-def _patch_failing_browser_sign_in_service(
-    monkeypatch: pytest.MonkeyPatch, captured_base_urls: list[tuple[str, str]]
-) -> None:
-    class FakeGateway:
-        def __init__(self, browser_base_url: str, api_base_url: str) -> None:
-            captured_base_urls.append((browser_base_url, api_base_url))
-
-    class FakeService:
-        def __init__(self, gateway: FakeGateway) -> None:
-            self._gateway = gateway
-
-        async def authenticate(self, *args, **kwargs) -> str:
-            raise BrowserSignInError(
-                "Browser sign-in polling failed.",
-                code=BrowserSignInErrorCode.POLL_FAILED,
-            )
-
-        async def aclose(self) -> None:
-            return None
-
-    monkeypatch.setattr(onboarding_module, "HttpBrowserSignInGateway", FakeGateway)
-    monkeypatch.setattr(onboarding_module, "BrowserSignInService", FakeService)
-
-
-def _saved_env_contents() -> str:
-    return GLOBAL_ENV_FILE.path.read_text(encoding="utf-8")
-
-
 def _browser_sign_in_step_cards(screen: Screen) -> list[Widget]:
     return list(screen.query(".browser-sign-in-step"))
-
-
-def _browser_sign_in_step_card(screen: Screen, index: int) -> Widget:
-    return _browser_sign_in_step_cards(screen)[index]
 
 
 def _active_browser_sign_in_step_card(screen: Screen) -> Widget:
@@ -212,106 +94,76 @@ def _browser_sign_in_url_text(screen: Screen) -> str:
     return str(screen.query_one("#browser-sign-in-url", Static).render())
 
 
-def _build_unexpected_browser_sign_in_service_factory(
-    outcomes: list[str],
-    *,
-    api_key: str = "sk-browser-onboarding-test-key",
-    close_blocker: asyncio.Event | None = None,
-    close_started: asyncio.Event | None = None,
-    close_finished: asyncio.Event | None = None,
-    close_cancelled: asyncio.Event | None = None,
-) -> Callable[[], BrowserSignInService]:
-    remaining_outcomes = list(outcomes)
+def _blocked_sleep(blocker: asyncio.Event) -> Callable[[float], Awaitable[None]]:
+    async def wait(_: float) -> None:
+        await blocker.wait()
 
-    class UnexpectedBrowserSignInService:
-        def __init__(self, outcome: str) -> None:
-            self._outcome = outcome
+    return wait
+
+
+def _assert_browser_sign_in_waiting(
+    screen: Screen, gateway: FakeBrowserSignInGateway
+) -> BrowserSignInScreen:
+    assert isinstance(screen, BrowserSignInScreen)
+    assert screen.state.variant == "pending"
+    assert screen.state.running is True
+    assert gateway.poll_calls == 1
+    return screen
+
+
+@dataclass(frozen=True)
+class BrowserSignInCleanupProbe:
+    blocker: asyncio.Event = field(default_factory=asyncio.Event)
+    started: asyncio.Event = field(default_factory=asyncio.Event)
+    finished: asyncio.Event = field(default_factory=asyncio.Event)
+    cancelled: asyncio.Event = field(default_factory=asyncio.Event)
+
+
+def _build_unexpected_browser_sign_in_service_factory(
+    results: list[str | Exception],
+    *,
+    cleanup_probe: BrowserSignInCleanupProbe | None = None,
+) -> Callable[[], BrowserSignInService]:
+    remaining_results = list(results)
+
+    class FakeBrowserSignInService:
+        def __init__(self, result: str | Exception) -> None:
+            self._result = result
 
         async def authenticate(
             self, event_callback: Callable[[BrowserSignInEvent], None] | None = None
         ) -> str:
-            if self._outcome == "completed":
-                if event_callback is not None:
-                    event_callback(
-                        BrowserSignInStatusChanged(status=BrowserSignInStatus.COMPLETED)
-                    )
-                return api_key
-            if self._outcome == "runtime_error":
-                raise RuntimeError("boom")
-            msg = f"Unsupported browser sign-in outcome: {self._outcome}"
-            raise AssertionError(msg)
+            if isinstance(self._result, Exception):
+                raise self._result
+            if event_callback is not None:
+                event_callback(
+                    BrowserSignInStatusChanged(status=BrowserSignInStatus.COMPLETED)
+                )
+            return self._result
 
         async def aclose(self) -> None:
+            if cleanup_probe is None:
+                return
             try:
-                if close_started is not None:
-                    close_started.set()
-                if close_blocker is not None:
-                    await close_blocker.wait()
+                cleanup_probe.started.set()
+                await cleanup_probe.blocker.wait()
             except asyncio.CancelledError:
-                if close_cancelled is not None:
-                    close_cancelled.set()
+                cleanup_probe.cancelled.set()
                 raise
             finally:
-                if close_finished is not None:
-                    close_finished.set()
-
-            return None
+                cleanup_probe.finished.set()
 
     def build_service() -> BrowserSignInService:
-        if not remaining_outcomes:
+        if not remaining_results:
             msg = (
-                "Unexpected browser sign-in service factory requires scripted outcomes."
+                "Unexpected browser sign-in service factory requires scripted results."
             )
             raise AssertionError(msg)
         return cast(
-            BrowserSignInService,
-            UnexpectedBrowserSignInService(remaining_outcomes.pop(0)),
+            BrowserSignInService, FakeBrowserSignInService(remaining_results.pop(0))
         )
 
     return build_service
-
-
-async def _pass_welcome_screen(pilot: Pilot) -> None:
-    welcome_screen = pilot.app.get_screen("welcome")
-    await _wait_for(
-        lambda: not welcome_screen.query_one("#enter-hint").has_class("hidden"), pilot
-    )
-    await pilot.press("enter")
-    await _wait_for(lambda: isinstance(pilot.app.screen, ThemeSelectionScreen), pilot)
-
-
-async def _pass_theme_selection_screen(pilot: Pilot) -> None:
-    await pilot.press("enter")
-
-
-async def _show_auth_method(pilot: Pilot) -> None:
-    await _pass_welcome_screen(pilot)
-    await _pass_theme_selection_screen(pilot)
-    await _wait_for(lambda: isinstance(pilot.app.screen, AuthMethodScreen), pilot)
-
-
-async def _show_browser_sign_in(pilot: Pilot) -> None:
-    await _show_auth_method(pilot)
-    await pilot.press("enter")
-    await _wait_for(lambda: isinstance(pilot.app.screen, BrowserSignInScreen), pilot)
-
-
-async def _show_manual_api_key_screen(pilot: Pilot) -> None:
-    await _show_auth_method(pilot)
-    await pilot.press("down", "enter")
-    await _wait_for(lambda: isinstance(pilot.app.screen, ApiKeyScreen), pilot)
-
-
-def test_welcome_gradient_animation_skips_relayout() -> None:
-    screen = WelcomeScreen()
-    screen._char_index = HIGHLIGHT_END
-    welcome_text = MagicMock(spec=Static)
-    screen._welcome_text = welcome_text
-
-    screen._animate_gradient()
-
-    welcome_text.update.assert_called_once()
-    assert welcome_text.update.call_args.kwargs == {"layout": False}
 
 
 def test_browser_sign_in_gradient_animation_skips_relayout() -> None:
@@ -342,85 +194,7 @@ def test_browser_sign_in_gradient_animation_skips_relayout() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ui_keeps_manual_flow_when_browser_sign_in_is_unsupported() -> None:
-    app = OnboardingApp(
-        config=_build_onboarding_config(
-            browser_auth_base_url="", browser_auth_api_base_url=""
-        )
-    )
-    api_key_value = "sk-onboarding-test-key"
-
-    async with app.run_test() as pilot:
-        await _pass_welcome_screen(pilot)
-        await _pass_theme_selection_screen(pilot)
-        await _wait_for(lambda: isinstance(pilot.app.screen, ApiKeyScreen), pilot)
-        input_widget = app.screen.query_one("#key", Input)
-        await pilot.press(*api_key_value)
-        assert input_widget.value == api_key_value
-        await pilot.press("enter")
-        await _wait_for(lambda: app.return_value is not None, pilot, timeout=2.0)
-
-    assert app.return_value == "completed"
-    assert api_key_value in _saved_env_contents()
-
-
-@pytest.mark.asyncio
-async def test_ui_supports_browser_sign_in_when_provider_supports_it() -> None:
-    _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"]
-    )
-    app = OnboardingApp(
-        config=_build_onboarding_config(
-            browser_auth_base_url=CONSOLE_URL,
-            browser_auth_api_base_url=BROWSER_AUTH_API_URL,
-        ),
-        browser_sign_in_service_factory=browser_sign_in_service_factory,
-    )
-
-    assert app.supports_browser_sign_in is True
-
-    async with app.run_test() as pilot:
-        await _show_auth_method(pilot)
-
-
-@pytest.mark.asyncio
-async def test_ui_offers_browser_sign_in_for_renamed_mistral_provider() -> None:
-    app = OnboardingApp(
-        config=_build_onboarding_config(
-            provider_name="customer-mistral",
-            backend=Backend.MISTRAL,
-            browser_auth_base_url=CONSOLE_URL,
-            browser_auth_api_base_url=BROWSER_AUTH_API_URL,
-        )
-    )
-
-    assert app.supports_browser_sign_in is True
-
-    async with app.run_test() as pilot:
-        await _show_auth_method(pilot)
-
-
-@pytest.mark.asyncio
-async def test_ui_allows_manual_path_when_browser_sign_in_is_supported() -> None:
-    app = _build_browser_onboarding_app()
-    api_key_value = "sk-manual-onboarding-test-key"
-
-    async with app.run_test() as pilot:
-        await _show_auth_method(pilot)
-        await pilot.press("down", "enter")
-        await _wait_for(lambda: isinstance(pilot.app.screen, ApiKeyScreen), pilot)
-        input_widget = app.screen.query_one("#key", Input)
-        await pilot.press(*api_key_value)
-        await pilot.press("enter")
-        await _wait_for(lambda: app.return_value is not None, pilot, timeout=2.0)
-        assert input_widget.value == api_key_value
-
-    assert app.return_value == "completed"
-    assert api_key_value in _saved_env_contents()
-
-
-@pytest.mark.asyncio
-async def test_ui_does_not_show_browser_opened_before_attempt_starts() -> None:
+async def test_ui_does_not_show_sign_in_page_ready_before_attempt_starts() -> None:
     authenticate_started = asyncio.Event()
     finish_authenticate = asyncio.Event()
     keep_authenticate_running = asyncio.Event()
@@ -430,7 +204,7 @@ async def test_ui_does_not_show_browser_opened_before_attempt_starts() -> None:
         copied_urls.append(url)
         return True
 
-    class DelayedBrowserSignInService:
+    class FakeDelayedBrowserSignInService:
         async def authenticate(
             self, event_callback: Callable[[BrowserSignInEvent], None] | None = None
         ) -> str:
@@ -450,7 +224,7 @@ async def test_ui_does_not_show_browser_opened_before_attempt_starts() -> None:
 
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=lambda: cast(
-            BrowserSignInService, DelayedBrowserSignInService()
+            BrowserSignInService, FakeDelayedBrowserSignInService()
         ),
         copy_sign_in_url=copy_sign_in_url,
     )
@@ -463,7 +237,7 @@ async def test_ui_does_not_show_browser_opened_before_attempt_starts() -> None:
         active_step_text = _browser_sign_in_step_text(active_step)
         assert "Open browser" in active_step_text
         assert "Getting things ready..." in active_step_text
-        assert "Browser opened" not in active_step_text
+        assert "Sign-in page ready" not in active_step_text
         assert _browser_sign_in_url_text(app.screen) == ""
         await pilot.press("c")
         assert copied_urls == []
@@ -484,11 +258,8 @@ async def test_ui_does_not_show_browser_opened_before_attempt_starts() -> None:
 async def test_ui_shows_browser_sign_in_url_copy_prompt_without_raw_url() -> None:
     blocker = asyncio.Event()
 
-    async def wait_forever(_: float) -> None:
-        await blocker.wait()
-
     _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"], sleep=wait_forever
+        poll_scripts=[build_completed_poll_script()], sleep=_blocked_sleep(blocker)
     )
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=browser_sign_in_service_factory
@@ -515,11 +286,8 @@ async def test_ui_shows_browser_sign_in_url_copy_prompt_without_raw_url() -> Non
 async def test_ui_delays_browser_sign_in_url_help() -> None:
     blocker = asyncio.Event()
 
-    async def wait_forever(_: float) -> None:
-        await blocker.wait()
-
     _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"], sleep=wait_forever
+        poll_scripts=[build_completed_poll_script()], sleep=_blocked_sleep(blocker)
     )
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=browser_sign_in_service_factory,
@@ -550,15 +318,12 @@ async def test_ui_copies_browser_sign_in_url() -> None:
     blocker = asyncio.Event()
     copied_urls: list[str] = []
 
-    async def wait_forever(_: float) -> None:
-        await blocker.wait()
-
     def copy_sign_in_url(url: str) -> bool:
         copied_urls.append(url)
         return True
 
-    _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"], sleep=wait_forever
+    gateway, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
+        poll_scripts=[build_completed_poll_script()], sleep=_blocked_sleep(blocker)
     )
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=browser_sign_in_service_factory,
@@ -572,6 +337,7 @@ async def test_ui_copies_browser_sign_in_url() -> None:
         )
         await pilot.press("c")
         assert "process-1" not in _browser_sign_in_url_text(app.screen)
+        _assert_browser_sign_in_waiting(app.screen, gateway)
 
     assert copied_urls == [_expected_browser_sign_in_url()]
 
@@ -581,15 +347,12 @@ async def test_ui_copies_browser_sign_in_url_when_help_text_is_clicked() -> None
     blocker = asyncio.Event()
     copied_urls: list[str] = []
 
-    async def wait_forever(_: float) -> None:
-        await blocker.wait()
-
     def copy_sign_in_url(url: str) -> bool:
         copied_urls.append(url)
         return True
 
     _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"], sleep=wait_forever
+        poll_scripts=[build_completed_poll_script()], sleep=_blocked_sleep(blocker)
     )
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=browser_sign_in_service_factory,
@@ -612,11 +375,8 @@ async def test_ui_copies_browser_sign_in_url_when_help_text_is_clicked() -> None
 async def test_ui_reveals_browser_sign_in_url_when_copy_fails() -> None:
     blocker = asyncio.Event()
 
-    async def wait_forever(_: float) -> None:
-        await blocker.wait()
-
-    _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"], sleep=wait_forever
+    gateway, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
+        poll_scripts=[build_completed_poll_script()], sleep=_blocked_sleep(blocker)
     )
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=browser_sign_in_service_factory,
@@ -637,49 +397,30 @@ async def test_ui_reveals_browser_sign_in_url_when_copy_fails() -> None:
         )
         url_text = _browser_sign_in_url_text(app.screen)
         assert "Copy failed. Open this URL manually:" in url_text
+        _assert_browser_sign_in_waiting(app.screen, gateway)
 
 
 @pytest.mark.asyncio
-async def test_ui_keeps_last_sign_in_url_copy_prompt_after_open_browser_failure() -> (
-    None
-):
-    _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"], open_browser=lambda _: False
-    )
-    app = _build_browser_onboarding_app(
-        browser_sign_in_service_factory=browser_sign_in_service_factory
-    )
-
-    async with app.run_test() as pilot:
-        await _show_browser_sign_in(pilot)
-        await _wait_for(
-            lambda: (
-                "Failed to open browser for sign-in."
-                in _browser_sign_in_step_text(
-                    _active_browser_sign_in_step_card(app.screen)
-                )
-            ),
-            pilot,
-        )
-        assert _browser_sign_in_hint(app.screen) == (
-            "Press r to retry - Press m to enter API key manually - Esc to cancel"
-        )
-        _assert_browser_sign_in_shortcuts_styled(app.screen)
-        url_text = _browser_sign_in_url_text(app.screen)
-        assert "If your browser did not open, copy this URL (press c)" in url_text
-        assert "process-1" not in url_text
-
-
-@pytest.mark.asyncio
-async def test_ui_copies_last_browser_sign_in_url_after_open_browser_failure() -> None:
+async def test_ui_completes_headless_browser_sign_in_after_copying_url() -> None:
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
     copied_urls: list[str] = []
+
+    async def wait_before_poll_result(poll_number: int) -> None:
+        if poll_number != 1:
+            return
+        poll_started.set()
+        await release_poll.wait()
 
     def copy_sign_in_url(url: str) -> bool:
         copied_urls.append(url)
         return True
 
-    _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"], open_browser=lambda _: False
+    gateway, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
+        poll_scripts=[build_completed_poll_script()],
+        open_browser=lambda _: False,
+        raise_on_browser_open_failure=False,
+        wait_before_poll_result=wait_before_poll_result,
     )
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=browser_sign_in_service_factory,
@@ -688,13 +429,97 @@ async def test_ui_copies_last_browser_sign_in_url_after_open_browser_failure() -
 
     async with app.run_test() as pilot:
         await _show_browser_sign_in(pilot)
+        await _wait_for(poll_started.is_set, pilot)
         await _wait_for(
             lambda: "copy this URL" in _browser_sign_in_url_text(app.screen), pilot
         )
-
         await pilot.press("c")
+        _assert_browser_sign_in_waiting(app.screen, gateway)
+        step_cards = _browser_sign_in_step_cards(app.screen)
+        assert "Sign-in page ready" in _browser_sign_in_step_text(step_cards[0])
+        assert "Browser opened" not in _browser_sign_in_step_text(step_cards[0])
+
+        release_poll.set()
+        await _wait_for(lambda: app.return_value is not None, pilot, timeout=2.0)
 
     assert copied_urls == [_expected_browser_sign_in_url()]
+    assert gateway.poll_calls == 2
+    assert len(gateway.exchange_requests) == 1
+    assert app.return_value == "completed"
+    assert "sk-browser-onboarding-test-key" in _saved_env_contents()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("poll_script", "expected_error"),
+    [
+        (
+            (
+                BrowserSignInPollResult(status="pending"),
+                BrowserSignInPollResult(status="expired"),
+            ),
+            "Browser sign-in expired.",
+        ),
+        (
+            (
+                BrowserSignInPollResult(status="pending"),
+                BrowserSignInPollResult(status="denied"),
+            ),
+            "Browser sign-in was denied.",
+        ),
+    ],
+    ids=["expired", "denied"],
+)
+async def test_ui_preserves_terminal_error_after_copying_headless_sign_in_url(
+    poll_script: BrowserSignInPollScript, expected_error: str
+) -> None:
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
+    copied_urls: list[str] = []
+
+    async def wait_before_poll_result(poll_number: int) -> None:
+        if poll_number != 1:
+            return
+        poll_started.set()
+        await release_poll.wait()
+
+    gateway, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
+        poll_scripts=[poll_script],
+        open_browser=lambda _: False,
+        raise_on_browser_open_failure=False,
+        wait_before_poll_result=wait_before_poll_result,
+    )
+    app = _build_browser_onboarding_app(
+        browser_sign_in_service_factory=browser_sign_in_service_factory,
+        copy_sign_in_url=lambda url: copied_urls.append(url) or True,
+    )
+
+    async with app.run_test() as pilot:
+        await _show_browser_sign_in(pilot)
+        await _wait_for(poll_started.is_set, pilot)
+        await _wait_for(
+            lambda: "copy this URL" in _browser_sign_in_url_text(app.screen), pilot
+        )
+        await pilot.press("c")
+        screen = _assert_browser_sign_in_waiting(app.screen, gateway)
+
+        release_poll.set()
+        await _wait_for(
+            lambda: (
+                expected_error
+                in _browser_sign_in_step_text(
+                    _active_browser_sign_in_step_card(app.screen)
+                )
+            ),
+            pilot,
+        )
+
+        assert screen.state.variant == "error"
+        assert screen.state.running is False
+
+    assert copied_urls == [_expected_browser_sign_in_url()]
+    assert gateway.poll_calls == 2
+    assert gateway.exchange_requests == []
 
 
 @pytest.mark.asyncio
@@ -702,15 +527,16 @@ async def test_ui_retry_hides_old_sign_in_url_and_uses_fresh_attempt_url() -> No
     blocker = asyncio.Event()
     copied_urls: list[str] = []
 
-    async def wait_forever(_: float) -> None:
-        await blocker.wait()
-
     def copy_sign_in_url(url: str) -> bool:
         copied_urls.append(url)
         return True
 
     _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["expired", "completed"], sleep=wait_forever
+        poll_scripts=[
+            build_expired_poll_script(),
+            build_completed_poll_script(process_id="process-2"),
+        ],
+        sleep=_blocked_sleep(blocker),
     )
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=browser_sign_in_service_factory,
@@ -757,7 +583,12 @@ async def test_ui_retry_hides_old_sign_in_url_and_uses_fresh_attempt_url() -> No
 @pytest.mark.asyncio
 async def test_ui_completes_browser_sign_in_and_retries_after_failure() -> None:
     gateway, browser_sign_in_service_factory, created_services = (
-        build_browser_sign_in_service_factory(outcomes=["expired", "completed"])
+        build_browser_sign_in_service_factory(
+            poll_scripts=[
+                build_expired_poll_script(),
+                build_completed_poll_script(process_id="process-2"),
+            ]
+        )
     )
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=browser_sign_in_service_factory
@@ -787,7 +618,7 @@ async def test_ui_completes_browser_sign_in_and_retries_after_failure() -> None:
 @pytest.mark.asyncio
 async def test_ui_preserves_completed_browser_sign_in_during_success_delay() -> None:
     _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"]
+        poll_scripts=[build_completed_poll_script()]
     )
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=browser_sign_in_service_factory,
@@ -826,7 +657,7 @@ async def test_ui_skips_success_delay_when_browser_api_key_cannot_be_persisted()
     None
 ):
     _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"]
+        poll_scripts=[build_completed_poll_script()]
     )
     provider = ProviderConfig(
         name="mistral",
@@ -852,7 +683,7 @@ async def test_ui_skips_success_delay_when_browser_api_key_cannot_be_persisted()
 @pytest.mark.asyncio
 async def test_ui_browser_sign_in_falls_back_to_mistral_env_var_when_missing() -> None:
     _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"]
+        poll_scripts=[build_completed_poll_script()]
     )
     app = OnboardingApp(
         config=_build_onboarding_config(
@@ -877,7 +708,7 @@ async def test_ui_browser_sign_in_falls_back_to_mistral_env_var_when_missing() -
 @pytest.mark.asyncio
 async def test_ui_shows_human_message_when_polling_fails() -> None:
     _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["poll_failed"]
+        poll_scripts=[build_poll_failed_script()]
     )
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=browser_sign_in_service_factory
@@ -902,7 +733,7 @@ async def test_ui_shows_retryable_error_when_browser_sign_in_fails_unexpectedly(
 ):
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=_build_unexpected_browser_sign_in_service_factory([
-            "runtime_error"
+            RuntimeError("boom")
         ])
     )
 
@@ -933,8 +764,8 @@ async def test_ui_shows_retryable_error_when_browser_sign_in_fails_unexpectedly(
 async def test_ui_retries_after_unexpected_browser_sign_in_failure() -> None:
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=_build_unexpected_browser_sign_in_service_factory([
-            "runtime_error",
-            "completed",
+            RuntimeError("boom"),
+            "sk-browser-onboarding-test-key",
         ])
     )
 
@@ -958,19 +789,17 @@ async def test_ui_retries_after_unexpected_browser_sign_in_failure() -> None:
 
 @pytest.mark.asyncio
 async def test_ui_waits_for_browser_sign_in_cleanup_before_retrying() -> None:
-    close_started = asyncio.Event()
-    close_blocker = asyncio.Event()
+    cleanup_probe = BrowserSignInCleanupProbe()
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=_build_unexpected_browser_sign_in_service_factory(
-            ["runtime_error", "completed"],
-            close_blocker=close_blocker,
-            close_started=close_started,
+            [RuntimeError("boom"), "sk-browser-onboarding-test-key"],
+            cleanup_probe=cleanup_probe,
         )
     )
 
     async with app.run_test() as pilot:
         await _show_browser_sign_in(pilot)
-        await _wait_for(close_started.is_set, pilot)
+        await _wait_for(cleanup_probe.started.is_set, pilot)
 
         hint_widget = app.screen.query_one("#browser-sign-in-hint")
         await _wait_for(
@@ -1010,7 +839,7 @@ async def test_ui_waits_for_browser_sign_in_cleanup_before_retrying() -> None:
         )
         assert app.return_value is None
 
-        close_blocker.set()
+        cleanup_probe.blocker.set()
         await _wait_for(
             lambda: (
                 "Something went wrong during browser sign-in. Please try again."
@@ -1032,42 +861,32 @@ async def test_ui_waits_for_browser_sign_in_cleanup_before_retrying() -> None:
 async def test_ui_switches_to_manual_path_without_cancelling_browser_sign_in_cleanup() -> (
     None
 ):
-    close_started = asyncio.Event()
-    close_blocker = asyncio.Event()
-    close_finished = asyncio.Event()
-    close_cancelled = asyncio.Event()
+    cleanup_probe = BrowserSignInCleanupProbe()
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=_build_unexpected_browser_sign_in_service_factory(
-            ["runtime_error"],
-            close_blocker=close_blocker,
-            close_started=close_started,
-            close_finished=close_finished,
-            close_cancelled=close_cancelled,
+            [RuntimeError("boom")], cleanup_probe=cleanup_probe
         )
     )
 
     async with app.run_test() as pilot:
         await _show_browser_sign_in(pilot)
-        await _wait_for(close_started.is_set, pilot)
+        await _wait_for(cleanup_probe.started.is_set, pilot)
 
         await pilot.press("m")
         await _wait_for(lambda: isinstance(pilot.app.screen, ApiKeyScreen), pilot)
 
-        close_blocker.set()
-        await _wait_for(close_finished.is_set, pilot)
+        cleanup_probe.blocker.set()
+        await _wait_for(cleanup_probe.finished.is_set, pilot)
 
-    assert close_cancelled.is_set() is False
+    assert cleanup_probe.cancelled.is_set() is False
 
 
 @pytest.mark.asyncio
 async def test_ui_switches_to_manual_path_while_browser_sign_in_is_running() -> None:
     blocker = asyncio.Event()
 
-    async def wait_forever(_: float) -> None:
-        await blocker.wait()
-
     gateway, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
-        outcomes=["completed"], sleep=wait_forever
+        poll_scripts=[build_completed_poll_script()], sleep=_blocked_sleep(blocker)
     )
     app = _build_browser_onboarding_app(
         browser_sign_in_service_factory=browser_sign_in_service_factory
@@ -1091,7 +910,7 @@ async def test_ui_switches_to_manual_path_while_browser_sign_in_is_running() -> 
         assert len(step_cards) == 3
         assert step_cards[0].has_class("done")
         assert "Open browser" in _browser_sign_in_step_text(step_cards[0])
-        assert "Browser opened" in _browser_sign_in_step_text(step_cards[0])
+        assert "Sign-in page ready" in _browser_sign_in_step_text(step_cards[0])
         assert step_cards[1].has_class("active")
         assert "Complete sign-in" in _browser_sign_in_step_text(step_cards[1])
         assert "Waiting for authentication..." in _browser_sign_in_step_text(
@@ -1111,263 +930,3 @@ async def test_ui_switches_to_manual_path_while_browser_sign_in_is_running() -> 
     env_contents = _saved_env_contents()
     assert api_key_value in env_contents
     assert "sk-browser-onboarding-test-key" not in env_contents
-
-
-@pytest.mark.asyncio
-async def test_ui_uses_default_mistral_browser_auth_urls(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured_base_urls: list[tuple[str, str]] = []
-    _patch_failing_browser_sign_in_service(monkeypatch, captured_base_urls)
-
-    app = OnboardingApp(config=build_test_vibe_config())
-
-    assert app.supports_browser_sign_in is True
-
-    async with app.run_test() as pilot:
-        await _show_browser_sign_in(pilot)
-        await _wait_for(lambda: bool(captured_base_urls), pilot)
-
-    assert captured_base_urls == [
-        (
-            DEFAULT_MISTRAL_BROWSER_AUTH_BASE_URL,
-            DEFAULT_MISTRAL_BROWSER_AUTH_API_BASE_URL,
-        )
-    ]
-
-
-@pytest.mark.asyncio
-async def test_ui_preserves_custom_browser_auth_urls_when_api_key_is_missing(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
-    monkeypatch.setenv("VIBE_HOME", str(tmp_path))
-    config_file = tmp_path / "config.toml"
-    config_file.write_text(
-        "\n".join([
-            'active_model = "devstral-2"',
-            "[[providers]]",
-            'name = "mistral"',
-            'api_base = "https://api.mistral.ai/v1"',
-            'api_key_env_var = "MISTRAL_API_KEY"',
-            'browser_auth_base_url = "http://127.0.0.1:8787"',
-            'browser_auth_api_base_url = "http://127.0.0.1:8787"',
-            'backend = "mistral"',
-            "",
-            "[[models]]",
-            'name = "mistral-vibe-cli-latest"',
-            'provider = "mistral"',
-            'alias = "devstral-2"',
-            "",
-        ]),
-        encoding="utf-8",
-    )
-    reset_harness_files_manager()
-    init_harness_files_manager("user")
-    captured_base_urls: list[tuple[str, str]] = []
-    _patch_failing_browser_sign_in_service(monkeypatch, captured_base_urls)
-
-    app = OnboardingApp()
-
-    assert app.supports_browser_sign_in is True
-
-    async with app.run_test() as pilot:
-        await _show_browser_sign_in(pilot)
-        await _wait_for(lambda: bool(captured_base_urls), pilot)
-
-    assert captured_base_urls == [("http://127.0.0.1:8787", "http://127.0.0.1:8787")]
-
-
-@pytest.mark.asyncio
-async def test_ui_falls_back_to_default_onboarding_context_with_invalid_active_model(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
-    monkeypatch.setenv("VIBE_HOME", str(tmp_path))
-    config_file = tmp_path / "config.toml"
-    config_file.write_text(
-        "\n".join([
-            'active_model = "does-not-exist"',
-            "",
-            "[[providers]]",
-            'name = "mistral"',
-            'api_base = "https://api.mistral.ai/v1"',
-            'api_key_env_var = "MISTRAL_API_KEY"',
-            'browser_auth_base_url = "https://console.mistral.ai"',
-            'browser_auth_api_base_url = "https://console.mistral.ai/api"',
-            'backend = "mistral"',
-            "",
-            "[[models]]",
-            'name = "mistral-vibe-cli-latest"',
-            'provider = "mistral"',
-            'alias = "devstral-2"',
-            "",
-        ]),
-        encoding="utf-8",
-    )
-    reset_harness_files_manager()
-    init_harness_files_manager("user")
-
-    app = OnboardingApp()
-
-    assert app.supports_browser_sign_in is True
-
-    async with app.run_test() as pilot:
-        await _show_auth_method(pilot)
-
-
-@pytest.mark.asyncio
-async def test_ui_preserves_auto_theme_when_selection_is_unchanged() -> None:
-    app = OnboardingApp()
-
-    async with app.run_test() as pilot:
-        await _pass_welcome_screen(pilot)
-
-        theme_screen = app.screen
-        assert isinstance(theme_screen, ThemeSelectionScreen)
-        assert theme_screen.selected_theme == AUTO_THEME
-
-        await pilot.press("enter")
-        await _wait_for(lambda: isinstance(app.screen, AuthMethodScreen), pilot)
-
-    assert app.selected_theme == AUTO_THEME
-
-
-@pytest.mark.asyncio
-async def test_ui_can_pick_a_theme_and_saves_selection() -> None:
-    app = OnboardingApp()
-
-    async with app.run_test() as pilot:
-        await _pass_welcome_screen(pilot)
-
-        theme_screen = app.screen
-        assert isinstance(theme_screen, ThemeSelectionScreen)
-        app.post_message(Resize(Size(40, 10), Size(40, 10)))
-        preview = theme_screen.query_one("#preview")
-        assert preview.styles.max_height is not None
-
-        target_theme = "gruvbox"
-        assert target_theme in THEMES
-        start_index = theme_screen._theme_index
-        target_index = THEMES.index(target_theme)
-        steps_down = (target_index - start_index) % len(THEMES)
-        await pilot.press(*["down"] * steps_down)
-        assert app.theme == target_theme
-
-        await pilot.press("enter")
-        await _wait_for(lambda: isinstance(app.screen, AuthMethodScreen), pilot)
-
-    # Persistence is the caller's job; the app carries the selection out via its
-    # live theme for the caller to persist through its orchestrator.
-    assert app.theme == target_theme
-
-
-def test_api_key_screen_falls_back_to_mistral_for_provider_without_env_key() -> None:
-    screen = ApiKeyScreen(
-        provider=ProviderConfig(
-            name="llamacpp", api_base="http://127.0.0.1:8080/v1", api_key_env_var=""
-        )
-    )
-
-    assert screen.provider.name == "mistral"
-    assert screen.provider.api_key_env_var == "MISTRAL_API_KEY"
-
-
-def test_api_key_screen_keeps_provider_with_explicit_env_key() -> None:
-    provider = ProviderConfig(
-        name="custom",
-        api_base="https://custom.example/v1",
-        api_key_env_var="CUSTOM_API_KEY",
-    )
-
-    screen = ApiKeyScreen(provider=provider)
-
-    assert screen.provider == provider
-
-
-def test_api_key_screen_uses_mistral_fallback_for_context_without_env_key(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        "vibe.setup.auth.api_key_persistence._load_onboarding_provider",
-        lambda: ProviderConfig(
-            name="llamacpp", api_base="http://127.0.0.1:8080/v1", api_key_env_var=""
-        ),
-    )
-
-    screen = ApiKeyScreen()
-
-    assert screen.provider.name == "mistral"
-    assert screen.provider.api_key_env_var == "MISTRAL_API_KEY"
-
-
-@pytest.mark.asyncio
-async def test_ui_manual_api_key_screen_uses_configured_vibe_url() -> None:
-    app = OnboardingApp(
-        config=_build_onboarding_config(vibe_base_url="https://vibe.example.com/")
-    )
-
-    async with app.run_test() as pilot:
-        await _show_manual_api_key_screen(pilot)
-
-        provider_link = app.screen.query_one("#api-key-provider-link", Link)
-
-    assert provider_link.url == "https://vibe.example.com/code/extensions?focus=key"
-
-
-def test_persist_api_key_returns_save_error_for_invalid_env_var_name() -> None:
-    provider = ProviderConfig(
-        name="custom", api_base="https://custom.example/v1", api_key_env_var="BAD=NAME"
-    )
-
-    result = persist_api_key(provider, "secret")
-
-    assert result == "env_var_error:BAD=NAME"
-
-
-def test_persist_api_key_returns_env_var_error_for_empty_env_var_name() -> None:
-    provider = ProviderConfig(
-        name="custom", api_base="https://custom.example/v1", api_key_env_var=""
-    )
-
-    result = persist_api_key(provider, "secret")
-
-    assert result == "env_var_error:<empty>"
-
-
-def test_persist_api_key_sends_onboarding_telemetry_with_launch_context(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    recorded_metadata: dict[str, str] = {}
-
-    def capture(self: TelemetryClient) -> None:
-        recorded_metadata.update(self.build_client_event_metadata())
-
-    monkeypatch.setattr(TelemetryClient, "send_onboarding_api_key_added", capture)
-
-    provider = ProviderConfig(
-        name="mistral",
-        api_base="https://inference.mistral.test/v1",
-        api_key_env_var="MISTRAL_API_KEY",
-        backend=Backend.MISTRAL,
-    )
-
-    result = persist_api_key(
-        provider,
-        "secret",
-        launch_context=build_launch_context(
-            agent_entrypoint="cli",
-            agent_version="1.0.0",
-            client_name="vibe_cli",
-            client_version="1.0.0",
-            terminal_emulator=TerminalEmulator.APPLE_TERMINAL,
-        ),
-    )
-
-    assert result == "completed"
-    assert recorded_metadata["agent_entrypoint"] == "cli"
-    assert recorded_metadata["agent_version"] == "1.0.0"
-    assert recorded_metadata["client_name"] == "vibe_cli"
-    assert recorded_metadata["client_version"] == "1.0.0"
-    assert recorded_metadata["terminal_emulator"] == "apple_terminal"
-    assert "session_id" not in recorded_metadata

--- a/tests/setup/onboarding/test_onboarding.py
+++ b/tests/setup/onboarding/test_onboarding.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from textual.events import Resize
+from textual.geometry import Size
+from textual.widgets import Input, Link, Static
+
+from tests.conftest import build_test_vibe_config
+from tests.setup.onboarding._test_helpers import (
+    BROWSER_AUTH_API_URL,
+    CONSOLE_URL,
+    build_browser_onboarding_app as _build_browser_onboarding_app,
+    build_onboarding_config as _build_onboarding_config,
+    pass_theme_selection_screen as _pass_theme_selection_screen,
+    pass_welcome_screen as _pass_welcome_screen,
+    saved_env_contents as _saved_env_contents,
+    show_auth_method as _show_auth_method,
+    show_browser_sign_in as _show_browser_sign_in,
+    show_manual_api_key_screen as _show_manual_api_key_screen,
+    wait_for as _wait_for,
+)
+from tests.stubs.fake_browser_sign_in_gateway import (
+    build_browser_sign_in_service_factory,
+    build_completed_poll_script,
+)
+from vibe.core.config import (
+    AUTO_THEME,
+    DEFAULT_MISTRAL_BROWSER_AUTH_API_BASE_URL,
+    DEFAULT_MISTRAL_BROWSER_AUTH_BASE_URL,
+    ProviderConfig,
+)
+from vibe.core.config.harness_files import (
+    init_harness_files_manager,
+    reset_harness_files_manager,
+)
+from vibe.core.telemetry.build_metadata import build_launch_context
+from vibe.core.telemetry.send import TelemetryClient
+from vibe.core.telemetry.types import TerminalEmulator
+from vibe.core.types import Backend
+from vibe.setup.auth import BrowserSignInError, BrowserSignInErrorCode
+from vibe.setup.auth.api_key_persistence import persist_api_key
+import vibe.setup.onboarding as onboarding_module
+from vibe.setup.onboarding import OnboardingApp
+from vibe.setup.onboarding.screens.api_key import ApiKeyScreen
+from vibe.setup.onboarding.screens.auth_method import AuthMethodScreen
+from vibe.setup.onboarding.screens.theme_selection import THEMES, ThemeSelectionScreen
+from vibe.setup.onboarding.screens.welcome import HIGHLIGHT_END, WelcomeScreen
+
+
+def _patch_failing_browser_sign_in_service(
+    monkeypatch: pytest.MonkeyPatch, captured_base_urls: list[tuple[str, str]]
+) -> None:
+    class FakeGateway:
+        def __init__(self, browser_base_url: str, api_base_url: str) -> None:
+            captured_base_urls.append((browser_base_url, api_base_url))
+
+    class FakeService:
+        def __init__(
+            self, gateway: FakeGateway, *, raise_on_browser_open_failure: bool = True
+        ) -> None:
+            if raise_on_browser_open_failure:
+                raise AssertionError(
+                    "Onboarding must tolerate browser launch failures."
+                )
+            self._gateway = gateway
+
+        async def authenticate(self, *args, **kwargs) -> str:
+            raise BrowserSignInError(
+                "Browser sign-in polling failed.",
+                code=BrowserSignInErrorCode.POLL_FAILED,
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(onboarding_module, "HttpBrowserSignInGateway", FakeGateway)
+    monkeypatch.setattr(onboarding_module, "BrowserSignInService", FakeService)
+
+
+def test_welcome_gradient_animation_skips_relayout() -> None:
+    screen = WelcomeScreen()
+    screen._char_index = HIGHLIGHT_END
+    welcome_text = MagicMock(spec=Static)
+    screen._welcome_text = welcome_text
+
+    screen._animate_gradient()
+
+    welcome_text.update.assert_called_once()
+    assert welcome_text.update.call_args.kwargs == {"layout": False}
+
+
+@pytest.mark.asyncio
+async def test_ui_keeps_manual_flow_when_browser_sign_in_is_unsupported() -> None:
+    app = OnboardingApp(
+        config=_build_onboarding_config(
+            browser_auth_base_url="", browser_auth_api_base_url=""
+        )
+    )
+    api_key_value = "sk-onboarding-test-key"
+
+    async with app.run_test() as pilot:
+        await _pass_welcome_screen(pilot)
+        await _pass_theme_selection_screen(pilot)
+        await _wait_for(lambda: isinstance(pilot.app.screen, ApiKeyScreen), pilot)
+        input_widget = app.screen.query_one("#key", Input)
+        await pilot.press(*api_key_value)
+        assert input_widget.value == api_key_value
+        await pilot.press("enter")
+        await _wait_for(lambda: app.return_value is not None, pilot, timeout=2.0)
+
+    assert app.return_value == "completed"
+    assert api_key_value in _saved_env_contents()
+
+
+@pytest.mark.asyncio
+async def test_ui_supports_browser_sign_in_when_provider_supports_it() -> None:
+    _, browser_sign_in_service_factory, _ = build_browser_sign_in_service_factory(
+        poll_scripts=[build_completed_poll_script()]
+    )
+    app = OnboardingApp(
+        config=_build_onboarding_config(
+            browser_auth_base_url=CONSOLE_URL,
+            browser_auth_api_base_url=BROWSER_AUTH_API_URL,
+        ),
+        browser_sign_in_service_factory=browser_sign_in_service_factory,
+    )
+
+    assert app.supports_browser_sign_in is True
+
+    async with app.run_test() as pilot:
+        await _show_auth_method(pilot)
+
+
+@pytest.mark.asyncio
+async def test_ui_offers_browser_sign_in_for_renamed_mistral_provider() -> None:
+    app = OnboardingApp(
+        config=_build_onboarding_config(
+            provider_name="customer-mistral",
+            backend=Backend.MISTRAL,
+            browser_auth_base_url=CONSOLE_URL,
+            browser_auth_api_base_url=BROWSER_AUTH_API_URL,
+        )
+    )
+
+    assert app.supports_browser_sign_in is True
+
+    async with app.run_test() as pilot:
+        await _show_auth_method(pilot)
+
+
+@pytest.mark.asyncio
+async def test_ui_allows_manual_path_when_browser_sign_in_is_supported() -> None:
+    app = _build_browser_onboarding_app()
+    api_key_value = "sk-manual-onboarding-test-key"
+
+    async with app.run_test() as pilot:
+        await _show_auth_method(pilot)
+        await pilot.press("down", "enter")
+        await _wait_for(lambda: isinstance(pilot.app.screen, ApiKeyScreen), pilot)
+        input_widget = app.screen.query_one("#key", Input)
+        await pilot.press(*api_key_value)
+        await pilot.press("enter")
+        await _wait_for(lambda: app.return_value is not None, pilot, timeout=2.0)
+        assert input_widget.value == api_key_value
+
+    assert app.return_value == "completed"
+    assert api_key_value in _saved_env_contents()
+
+
+@pytest.mark.asyncio
+async def test_ui_uses_default_mistral_browser_auth_urls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_base_urls: list[tuple[str, str]] = []
+    _patch_failing_browser_sign_in_service(monkeypatch, captured_base_urls)
+
+    app = OnboardingApp(config=build_test_vibe_config())
+
+    assert app.supports_browser_sign_in is True
+
+    async with app.run_test() as pilot:
+        await _show_browser_sign_in(pilot)
+        await _wait_for(lambda: bool(captured_base_urls), pilot)
+
+    assert captured_base_urls == [
+        (
+            DEFAULT_MISTRAL_BROWSER_AUTH_BASE_URL,
+            DEFAULT_MISTRAL_BROWSER_AUTH_API_BASE_URL,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ui_preserves_custom_browser_auth_urls_when_api_key_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    monkeypatch.setenv("VIBE_HOME", str(tmp_path))
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        "\n".join([
+            'active_model = "devstral-2"',
+            "[[providers]]",
+            'name = "mistral"',
+            'api_base = "https://api.mistral.ai/v1"',
+            'api_key_env_var = "MISTRAL_API_KEY"',
+            'browser_auth_base_url = "http://127.0.0.1:8787"',
+            'browser_auth_api_base_url = "http://127.0.0.1:8787"',
+            'backend = "mistral"',
+            "",
+            "[[models]]",
+            'name = "mistral-vibe-cli-latest"',
+            'provider = "mistral"',
+            'alias = "devstral-2"',
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    reset_harness_files_manager()
+    init_harness_files_manager("user")
+    captured_base_urls: list[tuple[str, str]] = []
+    _patch_failing_browser_sign_in_service(monkeypatch, captured_base_urls)
+
+    app = OnboardingApp()
+
+    assert app.supports_browser_sign_in is True
+
+    async with app.run_test() as pilot:
+        await _show_browser_sign_in(pilot)
+        await _wait_for(lambda: bool(captured_base_urls), pilot)
+
+    assert captured_base_urls == [("http://127.0.0.1:8787", "http://127.0.0.1:8787")]
+
+
+@pytest.mark.asyncio
+async def test_ui_falls_back_to_default_onboarding_context_with_invalid_active_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    monkeypatch.setenv("VIBE_HOME", str(tmp_path))
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        "\n".join([
+            'active_model = "does-not-exist"',
+            "",
+            "[[providers]]",
+            'name = "mistral"',
+            'api_base = "https://api.mistral.ai/v1"',
+            'api_key_env_var = "MISTRAL_API_KEY"',
+            'browser_auth_base_url = "https://console.mistral.ai"',
+            'browser_auth_api_base_url = "https://console.mistral.ai/api"',
+            'backend = "mistral"',
+            "",
+            "[[models]]",
+            'name = "mistral-vibe-cli-latest"',
+            'provider = "mistral"',
+            'alias = "devstral-2"',
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    reset_harness_files_manager()
+    init_harness_files_manager("user")
+
+    app = OnboardingApp()
+
+    assert app.supports_browser_sign_in is True
+
+    async with app.run_test() as pilot:
+        await _show_auth_method(pilot)
+
+
+@pytest.mark.asyncio
+async def test_ui_preserves_auto_theme_when_selection_is_unchanged() -> None:
+    app = OnboardingApp()
+
+    async with app.run_test() as pilot:
+        await _pass_welcome_screen(pilot)
+
+        theme_screen = app.screen
+        assert isinstance(theme_screen, ThemeSelectionScreen)
+        assert theme_screen.selected_theme == AUTO_THEME
+
+        await pilot.press("enter")
+        await _wait_for(lambda: isinstance(app.screen, AuthMethodScreen), pilot)
+
+    assert app.selected_theme == AUTO_THEME
+
+
+@pytest.mark.asyncio
+async def test_ui_can_pick_a_theme_and_saves_selection() -> None:
+    app = OnboardingApp()
+
+    async with app.run_test() as pilot:
+        await _pass_welcome_screen(pilot)
+
+        theme_screen = app.screen
+        assert isinstance(theme_screen, ThemeSelectionScreen)
+        app.post_message(Resize(Size(40, 10), Size(40, 10)))
+        preview = theme_screen.query_one("#preview")
+        assert preview.styles.max_height is not None
+
+        target_theme = "gruvbox"
+        assert target_theme in THEMES
+        start_index = theme_screen._theme_index
+        target_index = THEMES.index(target_theme)
+        steps_down = (target_index - start_index) % len(THEMES)
+        await pilot.press(*["down"] * steps_down)
+        assert app.theme == target_theme
+
+        await pilot.press("enter")
+        await _wait_for(lambda: isinstance(app.screen, AuthMethodScreen), pilot)
+
+    assert app.theme == target_theme
+
+
+def test_api_key_screen_falls_back_to_mistral_for_provider_without_env_key() -> None:
+    screen = ApiKeyScreen(
+        provider=ProviderConfig(
+            name="llamacpp", api_base="http://127.0.0.1:8080/v1", api_key_env_var=""
+        )
+    )
+
+    assert screen.provider.name == "mistral"
+    assert screen.provider.api_key_env_var == "MISTRAL_API_KEY"
+
+
+def test_api_key_screen_keeps_provider_with_explicit_env_key() -> None:
+    provider = ProviderConfig(
+        name="custom",
+        api_base="https://custom.example/v1",
+        api_key_env_var="CUSTOM_API_KEY",
+    )
+
+    screen = ApiKeyScreen(provider=provider)
+
+    assert screen.provider == provider
+
+
+def test_api_key_screen_uses_mistral_fallback_for_context_without_env_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "vibe.setup.auth.api_key_persistence._load_onboarding_provider",
+        lambda: ProviderConfig(
+            name="llamacpp", api_base="http://127.0.0.1:8080/v1", api_key_env_var=""
+        ),
+    )
+
+    screen = ApiKeyScreen()
+
+    assert screen.provider.name == "mistral"
+    assert screen.provider.api_key_env_var == "MISTRAL_API_KEY"
+
+
+@pytest.mark.asyncio
+async def test_ui_manual_api_key_screen_uses_configured_vibe_url() -> None:
+    app = OnboardingApp(
+        config=_build_onboarding_config(vibe_base_url="https://vibe.example.com/")
+    )
+
+    async with app.run_test() as pilot:
+        await _show_manual_api_key_screen(pilot)
+
+        provider_link = app.screen.query_one("#api-key-provider-link", Link)
+
+    assert provider_link.url == "https://vibe.example.com/code/extensions?focus=key"
+
+
+def test_persist_api_key_returns_save_error_for_invalid_env_var_name() -> None:
+    provider = ProviderConfig(
+        name="custom", api_base="https://custom.example/v1", api_key_env_var="BAD=NAME"
+    )
+
+    result = persist_api_key(provider, "secret")
+
+    assert result == "env_var_error:BAD=NAME"
+
+
+def test_persist_api_key_returns_env_var_error_for_empty_env_var_name() -> None:
+    provider = ProviderConfig(
+        name="custom", api_base="https://custom.example/v1", api_key_env_var=""
+    )
+
+    result = persist_api_key(provider, "secret")
+
+    assert result == "env_var_error:<empty>"
+
+
+def test_persist_api_key_sends_onboarding_telemetry_with_launch_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded_metadata: dict[str, str] = {}
+
+    def capture(self: TelemetryClient) -> None:
+        recorded_metadata.update(self.build_client_event_metadata())
+
+    monkeypatch.setattr(TelemetryClient, "send_onboarding_api_key_added", capture)
+
+    provider = ProviderConfig(
+        name="mistral",
+        api_base="https://inference.mistral.test/v1",
+        api_key_env_var="MISTRAL_API_KEY",
+        backend=Backend.MISTRAL,
+    )
+
+    result = persist_api_key(
+        provider,
+        "secret",
+        launch_context=build_launch_context(
+            agent_entrypoint="cli",
+            agent_version="1.0.0",
+            client_name="vibe_cli",
+            client_version="1.0.0",
+            terminal_emulator=TerminalEmulator.APPLE_TERMINAL,
+        ),
+    )
+
+    assert result == "completed"
+    assert recorded_metadata["agent_entrypoint"] == "cli"
+    assert recorded_metadata["agent_version"] == "1.0.0"
+    assert recorded_metadata["client_name"] == "vibe_cli"
+    assert recorded_metadata["client_version"] == "1.0.0"
+    assert recorded_metadata["terminal_emulator"] == "apple_terminal"
+    assert "session_id" not in recorded_metadata

--- a/tests/stubs/fake_browser_sign_in_gateway.py
+++ b/tests/stubs/fake_browser_sign_in_gateway.py
@@ -14,6 +14,9 @@ from vibe.setup.auth import (
 )
 from vibe.setup.auth.browser_sign_in import BrowserSignInService
 
+BrowserSignInPollScript = tuple[BrowserSignInPollResult | BrowserSignInError, ...]
+PollWaiter = Callable[[int], Awaitable[None]]
+
 
 @dataclass
 class ExchangeRequestPayload:
@@ -22,24 +25,28 @@ class ExchangeRequestPayload:
     code_verifier: str
 
 
-class StubBrowserSignInGateway(BrowserSignInGateway):
+class FakeBrowserSignInGateway(BrowserSignInGateway):
     def __init__(
         self,
         *,
         process: BrowserSignInProcess | None = None,
         processes: list[BrowserSignInProcess] | None = None,
+        start_error: BrowserSignInError | None = None,
         poll_results: list[BrowserSignInPollResult | BrowserSignInError] | None = None,
         exchange_result: str = "sk-browser-key",
         exchange_error: BrowserSignInError | None = None,
+        wait_before_poll_result: PollWaiter | None = None,
     ) -> None:
         if process is not None and processes is not None:
-            msg = "StubBrowserSignInGateway accepts either process or processes."
+            msg = "FakeBrowserSignInGateway accepts either process or processes."
             raise AssertionError(msg)
 
         self._processes = list(processes or ([] if process is None else [process]))
+        self._start_error = start_error
         self._poll_results = list(poll_results or [])
         self.exchange_result = exchange_result
         self.exchange_error = exchange_error
+        self._wait_before_poll_result = wait_before_poll_result
         self.code_challenges: list[str] = []
         self.polled_urls: list[str] = []
         self.exchange_requests: list[ExchangeRequestPayload] = []
@@ -49,8 +56,10 @@ class StubBrowserSignInGateway(BrowserSignInGateway):
 
     async def create_process(self, code_challenge: str) -> BrowserSignInProcess:
         self.code_challenges.append(code_challenge)
+        if self._start_error is not None:
+            raise self._start_error
         if not self._processes:
-            msg = "StubBrowserSignInGateway requires at least one scripted process."
+            msg = "FakeBrowserSignInGateway requires at least one scripted process."
             raise AssertionError(msg)
 
         self.process_number += 1
@@ -59,8 +68,10 @@ class StubBrowserSignInGateway(BrowserSignInGateway):
     async def poll(self, poll_url: str) -> BrowserSignInPollResult:
         self.polled_urls.append(poll_url)
         self.poll_calls += 1
+        if self._wait_before_poll_result is not None:
+            await self._wait_before_poll_result(self.poll_calls)
         if not self._poll_results:
-            msg = "StubBrowserSignInGateway requires scripted poll results."
+            msg = "FakeBrowserSignInGateway requires scripted poll results."
             raise AssertionError(msg)
         result = self._poll_results.pop(0)
         if isinstance(result, BrowserSignInError):
@@ -112,8 +123,32 @@ def build_poll_failed_error() -> BrowserSignInError:
     )
 
 
-def build_poll_results_from_outcomes(
-    outcomes: list[str],
+def build_completed_poll_script(
+    process_id: str = "process-1",
+) -> BrowserSignInPollScript:
+    return (
+        BrowserSignInPollResult(status="pending"),
+        BrowserSignInPollResult(
+            status="completed", exchange_token=f"exchange-{process_id}"
+        ),
+    )
+
+
+def build_expired_poll_script() -> BrowserSignInPollScript:
+    return (BrowserSignInPollResult(status="expired"),)
+
+
+def build_poll_failed_script() -> BrowserSignInPollScript:
+    return (
+        BrowserSignInPollResult(status="pending"),
+        build_poll_failed_error(),
+        build_poll_failed_error(),
+        build_poll_failed_error(),
+    )
+
+
+def build_processes_and_poll_results(
+    poll_scripts: list[BrowserSignInPollScript],
 ) -> tuple[
     list[BrowserSignInProcess], list[BrowserSignInPollResult | BrowserSignInError]
 ]:
@@ -121,30 +156,10 @@ def build_poll_results_from_outcomes(
     poll_results: list[BrowserSignInPollResult | BrowserSignInError] = []
     now = datetime(2026, 3, 16, tzinfo=UTC)
 
-    for process_index, outcome in enumerate(outcomes, start=1):
+    for process_index, poll_script in enumerate(poll_scripts, start=1):
         process_id = f"process-{process_index}"
         processes.append(build_sign_in_process(now, process_id=process_id))
-
-        match outcome:
-            case "completed":
-                poll_results.extend([
-                    BrowserSignInPollResult(status="pending"),
-                    BrowserSignInPollResult(
-                        status="completed", exchange_token=f"exchange-{process_id}"
-                    ),
-                ])
-            case "expired":
-                poll_results.append(BrowserSignInPollResult(status="expired"))
-            case "poll_failed":
-                poll_results.extend([
-                    BrowserSignInPollResult(status="pending"),
-                    build_poll_failed_error(),
-                    build_poll_failed_error(),
-                    build_poll_failed_error(),
-                ])
-            case _:
-                msg = f"Unsupported browser sign-in outcome: {outcome}"
-                raise AssertionError(msg)
+        poll_results.extend(poll_script)
 
     return processes, poll_results
 
@@ -154,20 +169,25 @@ async def noop_sleep(_: float) -> None:
 
 
 def build_browser_sign_in_service_factory(
-    outcomes: list[str],
+    poll_scripts: list[BrowserSignInPollScript],
     *,
     exchange_result: str = "sk-browser-onboarding-test-key",
     open_browser: Callable[[str], bool] | None = None,
+    raise_on_browser_open_failure: bool = True,
     sleep: Callable[[float], Awaitable[None]] = noop_sleep,
     now: Callable[[], datetime] | None = None,
+    wait_before_poll_result: PollWaiter | None = None,
 ) -> tuple[
-    StubBrowserSignInGateway,
+    FakeBrowserSignInGateway,
     Callable[[], BrowserSignInService],
     list[BrowserSignInService],
 ]:
-    processes, poll_results = build_poll_results_from_outcomes(outcomes)
-    gateway = StubBrowserSignInGateway(
-        processes=processes, poll_results=poll_results, exchange_result=exchange_result
+    processes, poll_results = build_processes_and_poll_results(poll_scripts)
+    gateway = FakeBrowserSignInGateway(
+        processes=processes,
+        poll_results=poll_results,
+        exchange_result=exchange_result,
+        wait_before_poll_result=wait_before_poll_result,
     )
     created_services: list[BrowserSignInService] = []
 
@@ -175,6 +195,7 @@ def build_browser_sign_in_service_factory(
         service = BrowserSignInService(
             gateway,
             open_browser=open_browser or (lambda _: True),
+            raise_on_browser_open_failure=raise_on_browser_open_failure,
             sleep=sleep,
             now=now
             or (

--- a/vibe/setup/auth/browser_sign_in.py
+++ b/vibe/setup/auth/browser_sign_in.py
@@ -62,12 +62,14 @@ class BrowserSignInService:
         gateway: BrowserSignInGateway,
         *,
         open_browser: BrowserOpener | None = None,
+        raise_on_browser_open_failure: bool = True,
         sleep: SleepFn = asyncio.sleep,
         now: NowFn | None = None,
         poll_interval: float = 3.0,
     ) -> None:
         self._gateway = gateway
         self._open_browser = open_browser or webbrowser.open
+        self._raise_on_browser_open_failure = raise_on_browser_open_failure
         self._sleep = sleep
         self._now = now or (lambda: datetime.now(UTC))
         self._poll_interval = poll_interval
@@ -99,7 +101,14 @@ class BrowserSignInService:
         if event_callback is not None:
             event_callback(event)
         self._emit_status(event_callback, BrowserSignInStatus.OPENING_BROWSER)
-        self._open_browser_or_raise(attempt.sign_in_url)
+        try:
+            self._open_browser_or_raise(attempt.sign_in_url)
+        except BrowserSignInError as err:
+            if (
+                self._raise_on_browser_open_failure
+                or err.code is not BrowserSignInErrorCode.OPEN_BROWSER_FAILED
+            ):
+                raise
         return await self._complete_attempt(attempt, event_callback=event_callback)
 
     async def _complete_attempt(

--- a/vibe/setup/onboarding/__init__.py
+++ b/vibe/setup/onboarding/__init__.py
@@ -121,7 +121,8 @@ class OnboardingApp(App[str | None]):
         return lambda: BrowserSignInService(
             HttpBrowserSignInGateway(
                 browser_base_url=browser_base_url, api_base_url=api_base_url
-            )
+            ),
+            raise_on_browser_open_failure=False,
         )
 
     def _resolve_browser_sign_in_factory(

--- a/vibe/setup/onboarding/screens/browser_sign_in.py
+++ b/vibe/setup/onboarding/screens/browser_sign_in.py
@@ -54,7 +54,7 @@ SUCCESS_EXIT_DELAY_SECONDS: float = 2.0
 SIGN_IN_URL_HELP_DELAY_SECONDS: float = 4.0
 WAITING_FOR_AUTHENTICATION_MESSAGE = "Waiting for authentication..."
 STEP_DESCRIPTIONS = [
-    ("Open browser", "Your browser should open automatically", "Browser opened"),
+    ("Open browser", "Your browser should open automatically", "Sign-in page ready"),
     ("Complete sign-in", WAITING_FOR_AUTHENTICATION_MESSAGE, "Sign-in confirmed."),
     ("Finished setup", "Vibe will start automatically", "Setup complete."),
 ]


### PR DESCRIPTION
## Summary

- continue the existing browser sign-in attempt when local browser launch fails during onboarding
- keep the copy-URL fallback active while Vibe polls for authorization
- preserve strict browser-launch failure behavior for ACP and existing programmatic callers
- replace the misleading `Browser opened` status with `Sign-in page ready`
- cover false-return and exception launch failures, terminal polling errors, Textual completion, and ACP compatibility

## Root cause

`BrowserSignInService.authenticate()` raised `OPEN_BROWSER_FAILED` before calling the existing polling flow. In headless or container environments, the sign-in URL remained copyable, but the worker had already stopped and the gateway had been closed, so Vibe could not observe authorization completed in another browser.

## Behavior

Browser launch failure policy is now fixed when `BrowserSignInService` is constructed. The default remains strict. The onboarding factory opts into tolerant behavior and continues the same PKCE attempt through polling and token exchange. Other authentication failures, cancellation, expiry, URL validation, and ACP behavior remain unchanged.

The affected tests were also moved to mirror the source layout required by the repository conventions.

## Tests

- `uv run pytest -q tests/setup/auth/test_browser_sign_in.py tests/setup/onboarding/screens/test_browser_sign_in.py tests/setup/onboarding/test_onboarding.py tests/acp/test_authenticate.py` (74 passed)
- `uv run pyright`
- `uv run ruff check --fix .`
- `uv run ruff format .`
- `uv run pre-commit run --all-files`

Refs #941
