### PR TITLE
Fix reload picking up newly added models

### DIFF
--- a/tests/core/config/test_agent_loop_refresh_config.py
+++ b/tests/core/config/test_agent_loop_refresh_config.py
@@ -123,3 +123,27 @@ async def test_refresh_config_creates_mcp_registry_when_first_server_added(
 
     assert agent_loop.mcp_registry is registry
     assert registry.status() == {"linear": AuthStatus.NEEDS_AUTH}
+
+
+@pytest.mark.asyncio
+async def test_reload_with_initial_messages_picks_up_new_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_loop = build_test_agent_loop(config=build_test_vibe_config())
+    assert "new-model" not in agent_loop.config.models
+
+    refreshed_config = build_test_vibe_config(
+        models={
+            **agent_loop.config.models,
+            "new-model": {
+                "name": "new-model-name",
+                "provider": "mistral",
+                "alias": "new-model",
+            },
+        }
+    )
+    stub_config_reload(monkeypatch, refreshed_config)
+
+    await agent_loop.reload_with_initial_messages(reload_config=True)
+
+    assert "new-model" in agent_loop.config.models

--- a/vibe/app_server/_resources.py
+++ b/vibe/app_server/_resources.py
@@ -593,8 +593,9 @@ class ResourceRequestHandler:
             logger.debug("Admin config refresh failed on reload", exc_info=exc)
         if params.reload_runtime:
             self._clear_mcp_discovery_errors()
-            await self._agent_loop.config_orchestrator.reload()
-            await self._agent_loop.reload_with_initial_messages(reload_hooks=True)
+            await self._agent_loop.reload_with_initial_messages(
+                reload_hooks=True, reload_config=True
+            )
         else:
             await self._agent_loop.refresh_config()
         return self._config_mutation_response()

--- a/vibe/core/agent_loop/_loop.py
+++ b/vibe/core/agent_loop/_loop.py
@@ -2777,6 +2777,7 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         reset_middleware: bool = True,
         switch_to_agent: str | None = None,
         reload_hooks: bool = False,
+        reload_config: bool = False,
     ) -> None:
         self._reload_generation += 1
         generation = self._reload_generation
@@ -2793,9 +2794,10 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         if generation != self._reload_generation:
             return
 
-        # Callers mutate the orchestrator (reload / set_field) before reinit; pick
-        # up whatever config it now holds.
-        self.agent_manager.invalidate_config()
+        if reload_config:
+            await self.refresh_config()
+        else:
+            self.agent_manager.invalidate_config()
         if max_turns is not None:
             self._max_turns = max_turns
         if max_price is not None:


### PR DESCRIPTION
## Summary
- Root cause: the `/reload` runtime path reloaded the config orchestrator before calling `reload_with_initial_messages`, but that helper only invalidated the agent-profile config cache and rebuilt runtime managers from the already-cached snapshot. Newly added `[[models]]` entries could therefore stay out of the active loop/runtime projection until process restart.
- Add an explicit `reload_config` option to `reload_with_initial_messages` so config-driven reloads atomically refresh the orchestrator snapshot before rebuilding backend/tools/skills/system prompt.
- Route app-server `config/reload` with runtime rebuild through that option and cover new model discovery with a regression test.

## Verification
- `uv run ruff check vibe/core/agent_loop/_loop.py vibe/app_server/_resources.py tests/core/config/test_agent_loop_refresh_config.py`
- `uv run pytest tests/app_server/test_harness_contracts.py tests/cli/test_reload_config_app.py tests/core/config/test_agent_loop_refresh_config.py`
- Commit hooks: pyright, ruff check, ruff format, typos

Closes VIBE-3980
