### PR TITLE
fix(acp): advertise the thinking selector under the reserved thought_level category

### DIFF
--- a/tests/acp/test_agent_methods.py
+++ b/tests/acp/test_agent_methods.py
@@ -168,6 +168,24 @@ async def test_config_options_delegate_to_typed_app_server_resources(
         await acp_agent_loop.set_config_option("unknown", session_id, "x")
 
 
+@pytest.mark.asyncio
+async def test_new_session_advertises_thinking_under_the_reserved_acp_category(
+    acp_agent_loop: VibeAcpAgent,
+) -> None:
+    response = await acp_agent_loop.new_session(cwd=str(Path.cwd()), mcp_servers=[])
+
+    assert response.config_options is not None
+    categories = {option.id: option.category for option in response.config_options}
+    assert categories["thinking"] == "thought_level"
+    assert categories["mode"] == "mode"
+    assert categories["model"] == "model"
+
+    assert (
+        await acp_agent_loop.set_config_option("thinking", response.session_id, "low")
+        is not None
+    )
+
+
 def _acp_agent_with_allowed_models() -> VibeAcpAgent:
     config = build_test_vibe_config(
         active_model="allowed",

--- a/vibe/acp/utils.py
+++ b/vibe/acp/utils.py
@@ -120,7 +120,9 @@ def make_thinking_response(config: ConfigView) -> SessionConfigOptionSelect:
         id="thinking",
         name="Thinking",
         current_value=config.active_model.thinking,
-        category="thinking",
+        # ACP reserves `thought_level` for reasoning-level selectors; clients
+        # that match on the reserved category drop anything else.
+        category="thought_level",
         type="select",
         options=[
             SessionConfigSelectOption(value=level, name=level.capitalize())


### PR DESCRIPTION
Fixes #989

## Summary

The ACP session-config spec reserves four category names, one of which is `thought_level` for reasoning-level selectors. `vibe-acp` sends `category: "thinking"`, which is not reserved, so a client that looks the option up by category never finds it.

- Paseo drops the option entirely: no thinking selector, and setting a thinking level fails with "does not expose ACP thought-level selection".
- Zed renders it through its generic `select` path, so the selector works, but `CycleThinkingEffort` and `ToggleThinkingEffortMenu` bind to `thought_level` and so never reach it.

## Change

One line in `make_thinking_response`: `category="thought_level"`.

The option id stays `"thinking"`. `set_config_option` matches on the id, so its contract is unchanged, and generic clients that render every `select` option are unaffected. `SessionConfigOptionSelect.category` is `str | None` in `acp.schema`, so nothing in the schema needed to change.

## Tests

`tests/acp/test_agent_methods.py::test_new_session_advertises_thinking_under_the_reserved_acp_category` asserts the categories a client actually receives from `session/new` — `mode`, `model`, `thought_level` — and that `set_config_option("thinking", …)` still succeeds afterwards.

## Verification

Workflows do not run on pull requests from forks in this repository, so these were run locally on 2.24.2 plus this change:

- `uv run pytest tests/acp` — 195 passed
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright` — clean
