### PR TITLE
fix(cli): stop tracebacks when the UI is torn down mid-submit

### DIFF
--- a/tests/cli/test_ui_exit_command.py
+++ b/tests/cli/test_ui_exit_command.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from textual.containers import VerticalGroup
 
 from tests.conftest import build_test_vibe_app
 from vibe.cli.textual_ui.widgets.chat_input.container import ChatInputContainer
@@ -36,3 +37,66 @@ async def test_exit_synonym_runs_exit_handler_and_is_not_sent_as_prompt(
             if not isinstance(m, SlashCommandMessage)
         ]
         assert prompts == []
+
+
+@pytest.mark.asyncio
+async def test_exit_does_not_echo_the_command_into_a_ui_that_is_closing() -> None:
+    vibe_app = build_test_vibe_app()
+    async with vibe_app.run_test() as pilot:
+        await pilot.pause(0.1)
+
+        chat_input = vibe_app.query_one(ChatInputContainer)
+        chat_input.post_message(ChatInputContainer.Submitted("/exit"))
+        await pilot.pause(0.2)
+
+        assert vibe_app.query(SlashCommandMessage).nodes == []
+
+
+@pytest.mark.asyncio
+async def test_submit_after_teardown_does_not_raise() -> None:
+    vibe_app = build_test_vibe_app()
+    async with vibe_app.run_test() as pilot:
+        await pilot.pause(0.1)
+
+        await vibe_app.query_one(ChatInputContainer).remove()
+
+        await vibe_app.on_chat_input_container_submitted(
+            ChatInputContainer.Submitted("/help")
+        )
+        await pilot.pause(0.1)
+
+
+@pytest.mark.asyncio
+async def test_mounting_into_an_unattached_messages_area_does_not_raise() -> None:
+    vibe_app = build_test_vibe_app()
+    async with vibe_app.run_test() as pilot:
+        await pilot.pause(0.1)
+
+        # The state behind the reported MountError: #messages is resolvable but
+        # not attached to the DOM, either not mounted yet or already detached.
+        vibe_app._cached_messages_area = VerticalGroup(id="messages")
+
+        await vibe_app._mount_and_scroll(UserMessage("late"))
+        await pilot.pause(0.1)
+
+
+@pytest.mark.asyncio
+async def test_submit_while_exiting_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    vibe_app = build_test_vibe_app()
+    async with vibe_app.run_test() as pilot:
+        await pilot.pause(0.1)
+
+        dispatched: list[str] = []
+
+        async def _record(value: str) -> None:
+            dispatched.append(value)
+
+        monkeypatch.setattr(vibe_app, "_handle_user_message", _record)
+        vibe_app._force_quit()
+
+        await vibe_app.on_chat_input_container_submitted(
+            ChatInputContainer.Submitted("hello")
+        )
+        await pilot.pause(0.1)
+
+        assert dispatched == []

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -21,6 +21,7 @@ from rich import print as rprint
 from textual.app import WINDOWS, App, ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Horizontal, VerticalGroup, VerticalScroll
+from textual.css.query import NoMatches
 from textual.dom import NoScreen
 from textual.driver import Driver
 from textual.events import AppBlur, AppFocus, MouseScrollDown, MouseScrollUp, MouseUp
@@ -594,6 +595,8 @@ class VibeApp(App):  # noqa: PLR0904
     CSS_PATH = "app.tcss"
     PAUSE_GC_ON_SCROLL: ClassVar[bool] = True
 
+    _exiting: bool = False
+
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("ctrl+c", "interrupt_or_quit", "Quit", show=False),
         Binding("ctrl+d", "delete_right_or_quit", "Quit", show=False, priority=True),
@@ -999,6 +1002,12 @@ class VibeApp(App):  # noqa: PLR0904
             self._cached_messages_area = self.query_one("#messages")
         return self._cached_messages_area
 
+    def _mounted_messages_area(self) -> Widget | None:
+        with suppress(NoMatches):
+            messages_area = self._messages_area
+            return messages_area if messages_area.is_attached else None
+        return None
+
     @property
     def _chat_widget(self) -> ChatScroll:
         if self._cached_chat is None:
@@ -1332,8 +1341,15 @@ class VibeApp(App):  # noqa: PLR0904
     async def on_chat_input_container_submitted(
         self, event: ChatInputContainer.Submitted
     ) -> None:
+        # A submit already in the message queue is still delivered while Textual
+        # tears the UI down, so both the input and the chat DOM can be gone.
+        if self._exiting:
+            return
+        input_widget = self._get_chat_input()
+        if input_widget is None:
+            return
+
         value = event.value.strip()
-        input_widget = self.query_one(ChatInputContainer)
 
         if not value and not self._input_queue.paused:
             return
@@ -1375,6 +1391,8 @@ class VibeApp(App):  # noqa: PLR0904
         self.notify(message, severity="warning", markup=False)
 
     async def _dispatch_idle_input(self, value: str) -> None:
+        if self._exiting:
+            return
         # Plain prompts are guarded by the readiness await in
         # _prepare_prompt_or_abort. classify() and the slash/skill/bash branches
         # below touch app_server directly, so those can still hit the unbound
@@ -1980,7 +1998,8 @@ class VibeApp(App):  # noqa: PLR0904
                 else cmd_name
             )
             command_message = SlashCommandMessage(display)
-            await self._mount_and_scroll(command_message)
+            if not command.exits:
+                await self._mount_and_scroll(command_message)
             handler = getattr(self, command.handler)
             if asyncio.iscoroutinefunction(handler):
                 await handler(cmd_args=cmd_args, command_message=command_message)
@@ -3689,6 +3708,7 @@ class VibeApp(App):  # noqa: PLR0904
         return self.app_server.exit_summary()
 
     async def _exit_app(self, **kwargs: Any) -> None:
+        self._exiting = True
         try:
             await self._begin_shutdown()
             if self._agent_task and not self._agent_task.done():
@@ -4629,6 +4649,7 @@ class VibeApp(App):  # noqa: PLR0904
     def _force_quit(self) -> None:
         if self._force_quit_task is not None and not self._force_quit_task.done():
             return
+        self._exiting = True
         self._force_quit_task = asyncio.create_task(self._force_quit_async())
 
     async def _force_quit_async(self) -> None:
@@ -4856,7 +4877,10 @@ class VibeApp(App):  # noqa: PLR0904
         *,
         container: Widget | None = None,
     ) -> None:
-        messages_area = self._messages_area
+        messages_area = self._mounted_messages_area()
+        if messages_area is None:
+            logger.debug("Dropped a %s mount: no chat DOM", type(widget).__name__)
+            return
         is_user_initiated = isinstance(widget, (UserMessage, UserCommandMessage))
         should_anchor = is_user_initiated or self._chat_widget.is_at_bottom
 
@@ -4866,6 +4890,16 @@ class VibeApp(App):  # noqa: PLR0904
 
         before_parent = before.parent if before is not None else None
         after_parent = after.parent if after is not None else None
+        target = messages_area
+        if isinstance(before_parent, Widget):
+            target = before_parent
+        elif isinstance(after_parent, Widget):
+            target = after_parent
+        elif container is not None:
+            target = container
+        if not target.is_attached:
+            logger.debug("Dropped a %s mount: target detached", type(widget).__name__)
+            return
         with self.batch_update():
             if isinstance(before_parent, Widget):
                 await before_parent.mount(widget, before=before)


### PR DESCRIPTION
Fixes #929

## Summary

Textual keeps delivering a queued `ChatInputContainer.Submitted` while the app shuts down, so the submit handler runs against a chat DOM that is already going away. `query_one(ChatInputContainer)` raises `NoMatches`, and the `/exit` echo is mounted into a `#messages` that Textual no longer considers mounted, which raises `MountError`. The process exits fine, so the tracebacks are cosmetic, but they print on every `/exit`, Ctrl+C and Ctrl+D.

## Note on the report

The report is against 2.21.0 and names `self.exiting`. That attribute no longer exists on `main`; the two quit paths are now `_exit_app` and `_force_quit`. These are the four guards the reporter proposed, re-sited onto the current code.

## Change

- An `_exiting` flag, set as soon as either quit path starts, short-circuits `on_chat_input_container_submitted` and `_dispatch_idle_input`.
- The submit handler resolves the input through the existing `_get_chat_input()`, which returns `None` instead of raising when the widget is gone.
- `_mount_and_scroll` resolves its mount target first and drops the mount when that target is not attached, instead of letting Textual raise. Both drops log at debug level.
- A command with `exits=True` no longer echoes a `SlashCommandMessage` it would only display for the instant before teardown.

## Tests

Four tests in `tests/cli/test_ui_exit_command.py`, each of which fails on 2.24.2 and passes with this change:

- `test_exit_does_not_echo_the_command_into_a_ui_that_is_closing`
- `test_submit_after_teardown_does_not_raise` — reproduces the `NoMatches` frame
- `test_submit_while_exiting_is_ignored`
- `test_mounting_into_an_unattached_messages_area_does_not_raise` — reproduces `MountError: Can't mount widget(s) before VerticalGroup(id='messages') is mounted`, the last frame in the report, by putting the cached `#messages` into the state the report's locals show

## Scope of the claim

This covers the five frames in the report, which all run through the submit path. It does not make every teardown-time mount in the app safe. A full-suite run on unmodified 2.24.2 hit `MountError("Can't mount widget(s) before ToolGroup(classes='tool-group') is mounted")` from a worker in `tests/cli/test_ui_skill_dispatch.py::test_idle_skill_fires_telemetry` — the same failure class reached from a different path, which this change does not address. Would you like that path covered here as well, or kept separate?

## Verification

Workflows do not run on pull requests from forks in this repository, so these were run locally on 2.24.2 plus this change:

- `uv run pytest tests/cli/test_ui_exit_command.py` — 9 passed
- `uv run pytest tests/cli tests/snapshots` — 1485 passed, 1 failed: `test_chat_input_word_drag.py::test_jitter_within_word_does_not_break_click_chain`
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright` — clean

That one failure is a wall-clock click-chain test. Running it in alternating rounds against unmodified 2.24.2 and against this branch, it failed on both sides and tracked run duration rather than the branch — on a loaded machine it failed in 2 of 4 rounds on 2.24.2 and 4 of 4 on the branch, on an idle machine in neither. It does not touch any code path changed here.
