### PR TITLE
fix(workflows): build wheels for Windows 11 ARM

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -27,7 +27,8 @@ jobs:
               {"runner": "ubuntu-22.04-arm", "os": "linux", "arch": "aarch64", "container": "quay.io/pypa/manylinux_2_28_aarch64@sha256:360bf4ec4349372e9bcfb123bf11bcc4f085072bfa4f3b946d98f5a28f9c03b0"},
               {"runner": "macos-15-intel", "os": "darwin", "arch": "x86_64"},
               {"runner": "macos-14", "os": "darwin", "arch": "aarch64"},
-              {"runner": "windows-2022", "os": "windows", "arch": "x86_64"}
+              {"runner": "windows-2022", "os": "windows", "arch": "x86_64"},
+              {"runner": "windows-11-arm", "os": "windows", "arch": "aarch64"}
             ]
           }'
           # TODO: Re-enable macOS standalone artifact smoke tests once the PyInstaller
@@ -41,7 +42,8 @@ jobs:
               {"runner": "ubuntu-24.04", "os": "linux", "arch": "x86_64"},
               {"runner": "ubuntu-24.04", "os": "linux", "arch": "x86_64", "tag": "old-glibc", "container": "almalinux:8@sha256:4a87d2615a770506e204c27d6248ac97f4df67f4e41e2e9c47c81f0ed0be98cb"},
               {"runner": "ubuntu-24.04-arm", "os": "linux", "arch": "aarch64"},
-              {"runner": "windows-latest", "os": "windows", "arch": "x86_64"}
+              {"runner": "windows-latest", "os": "windows", "arch": "x86_64"},
+              {"runner": "windows-11-arm", "os": "windows", "arch": "aarch64"}
             ]
           }'
           echo "matrix=$(echo $matrix | jq -c .)" >> $GITHUB_OUTPUT
@@ -79,6 +81,14 @@ jobs:
         shell: bash
         run: bash ./scripts/ci/setup-linux-pyinstaller-build.sh
 
+      - name: Set up vcpkg
+        if: ${{ matrix.os == 'windows' && matrix.arch == 'aarch64' }}
+        uses: johnwason/vcpkg-action@v8
+        with:
+          pkgs: openssl
+          triplet: arm64-windows-static-md
+          token: ${{ github.token }}
+
       - name: Inject Sentry DSN
         shell: bash
         env:
@@ -89,6 +99,8 @@ jobs:
 
       - name: Build PyInstaller binaries
         shell: bash
+        env:
+          VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
         run: bash ./scripts/ci/build-pyinstaller-binaries.sh vibe-acp.spec vibe.spec
 
       - name: Clear executable stack on bundled libraries


### PR DESCRIPTION
Fixes #739 

This will let the users install wheels instead of building it from scratch.

This installs vcpkg because the package `cryptography` does not have arm64 Windows wheel yet and it requires openssl to build, which is provided by vcpkg in this PR.