### PR TITLE
fix(mcp): preserve Windows stdio command paths

### DIFF
--- a/tests/core/config/test_models.py
+++ b/tests/core/config/test_models.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+
+from vibe.core.config import MCPStdio
+import vibe.core.config.models as config_models
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        r"C:\Program Files\some-tool\tool.exe",
+        r"C:\tools\server.exe",
+        r"\\server\share\server.exe",
+    ],
+)
+def test_windows_mcp_command_preserves_absolute_native_path(
+    monkeypatch, command
+) -> None:
+    monkeypatch.setattr(config_models, "is_windows", lambda: True)
+    config = MCPStdio(name="test", transport="stdio", command=command)
+
+    assert config.argv() == [command]
+
+
+def test_windows_mcp_command_appends_args_unchanged(monkeypatch) -> None:
+    monkeypatch.setattr(config_models, "is_windows", lambda: True)
+    command = r"C:\Program Files\some-tool\tool.exe"
+    args = ["--stdio", "value with space"]
+    config = MCPStdio(name="test", transport="stdio", command=command, args=args)
+
+    assert config.argv() == [command, *args]
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (r"C:tools\server.exe", [r"C:toolsserver.exe"]),
+        ("python -m server --port 8080", ["python", "-m", "server", "--port", "8080"]),
+        ("C:/tools/server.exe --stdio", ["C:/tools/server.exe", "--stdio"]),
+        ("", []),
+    ],
+)
+def test_mcp_stdio_argv_preserves_historical_string_commands(
+    monkeypatch, command, expected
+) -> None:
+    monkeypatch.setattr(config_models, "is_windows", lambda: True)
+    config = MCPStdio(name="test", transport="stdio", command=command)
+
+    assert config.argv() == expected
+
+
+def test_mcp_stdio_argv_preserves_explicit_list_and_args(monkeypatch) -> None:
+    monkeypatch.setattr(config_models, "is_windows", lambda: True)
+    command = ["python", "-m", "server"]
+    args = ["--port", "8080"]
+    config = MCPStdio(name="test", transport="stdio", command=command, args=args)
+
+    assert config.argv() == [*command, *args]
+
+
+def test_mcp_stdio_argv_preserves_non_windows_behavior(monkeypatch) -> None:
+    monkeypatch.setattr(config_models, "is_windows", lambda: False)
+    command = r"C:\Program Files\some-tool\tool.exe"
+    config = MCPStdio(name="test", transport="stdio", command=command)
+
+    assert config.argv() == ["C:Program", "Filessome-tooltool.exe"]
+
+
+@pytest.mark.parametrize(
+    ("windows", "command", "args"),
+    [
+        (True, r"C:\Program Files\some-tool\tool.exe", []),
+        (True, r"C:\tools\server.exe", []),
+        (True, r"\\server\share\server.exe", []),
+        (True, r"C:\Program Files\some-tool\tool.exe", ["--stdio", "value with space"]),
+        (True, r"C:tools\server.exe", []),
+        (True, "python -m server --port 8080", []),
+        (True, ["python", "-m", "server"], ["--port", "8080"]),
+        (False, r"C:\Program Files\some-tool\tool.exe", []),
+        (True, "", []),
+    ],
+)
+def test_mcp_stdio_argv_is_idempotent_across_reloads(
+    monkeypatch, windows, command, args
+) -> None:
+    monkeypatch.setattr(config_models, "is_windows", lambda: windows)
+    data = {"name": "test", "transport": "stdio", "command": command, "args": args}
+    first = MCPStdio.model_validate(data)
+    serialized = first.model_dump()
+    argv = first.argv()
+
+    assert first.argv() == argv
+    assert first.model_dump() == serialized
+
+    reloaded = MCPStdio.model_validate(serialized)
+
+    assert reloaded.command == first.command
+    assert reloaded.args == first.args
+    assert reloaded.argv() == argv
+    assert reloaded.model_dump() == serialized

--- a/vibe/core/config/models.py
+++ b/vibe/core/config/models.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from enum import StrEnum, auto
 import logging
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 import re
 import shlex
 from string import Formatter
@@ -33,6 +33,7 @@ from vibe.core.config._defaults import (
 )
 from vibe.core.paths import SESSION_LOG_DIR
 from vibe.core.types import Backend
+from vibe.utils.platform import is_windows
 
 logger = logging.getLogger(__name__)
 
@@ -377,11 +378,16 @@ class MCPStdio(_MCPBase):
     )
 
     def argv(self) -> list[str]:
-        base = (
-            shlex.split(self.command)
-            if isinstance(self.command, str)
-            else list(self.command or [])
-        )
+        command = self.command
+        if isinstance(command, str):
+            is_native_windows_path = (
+                is_windows()
+                and "\\" in command
+                and PureWindowsPath(command).is_absolute()
+            )
+            base = [command] if is_native_windows_path else shlex.split(command)
+        else:
+            base = list(command)
         return [*base, *self.args] if self.args else base
 
 


### PR DESCRIPTION
## Problem

On Windows, `MCPStdio.argv()` passed every string command through POSIX `shlex.split()`. This consumed backslashes and split executable paths containing spaces before MCP discovery could launch them.

## Root cause

The `command` field supports both historical command lines and executable paths, but its string form was always tokenized with Unix shell rules, including on Windows.

## Change

- Preserve absolute native Windows paths containing backslashes as one executable token.
- Append configured `args` unchanged.
- Keep the existing behavior for composite commands, explicit argv lists, drive-relative paths, forward-slash command lines, empty commands, and non-Windows platforms.
- Add Linux-runnable coverage for drive-rooted paths, UNC paths, compatibility boundaries, reloads, and non-mutation.

## Tests

- `uv run pytest -q tests/core/config/test_models.py tests/tools/test_mcp.py -k "mcp_stdio_argv or windows_mcp_command"`
- `uv run pytest -q tests/cli/test_mcp_command.py tests/acp/test_agent_app_server.py -k "mcp"`
- `uv run pytest -q tests/tools/test_mcp.py -k "persists_real_subprocess_state_across_calls or aclose_terminates_real_subprocess"`
- Full CI-style pytest cycle, including last-failed retries under Bash with the C locale
- Real MCP subprocess probe from TOML decoding through `tools/list`
- `uv run pyright`
- `uv run ruff check --fix .`
- `uv run ruff format .`
- `uv run pre-commit run --all-files --show-diff-on-failure`

## Limits

Native Windows process creation was not available locally. The Windows branch is exercised deterministically on Linux, and the complete path is verified through a real MCP subprocess launch. Ambiguous inline Windows command strings remain outside this change; arguments should use the existing `args` field.

No schema, persistence, README, built-in Vibe Skill, Settings Manager, or Le Chat managed-config update is required.

Refs #536
