### PR TITLE
Rename default agent mode display name to "Ask"

### DIFF
--- a/vibe/core/agents/models.py
+++ b/vibe/core/agents/models.py
@@ -79,7 +79,7 @@ def _plan_overrides() -> dict[str, Any]:
 
 DEFAULT = AgentProfile(
     BuiltinAgentName.DEFAULT,
-    "Default",
+    "Ask",
     "Requires approval for tool executions",
     AgentSafety.NEUTRAL,
     overrides={"disabled_tools": ["exit_plan_mode"]},


### PR DESCRIPTION
The built-in default agent profile displays as "Default" in the mode picker, which doesn't convey what the mode actually does (prompt for approval on every tool call). Rename it to "Ask" for clarity.