### PR TITLE
fix(chat-input): make Shift+Enter insert newline instead of being swallowed

### DIFF
--- a/vibe/cli/textual_ui/widgets/chat_input/text_area.py
+++ b/vibe/cli/textual_ui/widgets/chat_input/text_area.py
@@ -371,6 +371,7 @@ class ChatTextArea(TextArea):
         if event.key == "shift+enter":
             event.prevent_default()
             event.stop()
+            self.action_insert_newline()
             return
 
         if (


### PR DESCRIPTION
## Summary

Fix a regression where pressing `Shift+Enter` in the chat input silently did nothing instead of inserting a newline. `Ctrl+J` already worked correctly; this makes `Shift+Enter` consistent with it.

## Motivation

Fixes #878. The widget had a binding `shift+enter,ctrl+j` -> `insert_newline`, but `ChatTextArea._on_key` intercepted `shift+enter` before the binding could fire and simply consumed the event without inserting anything.

## Changes

- In `vibe/cli/textual_ui/widgets/chat_input/text_area.py`, call `self.action_insert_newline()` in the `shift+enter` handler branch instead of silently returning.

## Tests

```bash
uv run pytest tests/cli/textual_ui/test_chat_input_keybindings.py -v
```

All 7 tests pass. No regressions.

Fixes #878