### PR TITLE
fix(reasoning): preserve signed thinking blocks

### DIFF
--- a/tests/backend/test_reasoning_adapter.py
+++ b/tests/backend/test_reasoning_adapter.py
@@ -95,6 +95,26 @@ class TestThinkingBlocksConversion:
         payload = _prepare(adapter, provider, messages)
         assert payload["messages"][1]["content"] == "Hello"
 
+    def test_assistant_with_reasoning_signature_to_content_block(
+        self, adapter, provider
+    ):
+        messages = [
+            LLMMessage(role=Role.user, content="Hi"),
+            LLMMessage(
+                role=Role.assistant,
+                reasoning_content="",
+                reasoning_signature="signed-thinking",
+            ),
+        ]
+        payload = _prepare(adapter, provider, messages, thinking="high")
+        assert payload["messages"][1]["content"] == [
+            {
+                "type": "thinking",
+                "thinking": [{"type": "text", "text": ""}],
+                "signature": "signed-thinking",
+            }
+        ]
+
     def test_assistant_with_reasoning_and_tool_calls(self, adapter, provider):
         messages = [
             LLMMessage(role=Role.user, content="Hi"),
@@ -168,6 +188,68 @@ class TestParseThinkingBlocks:
         chunk = adapter.parse_response(data, provider)
         assert chunk.message.content == "Final answer"
         assert chunk.message.reasoning_content == "Let me reason..."
+
+    def test_signed_thinking_round_trip_with_empty_text(self, adapter, provider):
+        data = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "thinking",
+                                "thinking": [{"type": "text", "text": ""}],
+                                "signature": "signed-thinking",
+                            }
+                        ],
+                        "tool_calls": [
+                            {
+                                "id": "tc_1",
+                                "index": 0,
+                                "function": {
+                                    "name": "search",
+                                    "arguments": '{"q": "test"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+
+        chunk = adapter.parse_response(data, provider)
+
+        assert chunk.message.reasoning_content is None
+        assert chunk.message.reasoning_signature == "signed-thinking"
+        payload = _prepare(
+            adapter,
+            provider,
+            [
+                LLMMessage(role=Role.user, content="Hi"),
+                chunk.message,
+                LLMMessage(
+                    role=Role.tool, content="result", tool_call_id="tc_1", name="search"
+                ),
+            ],
+            thinking="high",
+        )
+        assert payload["messages"][1]["content"] == [
+            {
+                "type": "thinking",
+                "thinking": [{"type": "text", "text": ""}],
+                "signature": "signed-thinking",
+            }
+        ]
+        assert payload["messages"][1]["tool_calls"] == [
+            {
+                "id": "tc_1",
+                "type": "function",
+                "function": {"name": "search", "arguments": '{"q": "test"}'},
+                "index": 0,
+            }
+        ]
+        assert payload["messages"][2]["tool_call_id"] == "tc_1"
 
     def test_multiple_thinking_inner_blocks(self, adapter, provider):
         data = {

--- a/vibe/core/llm/backend/reasoning_adapter.py
+++ b/vibe/core/llm/backend/reasoning_adapter.py
@@ -56,13 +56,14 @@ class ReasoningAdapter(APIAdapter):
     def _convert_assistant_message(self, msg: LLMMessage) -> dict[str, Any]:
         result: dict[str, Any] = {"role": "assistant"}
 
-        if msg.reasoning_content:
-            content: list[dict[str, Any]] = [
-                {
-                    "type": "thinking",
-                    "thinking": [{"type": "text", "text": msg.reasoning_content}],
-                }
-            ]
+        if msg.reasoning_content or msg.reasoning_signature:
+            thinking_block: dict[str, Any] = {
+                "type": "thinking",
+                "thinking": [{"type": "text", "text": msg.reasoning_content or ""}],
+            }
+            if msg.reasoning_signature:
+                thinking_block["signature"] = msg.reasoning_signature
+            content: list[dict[str, Any]] = [thinking_block]
             if msg.content:
                 content.append({"type": "text", "text": msg.content})
             result["content"] = content
@@ -122,25 +123,32 @@ class ReasoningAdapter(APIAdapter):
     @staticmethod
     def _parse_content_blocks(
         content: str | list[dict[str, Any]],
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[str | None, str | None, str | None]:
         if isinstance(content, str):
-            return content or None, None
+            return content or None, None, None
 
         text_parts: list[str] = []
         thinking_parts: list[str] = []
+        signature_parts: list[str] = []
 
         for block in content:
             block_type = block.get("type")
             if block_type == "text":
                 text_parts.append(block.get("text", ""))
             elif block_type == "thinking":
+                if isinstance(signature := block.get("signature"), str):
+                    signature_parts.append(signature)
                 for inner in block.get("thinking", []):
                     if isinstance(inner, dict) and inner.get("type") == "text":
                         thinking_parts.append(inner.get("text", ""))
                     elif isinstance(inner, str):
                         thinking_parts.append(inner)
 
-        return ("".join(text_parts) or None, "".join(thinking_parts) or None)
+        return (
+            "".join(text_parts) or None,
+            "".join(thinking_parts) or None,
+            "".join(signature_parts) or None,
+        )
 
     @staticmethod
     def _parse_tool_calls(
@@ -164,14 +172,18 @@ class ReasoningAdapter(APIAdapter):
         content = msg_dict.get("content")
         text_content: str | None = None
         reasoning_content: str | None = None
+        reasoning_signature: str | None = None
 
         if content is not None:
-            text_content, reasoning_content = self._parse_content_blocks(content)
+            text_content, reasoning_content, reasoning_signature = (
+                self._parse_content_blocks(content)
+            )
 
         return LLMMessage(
             role=Role.assistant,
             content=text_content,
             reasoning_content=reasoning_content,
+            reasoning_signature=reasoning_signature,
             tool_calls=self._parse_tool_calls(msg_dict.get("tool_calls")),
         )
 


### PR DESCRIPTION
## Summary

- capture signatures from thinking content blocks returned by reasoning-style endpoints
- preserve the signature on `LLMMessage.reasoning_signature`
- re-emit signed thinking blocks on subsequent requests, including blocks whose visible thinking text is empty
- add regression coverage for response-to-message-to-tool-continuation round trips

## Why

Some OpenAI-compatible gateways return Anthropic signed thinking blocks through the generic reasoning adapter. The adapter preserved the visible reasoning text but discarded the cryptographic signature. The next request could therefore not reproduce the authenticated thinking block, breaking reasoning continuity across tool calls.

This change is limited to the generic reasoning adapter. Native Anthropic and other backend behavior is unchanged.

## Validation

- `uv run pytest -n 0 tests/backend/test_reasoning_adapter.py -q` — 16 passed
- `uv run pytest -n 16 tests/backend -q` — 238 passed
- `uv run pyright` — 0 errors
- `uv run ruff check --fix .`
- `uv run ruff format .`
- `uv run pre-commit run --all-files`