### PR TITLE
fix(shell): stop cmd.exe mangling quoted arguments containing blanks

### DIFF
--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -131,8 +131,10 @@ async def test_handles_timeout(bash):
     assert "Command timed out after 1s" in str(err.value)
 
 
-@pytest.mark.asyncio
-async def test_windows_cmd_spawn_ignores_non_cmd_comspec(monkeypatch):
+_WINDOWS_SPAWN_SENTINEL = object()
+
+
+def _arrange_windows_cmd_shell(monkeypatch) -> list[tuple[tuple, dict]]:
     monkeypatch.setattr(sys, "platform", "win32")
     _hide_standard_git_installs(monkeypatch)
     monkeypatch.setenv(
@@ -143,32 +145,52 @@ async def test_windows_cmd_spawn_ignores_non_cmd_comspec(monkeypatch):
         "vibe.utils.platform.shutil.which", lambda name, path=None: None
     )
 
-    proc = object()
-    calls = []
-
-    async def fake_create_subprocess_exec(*args, **kwargs):
-        calls.append((args, kwargs))
-        return proc
+    calls: list[tuple[tuple, dict]] = []
 
     async def fake_create_subprocess_shell(*args, **kwargs):
-        raise AssertionError("cmd fallback must not use COMSPEC-backed shell mode")
+        calls.append((args, kwargs))
+        return _WINDOWS_SPAWN_SENTINEL
 
-    monkeypatch.setattr(
-        bash_module.asyncio, "create_subprocess_exec", fake_create_subprocess_exec
-    )
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        raise AssertionError("cmd fallback must not go through list2cmdline")
+
     monkeypatch.setattr(
         bash_module.asyncio, "create_subprocess_shell", fake_create_subprocess_shell
     )
+    monkeypatch.setattr(
+        bash_module.asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_windows_cmd_spawn_ignores_non_cmd_comspec(monkeypatch):
+    calls = _arrange_windows_cmd_shell(monkeypatch)
 
     result = await bash_module.spawn_shell_command("echo hello")
 
-    assert result is proc
-    assert calls[0][0][:4] == (
+    assert result is _WINDOWS_SPAWN_SENTINEL
+    assert calls[0][0][0] == "echo hello"
+    assert calls[0][1]["executable"] == "C:\\Windows\\System32\\cmd.exe"
+
+
+@pytest.mark.asyncio
+async def test_windows_cmd_spawn_keeps_quoted_arguments_with_blanks_intact(monkeypatch):
+    calls = _arrange_windows_cmd_shell(monkeypatch)
+    command = 'git commit -m "Foo Bar Baz"'
+
+    await bash_module.spawn_shell_command(command)
+
+    assert calls[0][0][0] == command
+    # Regression guard for the argv form: list2cmdline escapes the inner quotes
+    # as \", cmd.exe strips only the outer pair, and git then sees Bar and Baz"
+    # as separate pathspecs.
+    assert '\\"' in subprocess.list2cmdline([
         "C:\\Windows\\System32\\cmd.exe",
         "/d",
         "/c",
-        "echo hello",
-    )
+        command,
+    ])
 
 
 @pytest.mark.asyncio

--- a/vibe/core/utils/shell.py
+++ b/vibe/core/utils/shell.py
@@ -31,16 +31,20 @@ async def spawn_shell_command(
                 env=env,
                 cwd=cwd,
             )
-        return await asyncio.create_subprocess_exec(
-            shell.executable or "cmd.exe",
-            "/d",
-            "/c",
+        # cmd.exe must receive the command as one raw command-line tail, not as
+        # an argv entry: exec mode routes it through subprocess.list2cmdline,
+        # which escapes inner quotes as \" — a form cmd.exe does not undo, so
+        # `git commit -m "a b"` reaches git as three broken pathspecs. Shell
+        # mode passes it verbatim, and pinning `executable` keeps CPython from
+        # consulting COMSPEC to pick the interpreter.
+        return await asyncio.create_subprocess_shell(
             command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             stdin=asyncio.subprocess.DEVNULL,
             env=env,
             cwd=cwd,
+            executable=shell.executable or "cmd.exe",
         )
 
     return await asyncio.create_subprocess_shell(


### PR DESCRIPTION
Fixes #970

## Summary

Since 2.20.0 (`8dce11d5`) the Windows cmd.exe fallback in `vibe/core/utils/shell.py::spawn_shell_command` spawns with `asyncio.create_subprocess_exec("cmd.exe", "/d", "/c", command)`. On Windows there is no argv — `subprocess` folds that list into a single command line with `subprocess.list2cmdline`, which escapes the inner quotes as `\"`:

```
list2cmdline(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", 'git commit -m "Foo Bar Baz"'])
→ C:\Windows\System32\cmd.exe /d /c "git commit -m \"Foo Bar Baz\""
```

cmd.exe does not undo that escaping. With four quote characters on the line it takes the documented `/c` fallback — strip the first quote and the last quote — and hands the child `git commit -m \"Foo Bar Baz\"`. The child's own command-line parsing reads `\"` as a literal quote and splits on the blanks, which is the reported `error: pathspec 'Bar'` / `error: pathspec 'Baz"'`.

The bash-on-Windows branch is not affected: `bash.exe` parses its command line with the same rules `list2cmdline` writes, so `bash -c <command>` already arrived intact. Only the cmd.exe fallback is wrong.

## Change

`vibe/core/utils/shell.py` — the cmd.exe fallback moves from exec mode to shell mode, which passes the command line through verbatim:

```diff
-        return await asyncio.create_subprocess_exec(
-            shell.executable or "cmd.exe",
-            "/d",
-            "/c",
+        return await asyncio.create_subprocess_shell(
             command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             stdin=asyncio.subprocess.DEVNULL,
             env=env,
             cwd=cwd,
+            executable=shell.executable or "cmd.exe",
         )
```

`executable=` is what keeps the guarantee 2.20.0 added. CPython's `subprocess._execute_child` only consults `COMSPEC` when `executable` is empty (Windows branch: `if not executable: comspec = os.environ.get('ComSpec') … else: comspec = executable`), so the path `resolve_windows_shell()` picked is used both as the process image and as the head of the command line. A hijacked or non-cmd `COMSPEC` still cannot be reached.

## Tests

In `tests/tools/test_bash.py`, both Linux-runnable per `AGENTS.md` (they monkeypatch `sys.platform` and the probes rather than skipping):

- `test_windows_cmd_spawn_ignores_non_cmd_comspec` — retargeted to shell mode, still asserting the resolved cmd.exe path is passed as `executable` and that a non-cmd `COMSPEC` is not consulted. The existing shared arrangement is factored into `_arrange_windows_cmd_shell`.
- `test_windows_cmd_spawn_keeps_quoted_arguments_with_blanks_intact` — new. Asserts the command reaches the spawn verbatim, and pins the reason via `list2cmdline`, so the argv form cannot be reintroduced without the test failing.

## Verification on Windows

CI does not run workflows on pull requests from forks here, and `AGENTS.md` asks for manual native Windows commands and results when Windows shell CI is unavailable. All of the below is from a native Windows host — no WSL, no container.

| | |
| --- | --- |
| OS | Microsoft Windows 10 Pro, build 10.0.19045.7663 |
| cmd.exe | `C:\Windows\System32\cmd.exe`, version 10.0.19041.320 |
| Python | 3.12.13 (project venv via `uv sync --all-extras`) |
| Git for Windows | 2.31.1.windows.1, **present** — `C:\Program Files\Git\bin\bash.exe` exists |
| Baseline | `main` at 2.24.2 (`5e6aa0f`) |
| Branch | `283d804` |

### Forcing the cmd.exe branch

Git for Windows is installed on this machine, so `resolve_windows_shell()` prefers bash and the code under test never runs by default. Worth flagging for anyone reproducing this: **the environment cannot be stripped from a parent shell.** Windows re-synthesizes `%ProgramFiles%` into every child process, so clearing it in cmd or PowerShell does not reach the child:

```
$ cmd /d /c 'set "ProgramFiles=" & .venv\Scripts\python.exe -c "import os;print(os.environ.get(''ProgramFiles''))"'
child sees ProgramFiles= 'C:\Program Files'
```

`resolve_windows_shell()` reads `os.environ` at call time and is `lru_cache`d, so the working approach is to doctor `os.environ` in-process before the first call. No vibe code is patched — the real resolver runs, against an environment in which no bash is discoverable:

```python
os.environ["PATH"] = r"C:\Windows\System32;C:\Windows"
for var in ("ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"):
    os.environ[var] = r"C:\no-such-dir-970"
```

Both runs below then report `resolved shell : kind=CMD executable=C:\Windows\system32\cmd.exe` before executing anything. Commands are driven through `vibe.core.utils.shell.spawn_shell_command`, which is exactly what a `!` command reaches — `!<cmd>` classifies to `Bash(command=…)` in `vibe/cli/textual_ui/widgets/chat_input/input_kinds.py`, and `vibe/core/tools/builtins/bash.py:579` calls `spawn_shell_command(args.command, cwd=self.cwd)`. Driving that function directly keeps the TUI out of the transcript without changing the code path under test.

`git.exe` is invoked by its 8.3 short path `C:\PROGRA~1\Git\cmd\git.exe`, which contains no blanks and so needs no quoting of its own — only the commit message is quoted, matching the report. Invoking it that way also keeps `git` off `PATH`, so it cannot pull bash back into the resolution above.

### Before — `main` @ `5e6aa0f`

```
resolved shell : kind=CMD executable=C:\Windows\system32\cmd.exe

$ echo "Foo Bar Baz"
  rc     : 0
  stdout | \"Foo Bar Baz\"

$ C:\Windows\System32\findstr.exe /C:"Foo Bar" nul & echo done
  rc     : 0
  stdout | done
  stderr | FINDSTR: Cannot open Bar"

$ dir "C:\Program Files"
  rc     : 1
  stderr | The filename, directory name, or volume label syntax is incorrect.

$ echo a & echo b
  rc     : 0
  stdout | a
  stdout | b

$ echo %CD%
  rc     : 0
  stdout | C:\Users\Igor\Documents\GitHub\OSS\mistral-vibe

$ C:\PROGRA~1\Git\cmd\git.exe commit --allow-empty -m "Foo Bar Baz"
  rc     : 1
  stderr | error: pathspec 'Bar' did not match any file(s) known to git
  stderr | error: pathspec 'Baz"' did not match any file(s) known to git

$ C:\PROGRA~1\Git\cmd\git.exe log -1 --pretty=%s
  rc     : 0
  stdout | base
```

That is the reporter's symptom reproduced exactly, and `git log` confirms no commit was created.

### After — `283d804`

```
resolved shell : kind=CMD executable=C:\Windows\system32\cmd.exe

$ echo "Foo Bar Baz"
  rc     : 0
  stdout | "Foo Bar Baz"

$ C:\Windows\System32\findstr.exe /C:"Foo Bar" nul & echo done
  rc     : 0
  stdout | done

$ dir "C:\Program Files"
  rc     : 0
  stdout |  Volume in drive C is OS
  stdout |  Directory of C:\Program Files
  stdout |  [full listing, 65 dirs — trimmed here]

$ echo a & echo b
  rc     : 0
  stdout | a
  stdout | b

$ echo %CD%
  rc     : 0
  stdout | C:\Users\Igor\Documents\GitHub\OSS\mistral-vibe

$ C:\PROGRA~1\Git\cmd\git.exe commit --allow-empty -m "Foo Bar Baz"
  rc     : 0
  stdout | [master 1d05379] Foo Bar Baz

$ C:\PROGRA~1\Git\cmd\git.exe log -1 --pretty=%s
  rc     : 0
  stdout | Foo Bar Baz
```

The commit subject is exactly `Foo Bar Baz`. `&` chaining, which shell mode now hands to cmd.exe unchanged, still behaves.

### The mechanism in isolation

Independent of Vibe, on stock Python 3.12.13:

```
old command line: C:\Windows\System32\cmd.exe /d /c "echo \"Foo Bar Baz\""
new command line: C:\Windows\System32\cmd.exe /c "echo "Foo Bar Baz""
old output: \"Foo Bar Baz\"
new output: "Foo Bar Baz"
```

### Test suite

`uv run pytest` on this Windows host, both branches. CI is Linux-only, so much of the suite meets a real Windows host here for the first time and there is a large pre-existing failure baseline — `ModuleNotFoundError: No module named 'fcntl'`, `module 'time' has no attribute 'tzset'`, `os.getuid`, and git-lock races under `xdist`. None of it is introduced by this change.

Full suite, same host, back to back:

| | main `5e6aa0f` | branch `283d804` |
| --- | --- | --- |
| run A | 355 failed, 8994 passed, 77 skipped, 174 errors | 356 failed, 8994 passed, 77 skipped, 174 errors |
| run B | 359 failed, 8990 passed, 77 skipped, 174 errors | 356 failed, 8994 passed, 77 skipped, 174 errors |

`main` moved by 4 between two runs of the same commit, so the totals are noise. Comparing failure *names* instead, the branch-only set was three tests, all re-run to check:

- `tests/audio_recorder/test_audio_recorder.py::TestStreamMode::test_stop_without_drain_returns_promptly`
- `tests/cli/test_ui_skill_dispatch.py::test_skill_with_args_displays_literal_command_with_args`
- `tests/cli/test_ui_skill_dispatch.py::test_skill_without_args_displays_literal_command`

Running just those two files three times per branch, `main` produced 2, 3 and 4 failures across identical runs, and its 4-failure run was the same four names the branch produces. They are wall-clock/UI flakes on this host, present on `main`, and touch no shell-spawning code.

The files that matter:

- `tests/tools/test_bash.py` + `tests/core/utils/test_shell.py` — main 37 failed / 70 passed, branch 37 failed / **71** passed. Same failures (all `fcntl`), one extra pass: the new test.
- `uv run pytest -k windows_cmd_spawn tests/tools/test_bash.py` — 2 passed (`test_windows_cmd_spawn_ignores_non_cmd_comspec`, `test_windows_cmd_spawn_keeps_quoted_arguments_with_blanks_intact`).
- `uv run pytest tests/core/utils/test_shell.py` — 3 passed.
- `tests/app_server` — the other caller of `spawn_shell_command`, via `vibe/app_server/_shell.py`. 46 failed / 492 passed on both, and the sorted failure-name sets are **identical**. The four `tests/app_server/test_shell.py` failures there (`[WinError 3] The system cannot find the path specified`) reproduce unchanged on `main`.

Lint and types, on the branch:

- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 1038 files already formatted
- `uv run pyright` — 38 errors, byte-identical to `main`'s 38, all POSIX-module attribute errors from analyzing on a Windows host (`termios`, `fcntl`, `pty`, `signal.SIGKILL`, `os.getuid`). None are in `shell.py` or the touched tests.

## Known trade-off

Shell mode cannot carry `/d`, so a `Command Processor\AutoRun` script runs again for each spawned command, as it did before 2.20.0. This host has one set, so it was measured rather than predicted:

```
HKCU AutoRun: 'if exist "C:\Users\Igor\anaconda3\condabin\conda_hook.bat" "C:\Users\Igor\anaconda3\condabin\conda_hook.bat"'
HKLM AutoRun: None

with /d (main's form)    stdout='hi' stderr=''
without /d (branch form) stdout='hi' stderr=''

with /d   :    12.4 ms per spawn (mean of 15)
without /d:    29.8 ms per spawn (mean of 15)
```

On this machine the AutoRun script is silent, so **nothing leaks into tool output** — but it costs roughly +17 ms per command, about 2.4x the spawn time. A noisier AutoRun (a banner, a `chcp` line) would appear in tool results, which is the more disruptive form of this.

If you would rather not accept that, the alternative is to keep exec mode and pre-quote the command so `list2cmdline` round-trips to what cmd.exe should see. I did not go that way: it means reimplementing cmd.exe's quote-stripping rules well enough to be correct for arbitrary user commands, including carets, `&`, and unbalanced quotes, and the failure mode is silent mangling rather than a clean error. Shell mode hands cmd.exe the string the user typed, which is what the tool promises. Happy to switch if you prefer keeping the `/d` guarantee.
