### PR TITLE
Avoid blocking event loop while resuming sessions

### DIFF
--- a/tests/app_server/test_local.py
+++ b/tests/app_server/test_local.py
@@ -999,6 +999,76 @@ async def test_resume_builds_an_independent_backend(
         await source.telemetry_client.aclose()
 
 
+@pytest.mark.asyncio
+async def test_resume_root_loads_session_in_worker_thread(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    logging = SessionLoggingConfig(
+        enabled=True, save_dir=str(tmp_path / "sessions"), session_prefix="session"
+    )
+    source = build_test_agent_loop(
+        config=build_test_vibe_config(session_logging=logging)
+    )
+    await source.persist_empty_session()
+    event_loop_thread = threading.get_ident()
+    load_thread: int | None = None
+    original_load_session = runtime.SessionLoader.load_session
+
+    def load_session(session_dir: Path):
+        nonlocal load_thread
+        load_thread = threading.get_ident()
+        return original_load_session(session_dir)
+
+    monkeypatch.setattr(runtime.SessionLoader, "load_session", load_session)
+    replacement = await runtime.AgentRuntimeFactory().resume_root(
+        source, source.session_id
+    )
+    try:
+        assert load_thread is not None
+        assert load_thread != event_loop_thread
+    finally:
+        await replacement.aclose()
+        await replacement.telemetry_client.aclose()
+        await source.aclose()
+        await source.telemetry_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_continue_resolves_latest_session_in_worker_thread(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config = build_test_vibe_config(
+        session_logging=SessionLoggingConfig(enabled=True, save_dir=str(tmp_path))
+    )
+    session_path = tmp_path / "latest"
+    session_path.mkdir()
+    event_loop_thread = threading.get_ident()
+    resolve_thread: int | None = None
+
+    def find_latest_session(*_args, **_kwargs):
+        nonlocal resolve_thread
+        resolve_thread = threading.get_ident()
+        return session_path
+
+    monkeypatch.setattr(runtime.last_session_pointer, "load", lambda _config: None)
+    monkeypatch.setattr(
+        runtime.SessionLoader, "find_latest_session", find_latest_session
+    )
+    monkeypatch.setattr(
+        runtime.SessionLoader,
+        "load_session",
+        lambda _path: ([], {"session_id": "latest-id"}),
+    )
+    source = cast(AgentLoop, SimpleNamespace(config=config))
+
+    assert (
+        await runtime.AgentRuntimeFactory().resolve_latest(source, Path.cwd())
+        == "latest-id"
+    )
+    assert resolve_thread is not None
+    assert resolve_thread != event_loop_thread
+
+
 def test_continue_prefers_valid_terminal_session_pointer(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1013,8 +1083,9 @@ def test_continue_prefers_valid_terminal_session_pointer(
         lambda *_args, **_kwargs: session_path,
     )
 
-    source = cast(AgentLoop, SimpleNamespace(config=config))
-    assert runtime.AgentRuntimeFactory().resolve_latest(source, Path.cwd()) == "saved"
+    assert (
+        runtime.AgentRuntimeFactory().resolve_latest_sync(config, Path.cwd()) == "saved"
+    )
 
 
 def test_continue_falls_back_to_latest_session_for_working_directory(
@@ -1039,17 +1110,15 @@ def test_continue_falls_back_to_latest_session_for_working_directory(
         lambda _path: ([], {"session_id": "latest-id"}),
     )
 
-    source = cast(AgentLoop, SimpleNamespace(config=config))
     assert (
-        runtime.AgentRuntimeFactory().resolve_latest(source, Path.cwd()) == "latest-id"
+        runtime.AgentRuntimeFactory().resolve_latest_sync(config, Path.cwd())
+        == "latest-id"
     )
 
 
 def test_continue_requires_session_logging() -> None:
     config = build_test_vibe_config(session_logging=SessionLoggingConfig(enabled=False))
-    source = cast(AgentLoop, SimpleNamespace(config=config))
-
     with pytest.raises(
         runtime.RuntimeSessionNotFoundError, match="Session logging is disabled"
     ):
-        runtime.AgentRuntimeFactory().resolve_latest(source, Path.cwd())
+        runtime.AgentRuntimeFactory().resolve_latest_sync(config, Path.cwd())

--- a/vibe/app_server/_runtime.py
+++ b/vibe/app_server/_runtime.py
@@ -249,13 +249,21 @@ class HarnessServer:
 
 
 class AgentRuntimeFactory:
-    def resolve_latest(self, source: AgentLoop, cwd: Path) -> str:
-        _require_session_logging(source.config)
-        return _find_session_to_continue(source.config, cwd=cwd)
+    async def resolve_latest(self, source: AgentLoop, cwd: Path) -> str:
+        return await asyncio.to_thread(self.resolve_latest_sync, source.config, cwd)
+
+    def resolve_latest_sync(self, config: VibeConfigSchema, cwd: Path) -> str:
+        _require_session_logging(config)
+        return _find_session_to_continue(config, cwd=cwd)
+
+    async def resolve_latest_sync_threaded(
+        self, config: VibeConfigSchema, cwd: Path
+    ) -> str:
+        return await asyncio.to_thread(self.resolve_latest_sync, config, cwd)
 
     async def resume_root(self, source: AgentLoop, session_id: str) -> AgentLoop:
-        session_path, loaded_messages, metadata = _load_session(
-            source.config, session_id
+        session_path, loaded_messages, metadata = await asyncio.to_thread(
+            _load_session, source.config, session_id
         )
         replacement = self._create_like(
             source,
@@ -271,8 +279,8 @@ class AgentRuntimeFactory:
     async def resume_blueprint(
         self, blueprint: _RootRuntimeBlueprint, session_id: str
     ) -> AgentLoop:
-        session_path, loaded_messages, metadata = _load_session(
-            blueprint.config, session_id
+        session_path, loaded_messages, metadata = await asyncio.to_thread(
+            _load_session, blueprint.config, session_id
         )
         replacement = blueprint.build(
             parent_session_id=_parent_session_id(metadata),
@@ -357,7 +365,9 @@ class AgentRuntimeFactory:
     async def resume_child(
         self, parent: AgentLoop, agent_name: str, session_id: str, session_dir: Path
     ) -> AgentLoop:
-        loaded_messages, metadata = SessionLoader.load_session(session_dir)
+        loaded_messages, metadata = await asyncio.to_thread(
+            SessionLoader.load_session, session_dir
+        )
         child = await self.create_child(
             parent, agent_name, session_id=session_id, session_dir=session_dir
         )
@@ -513,8 +523,8 @@ class HarnessProcess:
             )
             session_id = request.session_id
             if request.continue_latest:
-                session_id = _find_session_to_continue(
-                    blueprint.config, cwd=blueprint.cwd
+                session_id = await self.runtime_factory.resolve_latest_sync_threaded(
+                    blueprint.config, blueprint.cwd
                 )
             if session_id is not None:
                 return await self.runtime_factory.resume_blueprint(


### PR DESCRIPTION
## Summary
- Move session restore file lookup/read/JSON/Pydantic parsing onto worker threads so `/continue` and `--resume` do not block the TUI event loop while opening older or large sessions.
- Apply the same offload to root resume, blueprint resume, child-agent resume, and latest-session resolution used by `/continue`.
- Add regression tests proving resume and continue session lookup/load paths run outside the event-loop thread.

## Cause
Continuing/restoring a saved session performs synchronous filesystem scans plus `SessionLoader.load_session()` JSON parsing/model validation on the same asyncio loop that drives the Textual TUI. On large or old saved sessions this can monopolize the loop and make the interface appear frozen until the restore completes.

## Verification
- `uv run ruff format vibe/app_server/_runtime.py tests/app_server/test_local.py`
- `uv run ruff check --fix vibe/app_server/_runtime.py tests/app_server/test_local.py`
- `uv run pytest tests/app_server/test_local.py -k 'resume_builds_an_independent_backend or resume_root_loads_session_in_worker_thread or continue_resolves_latest_session_in_worker_thread or continue_prefers_valid_terminal_session_pointer or continue_falls_back_to_latest_session_for_working_directory or continue_requires_session_logging or session_continue_opens_the_resumed_root_once_over_json_rpc'`
- `uv run pyright vibe/app_server/_runtime.py tests/app_server/test_local.py`
- Pre-commit hooks during `uv run git commit`: pyright, ruff check, ruff format, typos, whitespace/end-of-file checks

Closes VIBE-3969
