### PR TITLE
fix(security): disable git fsmonitor hook execution in project context gathering

### DIFF
--- a/tests/core/test_system_prompt.py
+++ b/tests/core/test_system_prompt.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import subprocess
 
 import pytest
 
@@ -25,3 +26,60 @@ def test_run_git_survives_non_utf8_output(tmp_path: Path, monkeypatch) -> None:
 
     # The bad bytes are replaced with U+FFFD instead of crashing
     assert "\ufffd" in result.stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="fake git shell script is POSIX-only")
+def test_run_git_disables_fsmonitor_hook(tmp_path: Path, monkeypatch) -> None:
+    # Fake git that records the argv it was invoked with, one arg per line.
+    fake_git = tmp_path / "git"
+    fake_git.write_text('#!/bin/sh\nfor a in "$@"; do echo "$a"; done\n')
+    fake_git.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+
+    provider = ProjectContextProvider(ProjectContextConfig(), root_path=tmp_path)
+    result = provider._run_git(["status", "--porcelain"], timeout=5.0)
+
+    argv = result.stdout.splitlines()
+    # -c core.fsmonitor= must come before any positional git subcommand so it
+    # actually overrides the repo's own config, and must not be overridable by
+    # anything the invoked repo could inject via its own .git/config.
+    assert "-c" in argv
+    assert argv[argv.index("-c") + 1] == "core.fsmonitor="
+    assert argv.index("-c") < argv.index("status")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="uses a POSIX shell payload")
+def test_fetch_git_status_does_not_execute_malicious_fsmonitor_hook(
+    tmp_path: Path,
+) -> None:
+    # Regression test for the RCE reported in #942: a repo's own .git/config
+    # can declare core.fsmonitor as an arbitrary command, which git runs on
+    # `status` (and other worktree-refreshing commands) with the invoking
+    # user's full privileges -- and this runs on every session start, before
+    # any trust dialog is shown to the user.
+    repo = tmp_path / "malicious_repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "README.md").write_text("# README\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+
+    payload_marker = tmp_path / "PWNED"
+    subprocess.run(
+        ["git", "config", "core.fsmonitor", f"touch {payload_marker}"],
+        cwd=repo,
+        check=True,
+    )
+
+    provider = ProjectContextProvider(ProjectContextConfig(), root_path=repo)
+    status = provider.get_git_status()
+
+    assert not payload_marker.exists()
+    # The fix must not break normal status reporting.
+    assert "Current branch:" in status
+    assert "Git operations timed out" not in status
+    assert "Not a git repository" not in status

--- a/vibe/core/system_prompt.py
+++ b/vibe/core/system_prompt.py
@@ -52,7 +52,16 @@ class ProjectContextProvider:
         self, args: list[str], timeout: float
     ) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
-            ["git", "--no-optional-locks", *args],
+            # -c core.fsmonitor= overrides (and disables) any fsmonitor hook a
+            # repo's own .git/config declares, for this invocation only. This
+            # runs unconditionally on session start, before any trust prompt,
+            # so a malicious repo cloned/opened by the user could otherwise use
+            # `[core] fsmonitor = <payload>` to get its command executed by
+            # `git status`/`git branch`/`git log` here with the user's full
+            # privileges. -c on the command line takes precedence over the
+            # repo's own config, so this can't be overridden by the repo being
+            # inspected.
+            ["git", "-c", "core.fsmonitor=", "--no-optional-locks", *args],
             capture_output=True,
             check=True,
             cwd=self.root_path,


### PR DESCRIPTION
Fixes #942.

## Summary

`ProjectContextProvider._run_git()` runs `git status`/`branch`/`log` via `subprocess.run(["git", "--no-optional-locks", *args], ...)` on every session start, before any trust dialog is shown to the user (and unconditionally in `-p` programmatic mode too, per the original report).

git's `core.fsmonitor` config can name an arbitrary command that git executes on commands like `status` to refresh the index — and that config is **repo-local**, so a malicious repo the user merely opens or clones can plant

```ini
[core]
    fsmonitor = <payload>
```

in its own `.git/config` and have `<payload>` run with the user's full privileges as soon as `get_git_status()` is called. Reported publicly with a full PoC and **CVSS 3.1 base score 8.8 (High)** in #942.

## Fix

Pass `-c core.fsmonitor=` on the git invocation itself:

```python
["git", "-c", "core.fsmonitor=", "--no-optional-locks", *args]
```

Command-line `-c` overrides take precedence over a repo's own `.git/config`, so this can't be bypassed by whatever the inspected repo declares. Since all four call sites (`branch --show-current`, `branch -r`, `status --porcelain`, `log`) share `_run_git`, one change covers all of them.

## Verification

I reproduced the reported PoC locally before and after the fix, not just read the code and assumed:

```
$ git init POC_REPO && cd POC_REPO && git commit --allow-empty -m init
$ echo 'fsmonitor = "touch /tmp/PWNED"' >> .git/config

# pre-fix invocation:
$ git --no-optional-locks status --porcelain
$ ls /tmp/PWNED
-rw-r--r-- ... /tmp/PWNED          # payload executed

# post-fix invocation:
$ git -c core.fsmonitor= --no-optional-locks status --porcelain
$ ls /tmp/PWNED
ls: cannot access '/tmp/PWNED': No such file or directory   # neutralized, status still correct
```

## Tests

Added two tests to `tests/core/test_system_prompt.py`:
- `test_run_git_disables_fsmonitor_hook` — asserts `-c core.fsmonitor=` is present in the argv actually passed to git, positioned ahead of the subcommand.
- `test_fetch_git_status_does_not_execute_malicious_fsmonitor_hook` — full end-to-end reproduction of the #942 PoC against a real git repo; asserts the payload marker is never created and `get_git_status()` still returns a normal, non-error status string.

Both confirmed to **fail** against the pre-fix code (`git stash` isolating just `system_prompt.py`) — the malicious-hook test's failure is the payload marker file actually being created by the test harness itself, i.e. a live reproduction of the RCE, not just an assertion mismatch.

```
uv run pytest tests/ -q
# 8084 passed, 17 skipped, 5 failed -- same 5 pre-existing failures
# reproduced against a clean upstream/main checkout (TUI widget mounting,
# file-fingerprint mtime-resolution timing, two unrelated e2e timeouts,
# latin1 grep-encoding matching); none touch system_prompt.py or this
# call path.

uv run ruff check / ruff format --check
# clean
```