### PR TITLE
feat: add /log-level command and runtime log-level control

### DIFF
--- a/tests/cli/test_log_level_command.py
+++ b/tests/cli/test_log_level_command.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import (
+    build_test_agent_loop,
+    build_test_vibe_app,
+    build_test_vibe_config,
+)
+from vibe.cli.textual_ui.widgets.messages import ErrorMessage, UserCommandMessage
+from vibe.observability.logging import (
+    _VibeFileHandler,
+    get_effective_log_level,
+    get_log_level_chain,
+    get_session_override,
+    init_file_logging,
+    logger as vibe_logger,
+    set_session_override,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_session_override() -> Iterator[None]:
+    set_session_override(None)
+    yield
+    set_session_override(None)
+
+
+@pytest.mark.asyncio
+async def test_bare_prints_full_chain() -> None:
+    config = build_test_vibe_config()
+    agent_loop = build_test_agent_loop(config=config)
+    app = build_test_vibe_app(agent_loop=agent_loop)
+
+    async with app.run_test() as pilot:
+        handled = await app._handle_command("/log-level")
+        await pilot.pause()
+        messages = app.query(UserCommandMessage)
+        assert any(
+            "Session: (none)" in m._content
+            and "Env:" in m._content
+            and "Config:" in m._content
+            and "Effective:" in m._content
+            for m in messages
+        )
+
+    assert handled is True
+
+
+@pytest.mark.asyncio
+async def test_set_applies_session_override() -> None:
+    config = build_test_vibe_config()
+    agent_loop = build_test_agent_loop(config=config)
+    app = build_test_vibe_app(agent_loop=agent_loop)
+
+    async with app.run_test() as pilot:
+        handled = await app._handle_command("/log-level set DEBUG")
+        await pilot.pause()
+        messages = app.query(UserCommandMessage)
+        assert any("Session: DEBUG" in m._content for m in messages)
+
+    assert handled is True
+    assert get_session_override() == "DEBUG"
+
+
+@pytest.mark.asyncio
+async def test_set_normalizes_case() -> None:
+    config = build_test_vibe_config()
+    agent_loop = build_test_agent_loop(config=config)
+    app = build_test_vibe_app(agent_loop=agent_loop)
+
+    async with app.run_test() as pilot:
+        await app._handle_command("/log-level set info")
+        await pilot.pause()
+
+    assert get_session_override() == "INFO"
+
+
+@pytest.mark.asyncio
+async def test_invalid_level_shows_error() -> None:
+    config = build_test_vibe_config()
+    agent_loop = build_test_agent_loop(config=config)
+    app = build_test_vibe_app(agent_loop=agent_loop)
+
+    async with app.run_test() as pilot:
+        handled = await app._handle_command("/log-level set VERBOSE")
+        await pilot.pause()
+        errors = app.query(ErrorMessage)
+        assert any(
+            "Invalid" in str(m._error) or "Usage" in str(m._error) for m in errors
+        )
+
+    assert handled is True
+    assert get_session_override() is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_verb_shows_usage() -> None:
+    config = build_test_vibe_config()
+    agent_loop = build_test_agent_loop(config=config)
+    app = build_test_vibe_app(agent_loop=agent_loop)
+
+    async with app.run_test() as pilot:
+        await app._handle_command("/log-level DEBUG")
+        await pilot.pause()
+        errors = app.query(ErrorMessage)
+        assert any("Usage" in str(m._error) for m in errors)
+
+
+@pytest.mark.asyncio
+async def test_set_global_persists_and_applies() -> None:
+    config = build_test_vibe_config()
+    agent_loop = build_test_agent_loop(config=config)
+    app = build_test_vibe_app(agent_loop=agent_loop)
+
+    async with app.run_test() as pilot:
+        await app._handle_command("/log-level set-global DEBUG")
+        await pilot.pause()
+
+    assert get_session_override() == "DEBUG"
+    assert app.app_server.resources.config.current.log_level == "DEBUG"
+
+
+@pytest.mark.asyncio
+async def test_unset_clears_session_override(tmp_path: Path) -> None:
+    log_file = tmp_path / "vibe.log"
+    init_file_logging(log_file, target_logger=vibe_logger)
+    try:
+        config = build_test_vibe_config()
+        agent_loop = build_test_agent_loop(config=config)
+        app = build_test_vibe_app(agent_loop=agent_loop)
+
+        async with app.run_test() as pilot:
+            await app._handle_command("/log-level set DEBUG")
+            await pilot.pause()
+            assert get_session_override() == "DEBUG"
+
+            await app._handle_command("/log-level unset")
+            await pilot.pause()
+            assert get_session_override() is None
+            assert get_effective_log_level() == "WARNING"
+    finally:
+        vibe_logger.handlers = [
+            h
+            for h in vibe_logger.handlers
+            if not (isinstance(h, _VibeFileHandler) and h.baseFilename == str(log_file))
+        ]
+
+
+@pytest.mark.asyncio
+async def test_unset_when_no_override_prints_notice() -> None:
+    config = build_test_vibe_config()
+    agent_loop = build_test_agent_loop(config=config)
+    app = build_test_vibe_app(agent_loop=agent_loop)
+
+    async with app.run_test() as pilot:
+        await app._handle_command("/log-level unset")
+        await pilot.pause()
+        messages = app.query(UserCommandMessage)
+        assert any("No session override was set" in m._content for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_config_change_applies_when_no_session_override(tmp_path: Path) -> None:
+    log_file = tmp_path / "vibe.log"
+    init_file_logging(log_file, target_logger=vibe_logger)
+    try:
+        config = build_test_vibe_config()
+        agent_loop = build_test_agent_loop(config=config)
+        app = build_test_vibe_app(agent_loop=agent_loop)
+
+        async with app.run_test() as pilot:
+            await app.app_server.resources.config.update({"log_level": "ERROR"})
+            await pilot.pause()
+            assert get_session_override() is None
+            assert get_effective_log_level() == "ERROR"
+    finally:
+        vibe_logger.handlers = [
+            h
+            for h in vibe_logger.handlers
+            if not (isinstance(h, _VibeFileHandler) and h.baseFilename == str(log_file))
+        ]
+
+
+@pytest.mark.asyncio
+async def test_config_level_applied_at_mount(tmp_path: Path) -> None:
+    log_file = tmp_path / "vibe.log"
+    init_file_logging(log_file, target_logger=vibe_logger)
+    try:
+        config = build_test_vibe_config(log_level="ERROR")
+        agent_loop = build_test_agent_loop(config=config)
+        app = build_test_vibe_app(agent_loop=agent_loop)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chain = get_log_level_chain()
+            assert chain.config == "ERROR"
+            assert chain.session is None
+            assert get_effective_log_level() == "ERROR"
+    finally:
+        vibe_logger.handlers = [
+            h
+            for h in vibe_logger.handlers
+            if not (isinstance(h, _VibeFileHandler) and h.baseFilename == str(log_file))
+        ]

--- a/tests/core/config/test_vibe_config_schema.py
+++ b/tests/core/config/test_vibe_config_schema.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import keyring
+from pydantic import ValidationError
 import pytest
 
 from vibe.core.config import MissingAPIKeyError, ModelConfig, ProviderConfig
@@ -291,3 +292,23 @@ def test_check_api_key_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> N
 def test_theme_is_preserved_for_the_client_to_interpret() -> None:
     config = VibeConfigSchema(theme="totally-unknown-theme")
     assert config.theme == "totally-unknown-theme"
+
+
+def test_log_level_defaults_to_none() -> None:
+    schema = VibeConfigSchema()
+    assert schema.log_level is None
+
+
+def test_log_level_normalizes_case() -> None:
+    schema = VibeConfigSchema(log_level="debug")
+    assert schema.log_level == "DEBUG"
+
+
+def test_log_level_rejects_invalid() -> None:
+    with pytest.raises(ValidationError):
+        VibeConfigSchema(log_level="VERBOSE")
+
+
+@pytest.mark.parametrize("level", ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
+def test_log_level_accepts_canonical_levels(level: str) -> None:
+    assert VibeConfigSchema(log_level=level).log_level == level

--- a/tests/observability/test_logging.py
+++ b/tests/observability/test_logging.py
@@ -8,10 +8,19 @@ from textwrap import dedent
 import pytest
 
 from vibe.observability.logging import (
+    LOG_LEVELS,
+    LogLevelChain,
     StructuredLogFormatter,
+    _VibeFileHandler,
     decode_log_message,
     encode_log_message,
+    get_effective_log_level,
+    get_log_level_chain,
+    get_session_override,
     init_file_logging,
+    set_config_log_level,
+    set_log_level,
+    set_session_override,
 )
 
 
@@ -296,6 +305,136 @@ class TestDecodeLogMessage:
         original = "C:\\Users\\test\\file.txt"
         encoded = encode_log_message(original)
         assert decode_log_message(encoded) == original
+
+
+class TestRuntimeLogLevel:
+    def test_log_levels_constant_has_all_five(self) -> None:
+        assert LOG_LEVELS == frozenset({
+            "DEBUG",
+            "INFO",
+            "WARNING",
+            "ERROR",
+            "CRITICAL",
+        })
+
+    def test_set_log_level_changes_handler_level(
+        self, log_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+        test_logger = logging.getLogger("test_set_runtime")
+        test_logger.handlers.clear()
+        init_file_logging(log_file, target_logger=test_logger)
+
+        returned = set_log_level("DEBUG", target_logger=test_logger)
+
+        assert returned == "DEBUG"
+        handler = next(
+            h for h in test_logger.handlers if isinstance(h, _VibeFileHandler)
+        )
+        assert logging.getLevelName(handler.level) == "DEBUG"
+
+    def test_set_log_level_normalizes_case(
+        self, log_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+        test_logger = logging.getLogger("test_set_runtime_case")
+        test_logger.handlers.clear()
+        init_file_logging(log_file, target_logger=test_logger)
+
+        assert set_log_level("info", target_logger=test_logger) == "INFO"
+
+    def test_set_log_level_rejects_invalid(
+        self, log_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+        test_logger = logging.getLogger("test_set_runtime_invalid")
+        test_logger.handlers.clear()
+        init_file_logging(log_file, target_logger=test_logger)
+        original = get_effective_log_level(target_logger=test_logger)
+
+        with pytest.raises(ValueError):
+            set_log_level("VERBOSE", target_logger=test_logger)
+
+        assert get_effective_log_level(target_logger=test_logger) == original
+
+    def test_get_effective_log_level_no_handlers(self) -> None:
+        test_logger = logging.getLogger("test_no_handlers")
+        test_logger.handlers.clear()
+        assert get_effective_log_level(target_logger=test_logger) == "WARNING"
+
+    def test_session_override_round_trip(self) -> None:
+        set_session_override(None)
+        assert get_session_override() is None
+        set_session_override("DEBUG")
+        assert get_session_override() == "DEBUG"
+        set_session_override(None)
+        assert get_session_override() is None
+
+    def test_chain_session_wins_over_env_and_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        set_session_override("DEBUG")
+        set_config_log_level("INFO")
+        monkeypatch.setenv("LOG_LEVEL", "ERROR")
+        chain = get_log_level_chain()
+        assert chain.session == "DEBUG"
+        assert chain.env == "ERROR"
+        assert chain.config == "INFO"
+        assert chain.effective == "DEBUG"
+        set_session_override(None)
+        set_config_log_level(None)
+
+    def test_chain_env_wins_over_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        set_session_override(None)
+        set_config_log_level("INFO")
+        monkeypatch.setenv("LOG_LEVEL", "ERROR")
+        chain = get_log_level_chain()
+        assert chain.session is None
+        assert chain.env == "ERROR"
+        assert chain.config == "INFO"
+        assert chain.effective == "ERROR"
+        set_config_log_level(None)
+
+    def test_chain_config_when_no_env_no_session(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        set_session_override(None)
+        set_config_log_level("INFO")
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        chain = get_log_level_chain()
+        assert chain.session is None
+        assert chain.env is None
+        assert chain.config == "INFO"
+        assert chain.effective == "INFO"
+        set_config_log_level(None)
+
+    def test_chain_defaults_to_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        set_session_override(None)
+        set_config_log_level(None)
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        chain = get_log_level_chain()
+        assert chain.session is None
+        assert chain.env is None
+        assert chain.config is None
+        assert chain.effective == "WARNING"
+
+    def test_chain_env_none_when_invalid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        set_session_override(None)
+        set_config_log_level("INFO")
+        monkeypatch.setenv("LOG_LEVEL", "VERBOSE")
+        chain = get_log_level_chain()
+        assert chain.env is None
+        assert chain.effective == "INFO"
+        set_config_log_level(None)
+
+    def test_chain_returns_frozen_dataclass(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        set_config_log_level("WARNING")
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        chain = get_log_level_chain()
+        assert isinstance(chain, LogLevelChain)
+        set_config_log_level(None)
 
     def test_roundtrip_with_backslash_n(self) -> None:
         original = "C:\\new folder\\notes.txt"

--- a/tests/stubs/app_config.py
+++ b/tests/stubs/app_config.py
@@ -24,6 +24,7 @@ def build_test_app_config(
         active_model_pinned=True,
         default_model_alias="test-model",
         theme="textual-dark",
+        log_level=None,
         disable_welcome_banner_animation=False,
         autocopy_to_clipboard=True,
         file_watcher_for_autocomplete=False,

--- a/vibe/app_server/_projection.py
+++ b/vibe/app_server/_projection.py
@@ -109,6 +109,7 @@ def project_config_view(
         active_model_pinned=active_model_pinned,
         default_model_alias=default_model_alias,
         theme=config.theme,
+        log_level=config.log_level,
         disable_welcome_banner_animation=config.disable_welcome_banner_animation,
         show_greeting=config.show_greeting,
         autocopy_to_clipboard=config.autocopy_to_clipboard,

--- a/vibe/app_server/config.py
+++ b/vibe/app_server/config.py
@@ -58,6 +58,7 @@ class ConfigView(ProtocolModel):
     active_model_pinned: bool
     default_model_alias: str
     theme: str
+    log_level: str | None
     disable_welcome_banner_animation: bool
     show_greeting: bool
     autocopy_to_clipboard: bool

--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -101,6 +101,15 @@ class CommandRegistry:
                 description="Show path to current interaction log file",
                 handler="_show_log_path",
             ),
+            "log-level": Command(
+                aliases=frozenset(["/log-level"]),
+                description=(
+                    "Show or set the log level. "
+                    "Usage: `/log-level`, `/log-level set <LEVEL>`, "
+                    "`/log-level set-global <LEVEL>`, `/log-level unset`"
+                ),
+                handler="_log_level_command",
+            ),
             "debug": Command(
                 aliases=frozenset(["/debug"]),
                 description="Toggle debug console",

--- a/vibe/cli/entrypoint.py
+++ b/vibe/cli/entrypoint.py
@@ -33,6 +33,7 @@ def parse_arguments() -> argparse.Namespace:
             "Environment variables:\n"
             "  VIBE_HOME       Override the Vibe home directory (default: ~/.vibe)\n"
             "  LOG_LEVEL       Logging level: DEBUG, INFO, WARNING (default), ERROR, CRITICAL.\n"
+            "                  Also set via log_level in config.toml or /log-level at runtime.\n"
             "                  Logs are written to $VIBE_HOME/logs/vibe.log.\n"
             "  LOG_MAX_BYTES   Max size of vibe.log before rotation (default: 10485760).\n"
             "  VIBE_*          Override any config field (e.g. VIBE_ACTIVE_MODEL=local)."

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -224,7 +224,15 @@ from vibe.cli.vscode_extension_promo import (
     VscodeExtensionPromoState,
     should_show_promo,
 )
-from vibe.observability.logging import logger
+from vibe.observability.logging import (
+    LOG_LEVELS,
+    get_log_level_chain,
+    get_session_override,
+    logger,
+    set_config_log_level,
+    set_log_level,
+    set_session_override,
+)
 from vibe.observability.sentry import capture_sentry_exception
 from vibe.utils.cache_store import FileSystemCacheStore
 from vibe.utils.data_retention import DATA_RETENTION_MESSAGE
@@ -843,6 +851,7 @@ class VibeApp(App):  # noqa: PLR0904
     async def on_mount(self) -> None:
         await self._apply_theme(self.config.theme)
         self.app_server.resources.config.subscribe(self._on_config_changed)
+        set_config_log_level(self.config.log_level)
         self._terminal_notifier.restore()
         self._feedback_bar = self.query_one(FeedbackBar)
         self.run_worker(self._complete_mount(), exclusive=False)
@@ -850,6 +859,7 @@ class VibeApp(App):  # noqa: PLR0904
     def _on_config_changed(self, config: ConfigView) -> None:
         if resolve_theme_name(config.theme) != self.theme:
             self.run_worker(self._apply_theme(config.theme))
+        set_config_log_level(config.log_level)
 
     async def _complete_mount(self) -> None:
         self.event_handler = EventHandler(
@@ -2766,6 +2776,90 @@ class VibeApp(App):  # noqa: PLR0904
 
         await self._mount_and_scroll(
             UserCommandMessage(f'Session renamed to "{renamed_title}".')
+        )
+
+    async def _log_level_command(self, cmd_args: str = "", **kwargs: Any) -> None:
+        args = cmd_args.strip()
+        parts = args.split(None, 1) if args else []
+
+        if not parts:
+            await self._mount_and_scroll(
+                UserCommandMessage(self._format_log_level_status())
+            )
+            return
+
+        verb = parts[0].lower()
+        rest = parts[1].strip() if len(parts) > 1 else ""
+
+        if verb == "unset":
+            previous = get_session_override()
+            if previous is None:
+                await self._mount_and_scroll(
+                    UserCommandMessage(
+                        self._format_log_level_status()
+                        + "\nNo session override was set."
+                    )
+                )
+                return
+            set_session_override(None)
+            await self._mount_and_scroll(
+                UserCommandMessage(self._format_log_level_status())
+            )
+            return
+
+        if verb in {"set", "set-global"}:
+            if not rest:
+                await self._mount_and_scroll(
+                    ErrorMessage(
+                        f"Usage: /log-level {verb} <LEVEL>  "
+                        f"(one of {', '.join(sorted(LOG_LEVELS))})",
+                        collapsed=self._tools_collapsed,
+                    )
+                )
+                return
+            try:
+                canonical = set_log_level(rest)
+            except ValueError:
+                await self._mount_and_scroll(
+                    ErrorMessage(
+                        f"Invalid level {rest!r}; expected one of "
+                        f"{', '.join(sorted(LOG_LEVELS))}",
+                        collapsed=self._tools_collapsed,
+                    )
+                )
+                return
+            set_session_override(canonical)
+
+            if verb == "set-global":
+                await self._persist_config_changes({"log_level": canonical})
+
+            note = ""
+            chain = get_log_level_chain()
+            if verb == "set-global" and chain.env and chain.env != canonical:
+                note = (
+                    f"\nNote: LOG_LEVEL env ({chain.env}) overrides config.toml; "
+                    f"config updated to {canonical}."
+                )
+            await self._mount_and_scroll(
+                UserCommandMessage(self._format_log_level_status() + note)
+            )
+            return
+
+        await self._mount_and_scroll(
+            ErrorMessage(
+                "Usage: /log-level [set|set-global|unset] [LEVEL]  "
+                f"(levels: {', '.join(sorted(LOG_LEVELS))})",
+                collapsed=self._tools_collapsed,
+            )
+        )
+
+    def _format_log_level_status(self) -> str:
+        chain = get_log_level_chain()
+        return (
+            f"Session: {chain.session or '(none)'}\n"
+            f"Env: {chain.env or '(none)'}\n"
+            f"Config: {chain.config or '(none)'}\n"
+            f"Effective: {chain.effective}"
         )
 
     def _build_picker(self, sessions: list[SavedSessionSummary]) -> SessionPickerApp:

--- a/vibe/config_values.py
+++ b/vibe/config_values.py
@@ -5,6 +5,7 @@ from typing import Literal
 AUTO_THEME = "auto"
 FALLBACK_THEME = "ansi-dark"
 DEFAULT_THEME = AUTO_THEME
+DEFAULT_LOG_LEVEL = "WARNING"
 
 type AudioClient = Literal["mistral"]
 type ThinkingLevel = Literal["off", "low", "medium", "high", "max"]

--- a/vibe/core/agent_loop/_loop.py
+++ b/vibe/core/agent_loop/_loop.py
@@ -182,6 +182,7 @@ from vibe.core.utils import (
     get_user_cancellation_message,
     is_user_cancellation_event,
 )
+from vibe.observability.logging import logger
 from vibe.user_content import UserDisplayContent, UserResource
 from vibe.utils import VIBE_WARNING_TAG
 from vibe.utils.api_keys import resolve_api_key
@@ -330,6 +331,46 @@ def _refusal_error(provider: str, model: str, chunk: LLMChunk) -> RefusalError:
         category=stop.category if stop else None,
         explanation=stop.explanation if stop else None,
     )
+
+
+def _log_model_call_success(alias: str, duration_ms: int, usage: LLMUsage) -> None:
+    logger.info(
+        "Model call completed model=%s duration_ms=%d prompt_tokens=%d completion_tokens=%d cached_tokens=%d",
+        alias,
+        duration_ms,
+        usage.prompt_tokens,
+        usage.completion_tokens,
+        usage.cached_tokens,
+    )
+
+
+def _log_model_call_failure(
+    alias: str, provider: str, error: Exception, duration_ms: int
+) -> None:
+    backend_error = _extract_backend_error(error)
+    if backend_error is not None:
+        logger.warning(
+            "Model call failed model=%s duration_ms=%d\n%s",
+            alias,
+            duration_ms,
+            backend_error._fmt(),
+        )
+    else:
+        logger.info(
+            "Model call failed model=%s provider=%s error=%s duration_ms=%d",
+            alias,
+            provider,
+            type(error).__name__,
+            duration_ms,
+        )
+
+
+def _extract_backend_error(error: BaseException) -> BackendError | None:
+    if isinstance(error, BackendError):
+        return error
+    if isinstance(error, RuntimeError) and isinstance(error.__cause__, BackendError):
+        return error.__cause__
+    return None
 
 
 def _should_raise_rate_limit_error(e: Exception) -> bool:
@@ -2126,6 +2167,11 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
             cancel = str(
                 get_user_cancellation_message(CancellationReason.TOOL_INTERRUPTED)
             )
+            logger.info(
+                "Tool call cancelled tool=%s tool_call_id=%s outcome=cancelled",
+                tool_call.tool_name,
+                tool_call.call_id,
+            )
             self.stats.tool_calls_failed += 1
             yield ToolResultEvent(
                 tool_name=tool_call.tool_name,
@@ -2147,6 +2193,19 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
 
         except Exception as exc:
             error_msg = f"<{TOOL_ERROR_TAG}>{tool_instance.get_name()} failed: {exc}</{TOOL_ERROR_TAG}>"
+            if isinstance(exc, ToolPermissionError):
+                logger.info(
+                    "Tool call denied tool=%s tool_call_id=%s outcome=denied",
+                    tool_call.tool_name,
+                    tool_call.call_id,
+                )
+            else:
+                logger.warning(
+                    "Tool call failed tool=%s tool_call_id=%s outcome=error error=%s",
+                    tool_call.tool_name,
+                    tool_call.call_id,
+                    exc,
+                )
             if isinstance(exc, ToolPermissionError):
                 self.stats.tool_calls_agreed -= 1
                 self.stats.tool_calls_rejected += 1
@@ -2190,6 +2249,11 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
             self.checkpoint_recorder.add_snapshot(snapshot)
 
         start_time = time.perf_counter()
+        logger.debug(
+            "Tool call starting tool=%s tool_call_id=%s",
+            tool_call.tool_name,
+            tool_call.call_id,
+        )
         result_model = None
         async for item in tool_instance.invoke(
             ctx=InvokeContext(
@@ -2264,6 +2328,12 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         ):
             yield ev
         self.stats.tool_calls_succeeded += 1
+        logger.info(
+            "Tool call completed tool=%s tool_call_id=%s duration_ms=%d outcome=success",
+            tool_call.tool_name,
+            tool_call.call_id,
+            int(duration * 1000),
+        )
 
     async def _should_execute_tool(
         self, tool: BaseTool, args: BaseModel, tool_call_id: str
@@ -2438,8 +2508,16 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
             ),
         )
 
+        start_time = time.perf_counter()
         try:
-            start_time = time.perf_counter()
+            logger.debug(
+                "Model call starting model=%s provider=%s messages=%d tools=%d thinking=%s",
+                model.alias,
+                provider.name,
+                len(messages),
+                len(tools) if tools else 0,
+                model.thinking,
+            )
             result = await self.backend.complete(
                 model=model,
                 messages=self._messages_for_backend(messages, model),
@@ -2464,11 +2542,20 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
             processed_message = self.format_handler.process_api_response_message(
                 result.message
             )
+            _log_model_call_success(
+                model.alias, int((end_time - start_time) * 1000), result.usage
+            )
             return LLMChunk(
                 message=processed_message, usage=result.usage, stop=result.stop
             )
 
         except Exception as e:
+            _log_model_call_failure(
+                model.alias,
+                provider.name,
+                e,
+                int((time.perf_counter() - start_time) * 1000),
+            )
             if isinstance(e, RefusalError):
                 raise
             if _should_raise_rate_limit_error(e):
@@ -2528,8 +2615,16 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
         )
 
         chunk_agg: LLMChunk | None = None
+        start_time = time.perf_counter()
         try:
-            start_time = time.perf_counter()
+            logger.debug(
+                "Model call starting model=%s provider=%s messages=%d tools=%d streaming=%s",
+                active_model.alias,
+                provider.name,
+                len(self.messages),
+                len(available_tools) if available_tools else 0,
+                True,
+            )
             usage = LLMUsage()
             async for chunk in self.backend.complete_streaming(
                 model=active_model,
@@ -2568,7 +2663,17 @@ class AgentLoop(AgentLoopHooksMixin):  # noqa: PLR0904
             if chunk_agg.stop and chunk_agg.stop.is_refusal:
                 raise _refusal_error(provider.name, active_model.name, chunk_agg)
 
+            _log_model_call_success(
+                active_model.alias, int((end_time - start_time) * 1000), usage
+            )
+
         except Exception as e:
+            _log_model_call_failure(
+                active_model.alias,
+                provider.name,
+                e,
+                int((time.perf_counter() - start_time) * 1000),
+            )
             if isinstance(e, RefusalError):
                 raise
             if isinstance(e, BackendError):

--- a/vibe/core/config/_defaults.py
+++ b/vibe/core/config/_defaults.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from vibe.config_values import (
     AUTO_THEME as AUTO_THEME,
+    DEFAULT_LOG_LEVEL as DEFAULT_LOG_LEVEL,
     DEFAULT_THEME as DEFAULT_THEME,
     FALLBACK_THEME as FALLBACK_THEME,
 )

--- a/vibe/core/config/vibe_schema.py
+++ b/vibe/core/config/vibe_schema.py
@@ -229,6 +229,20 @@ def _coerce_routed_model_config(v: str) -> ModelConfig | None:
         return None
 
 
+_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
+
+
+def _normalize_log_level(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    normalized = value.strip().upper()
+    if normalized not in _LOG_LEVELS:
+        raise ValueError(
+            f"Invalid log level {value!r}; expected one of {sorted(_LOG_LEVELS)}"
+        )
+    return normalized
+
+
 class VibeConfigSchema(ConfigSchema):
     _validation_warnings: list[str] = PrivateAttr(default_factory=list)
 
@@ -458,6 +472,9 @@ class VibeConfigSchema(ConfigSchema):
     vibe_code_sessions_base_url: Annotated[str, WithReplaceMerge()] = (
         "https://chat.mistral.ai"
     )
+    log_level: Annotated[
+        str | None, WithReplaceMerge(), BeforeValidator(_normalize_log_level)
+    ] = None
 
     # Nested configs (REPLACE — simple nested models, no merge semantics)
     project_context: Annotated[ProjectContextConfig, WithReplaceMerge()] = Field(

--- a/vibe/core/skills/builtins/vibe.py
+++ b/vibe/core/skills/builtins/vibe.py
@@ -130,6 +130,7 @@ autocopy_to_clipboard = true  # Enable automatic copying of selected text to cli
 file_watcher_for_autocomplete = false
 ask_confirmation_on_exit = true  # Require a second Ctrl+D to quit (Ctrl+C always confirms)
 show_greeting = true  # Show "Hello {name}" greeting below the banner at startup (Mistral providers, once per 24h)
+log_level = "WARNING"  # Optional. DEBUG | INFO | WARNING | ERROR | CRITICAL — log level for ~/.vibe/logs/vibe.log
 ```
 
 ### Copy and Text Selection
@@ -690,6 +691,11 @@ Custom agents are TOML files in `~/.vibe/agents/NAME.toml`.
 - `/reload` - Reload configuration, agent instructions, and skills from disk
 - `/clear`, `/new` - Clear conversation history
 - `/log` - Show path to current interaction log file
+- `/log-level` - Show or set the log level. `/log-level` prints the full chain
+  (session, env, config, effective); `/log-level set <LEVEL>` sets a
+  process-lifetime override; `/log-level set-global <LEVEL>` also persists to
+  config.toml; `/log-level unset` clears the session override. LEVEL is one of
+  DEBUG, INFO, WARNING, ERROR, CRITICAL.
 - `/debug` - Toggle debug console
 - `/compact` - Compact conversation history by summarizing
 - `/retry [additional instructions]` - Continue a model response interrupted by
@@ -843,9 +849,9 @@ prompt). The model can still load them via the `skill` tool.
 - `MISTRAL_API_KEY` - API key for Mistral provider
 - `VIBE_ACTIVE_MODEL` - Override active model
 - `VIBE_*` - Any config field can be overridden with the `VIBE_` prefix
-- `LOG_LEVEL` - Logging level for `$VIBE_HOME/logs/vibe.log`. One of `DEBUG`,
-  `INFO`, `WARNING` (default), `ERROR`, `CRITICAL`. Invalid values fall back
-  to `WARNING`.
+- `LOG_LEVEL` - Overrides `log_level` config for `$VIBE_HOME/logs/vibe.log`.
+  One of `DEBUG`, `INFO`, `WARNING` (default), `ERROR`, `CRITICAL`. Invalid values
+  fall back to `WARNING`. Use `/log-level` to change at runtime.
 - `LOG_MAX_BYTES` - Max size in bytes of `vibe.log` before rotation
   (default: `10485760`, i.e. 10 MiB).
 - `DEBUG_MODE` - When `true`, forces `DEBUG`-level logging. Under `vibe-acp`

--- a/vibe/observability/logging.py
+++ b/vibe/observability/logging.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
 import logging
 from logging.handlers import RotatingFileHandler
 import os
 from pathlib import Path
 import re
+
+from vibe.config_values import DEFAULT_LOG_LEVEL
 
 logger = logging.getLogger("vibe")
 
@@ -43,20 +46,121 @@ def init_file_logging(
     resolved_log_file.parent.mkdir(parents=True, exist_ok=True)
     max_bytes = int(os.environ.get("LOG_MAX_BYTES", 10 * 1024 * 1024))
 
-    if os.environ.get("DEBUG_MODE") == "true":
-        log_level_name = "DEBUG"
-    else:
-        log_level_name = os.environ.get("LOG_LEVEL", "WARNING").upper()
-        if log_level_name not in {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}:
-            log_level_name = "WARNING"
-
     handler = _VibeFileHandler(
         resolved_log_file, maxBytes=max_bytes, backupCount=0, encoding="utf-8"
     )
     handler.setFormatter(StructuredLogFormatter())
-    handler.setLevel(getattr(logging, log_level_name, logging.WARNING))
     target_logger.setLevel(logging.DEBUG)
     target_logger.addHandler(handler)
+    _log_level_state._apply_effective(target_logger)
+
+
+LOG_LEVELS: frozenset[str] = frozenset({
+    "DEBUG",
+    "INFO",
+    "WARNING",
+    "ERROR",
+    "CRITICAL",
+})
+
+
+def _vibe_file_handlers(
+    target_logger: logging.Logger = logger,
+) -> list[_VibeFileHandler]:
+    return [h for h in target_logger.handlers if isinstance(h, _VibeFileHandler)]
+
+
+def _get_env_log_level() -> str | None:
+    if os.environ.get("DEBUG_MODE") == "true":
+        return "DEBUG"
+    env_level = os.environ.get("LOG_LEVEL")
+    if env_level and env_level.upper() in LOG_LEVELS:
+        return env_level.upper()
+    return None
+
+
+@dataclass(frozen=True)
+class LogLevelChain:
+    session: str | None
+    env: str | None
+    config: str | None
+    effective: str
+
+
+class _LogLevelState:
+    def __init__(self) -> None:
+        self._session_override: str | None = None
+        self._config_level: str | None = None
+
+    @property
+    def session_override(self) -> str | None:
+        return self._session_override
+
+    @property
+    def config_level(self) -> str | None:
+        return self._config_level
+
+    def chain(self) -> LogLevelChain:
+        env = _get_env_log_level()
+        effective = (
+            self._session_override or env or self._config_level or DEFAULT_LOG_LEVEL
+        )
+        return LogLevelChain(
+            session=self._session_override,
+            env=env,
+            config=self._config_level,
+            effective=effective,
+        )
+
+    def set_session_override(self, level: str | None) -> None:
+        self._session_override = level
+        self._apply_effective()
+
+    def set_config_level(self, level: str | None) -> None:
+        self._config_level = level
+        self._apply_effective()
+
+    def _apply_effective(self, target_logger: logging.Logger = logger) -> None:
+        effective = self.chain().effective
+        for handler in _vibe_file_handlers(target_logger):
+            handler.setLevel(effective)
+
+
+_log_level_state = _LogLevelState()
+
+
+def set_log_level(level: str, *, target_logger: logging.Logger = logger) -> str:
+    normalized = level.strip().upper()
+    if normalized not in LOG_LEVELS:
+        raise ValueError(
+            f"Invalid log level {level!r}; expected one of {sorted(LOG_LEVELS)}"
+        )
+    for handler in _vibe_file_handlers(target_logger):
+        handler.setLevel(normalized)
+    return normalized
+
+
+def get_effective_log_level(*, target_logger: logging.Logger = logger) -> str:
+    handlers = _vibe_file_handlers(target_logger)
+    if not handlers:
+        return "WARNING"
+    return logging.getLevelName(handlers[0].level)
+
+
+def get_log_level_chain() -> LogLevelChain:
+    return _log_level_state.chain()
+
+
+def get_session_override() -> str | None:
+    return _log_level_state.session_override
+
+
+def set_session_override(level: str | None) -> None:
+    _log_level_state.set_session_override(level)
+
+
+def set_config_log_level(level: str | None) -> None:
+    _log_level_state.set_config_level(level)
 
 
 def encode_log_message(message: str) -> str:
@@ -72,9 +176,17 @@ def decode_log_message(encoded: str) -> str:
 
 
 __all__ = [
+    "LOG_LEVELS",
+    "LogLevelChain",
     "StructuredLogFormatter",
     "decode_log_message",
     "encode_log_message",
+    "get_effective_log_level",
+    "get_log_level_chain",
+    "get_session_override",
     "init_file_logging",
     "logger",
+    "set_config_log_level",
+    "set_log_level",
+    "set_session_override",
 ]


### PR DESCRIPTION
## Summary

Add a `/log-level` slash command to inspect and change the log level at runtime, with optional persistence to `config.toml`. Also adds structured debug/info/warning logging to every model and tool invocation.

## Rationale

When debugging intermittent issues with the Vibe CLI — particularly errors communicating with the inference endpoint that disappear after a restart — the default `WARNING` log level provides almost no diagnostic information. The debug console (`Ctrl+\`) and log file (`~/.vibe/logs/vibe.log`) capture too little to investigate transient failures. Changing the level required restarting with a `LOG_LEVEL` env var, which loses the session context that may have triggered the issue. There was no in-session way to increase verbosity, and the agent loop had almost no log points at model or tool invocation boundaries.

This PR addresses both gaps: runtime log-level control without restarting, and structured logging at every model and tool call with enough metadata to diagnose failures (duration, token usage, error type, HTTP status, endpoint) without exposing raw messages or tool arguments.

**Precedence chain** (highest to lowest):

1. **Session override** — set via `/log-level set <LEVEL>`, process-lifetime only, cleared with `/log-level unset`
2. **`LOG_LEVEL` env var** — read once at startup, cached; includes `DEBUG_MODE=true` which forces `DEBUG`
3. **`log_level` in `config.toml`** — optional field, absent means `None`; persisted via `/log-level set-global <LEVEL>`
4. **Default** — `WARNING` (from `DEFAULT_LOG_LEVEL` in `vibe/config_values.py`)

The effective level is the first non-`None` value in this chain. `/log-level` prints every layer and the resolved effective level.

## Changes

### New config field: `log_level`

Optional field in `config.toml`, defaults to `None` (absent). Validated against `DEBUG | INFO | WARNING | ERROR | CRITICAL` (case-insensitive, stored uppercased). Surfaced in the `/config` screen automatically. Absent means the effective level falls through to env var or default.

```toml
log_level = "DEBUG"
```

### `/log-level` command

Inspect and control the log level at runtime.

```text
/log-level                       # show current levels (session, env, config, effective)
/log-level set DEBUG             # override for this process
/log-level set-global INFO       # also persist to config.toml
/log-level unset                 # clear the session override
```

### Invocation logging

Structured logs on every model and tool call. No raw model messages, tool arguments, or tool output — only metadata.

- **Model calls**: `DEBUG` before (model, provider, message/tool count, thinking), `INFO` after success (duration, token usage), `WARNING` on failure with full `BackendError` details (status, reason, endpoint, body excerpt, payload summary)
- **Tool calls**: `DEBUG` before (tool name, call_id), `INFO` after success (duration, outcome), `WARNING` on failure (error message), `INFO` on permission denial

### Docs

- README: new Logging section
- CONTRIBUTING: runtime log level docs + logging conventions for contributors
- Builtin vibe skill: `/log-level` command and `log_level` config field documented

## Implementation details

- `_LogLevelState` singleton holds session override and config level; setters auto-apply the effective level to the file handler
- `LogLevelChain` frozen dataclass exposes every layer (session, env, config, effective) for the status output
- Config level applied at mount time via `set_config_log_level`, not just on config-change events
- `init_file_logging` delegates to `_LogLevelState` — single mechanism for setting/changing the handler level; `DEBUG_MODE` read via cached `_get_env_log_level`
- `_log_model_call_success` / `_log_model_call_failure` helpers shared across `_complete` and `_chat_streaming`

## Test plan

- [x] `uv run pytest tests/observability/test_logging.py tests/cli/test_log_level_command.py tests/core/config/test_vibe_config_schema.py` — 75 passed
- [x] `uv run pyright` — 0 errors
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] Manual smoke test: `/log-level`, `/log-level set DEBUG`, `/log-level unset`, `/log-level set-global INFO`