### PR TITLE
tests: adjust UI tests to match user input prefixing logic

### DIFF
--- a/tests/cli/test_ui_exit_command.py
+++ b/tests/cli/test_ui_exit_command.py
@@ -26,7 +26,8 @@ async def test_exit_synonym_runs_exit_handler_and_is_not_sent_as_prompt(
         monkeypatch.setattr(vibe_app, "_exit_app", _record_exit)
 
         chat_input = vibe_app.query_one(ChatInputContainer)
-        chat_input.post_message(ChatInputContainer.Submitted(alias))
+        submitted_value = alias if alias.startswith("/") or alias.startswith(":") else f">{alias}"
+        chat_input.post_message(ChatInputContainer.Submitted(submitted_value))
         await pilot.pause(0.2)
 
         assert calls == [alias]

--- a/tests/test_ui_rewind.py
+++ b/tests/test_ui_rewind.py
@@ -209,7 +209,7 @@ async def test_rewind_confirm_edits_message_and_prefills_input() -> None:
 
         # Input should be pre-filled with the rewound message
         chat_input = app.query_one(ChatInputContainer)
-        assert chat_input.value == "world"
+        assert chat_input.value == ">world"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Update UI exit command and rewind tests to reflect changes in how chat input values are formatted and handled in the UI.

In the current implementation of the chat interface, normal user inputs (that do not start with command prefixes '/' or ':') are prefixed with a '>' character. This was causing failures in test cases that either asserted on the exact value of the input field or posted raw messages without the prefix.

Specifically, this patch:
- In `tests/cli/test_ui_exit_command.py`, formats the submitted message value with a '>' prefix if it is not a command starting with '/' or ':'.
- In `tests/test_ui_rewind.py`, updates the expected chat input value assertion from "first" to ">first".