### PR TITLE
feat(tui): show active model, session cost, and memory in status bar

### DIFF
--- a/tests/cli/textual_ui/test_context_progress.py
+++ b/tests/cli/textual_ui/test_context_progress.py
@@ -33,3 +33,34 @@ def test_context_progress_uses_compact_integer_m_format() -> None:
     widget.watch_tokens(TokenState(max_tokens=40_000_000, current_tokens=35_900_000))
 
     assert str(widget.render()) == "35.9M/40.0M tokens (90%)"
+
+
+def test_context_progress_renders_model_name() -> None:
+    widget = ContextProgress()
+
+    widget.watch_tokens(
+        TokenState(
+            max_tokens=200_000, current_tokens=10_000, model_name="mistral-large-latest"
+        )
+    )
+
+    assert str(widget.render()) == "10k/200k tokens (5%) | [mistral-large-latest]"
+
+
+def test_context_progress_renders_cost_and_memory() -> None:
+    widget = ContextProgress()
+
+    widget.watch_tokens(
+        TokenState(
+            max_tokens=200_000,
+            current_tokens=20_000,
+            model_name="dev",
+            session_cost=0.035,
+            memory_bytes=100 * 1024 * 1024,
+            total_memory_bytes=250 * 1024 * 1024,
+        )
+    )
+
+    dollar = chr(36)
+    expected = f"20k/200k tokens (10%) | [dev] | {dollar}0.04 | 100.0M"
+    assert str(widget.render()) == expected

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -144,7 +144,11 @@ from vibe.cli.textual_ui.widgets.chat_input.paste_image import (
 from vibe.cli.textual_ui.widgets.chat_input.text_area import ChatTextArea
 from vibe.cli.textual_ui.widgets.collapsible import CollapsibleSection
 from vibe.cli.textual_ui.widgets.compact import CompactMessage
-from vibe.cli.textual_ui.widgets.context_progress import ContextProgress, TokenState
+from vibe.cli.textual_ui.widgets.context_progress import (
+    ContextProgress,
+    TokenState,
+    _get_total_memory,
+)
 from vibe.cli.textual_ui.widgets.debug_console import DebugConsole
 from vibe.cli.textual_ui.widgets.feedback_bar import FeedbackBar
 from vibe.cli.textual_ui.widgets.inline_notice import InlineNotice
@@ -987,9 +991,21 @@ class VibeApp(App):  # noqa: PLR0904
             context_progress = ContextProgress()
             if has_session:
                 stats = self.app_server.resources.runtime.stats
+                try:
+                    import psutil
+
+                    memory_bytes = psutil.Process().memory_info().rss
+                except Exception:
+                    memory_bytes = _get_total_memory()
                 context_progress.tokens = TokenState(
                     max_tokens=self.app_server.resources.runtime.context_window,
                     current_tokens=stats.context_tokens,
+                    model_name=self.config.active_model.alias
+                    if self.config.active_model
+                    else "",
+                    session_cost=stats.session_cost,
+                    memory_bytes=memory_bytes,
+                    total_memory_bytes=_get_total_memory(),
                 )
             yield context_progress
 
@@ -1127,10 +1143,41 @@ class VibeApp(App):  # noqa: PLR0904
         gc.freeze()
 
     def _update_context_progress(self, event: StatsUpdated) -> None:
+        self._refresh_context_progress(event.params)
+
+    def _refresh_context_progress(
+        self, params: Any | None = None, *, model_name: str | None = None
+    ) -> None:
         context_progress = self.query_one(ContextProgress)
+        try:
+            import psutil
+
+            memory_bytes = psutil.Process().memory_info().rss
+        except Exception:
+            memory_bytes = _get_total_memory()
+
+        if params is not None:
+            max_tokens = params.context_window
+            current_tokens = params.stats.context_tokens
+            session_cost = params.stats.session_cost
+        else:
+            runtime = self.app_server.resources.runtime
+            max_tokens = runtime.context_window
+            current_tokens = runtime.stats.context_tokens
+            session_cost = runtime.stats.session_cost
+
+        if model_name is None:
+            model_name = (
+                self.config.active_model.alias if self.config.active_model else ""
+            )
+
         context_progress.tokens = TokenState(
-            max_tokens=event.params.context_window,
-            current_tokens=event.params.stats.context_tokens,
+            max_tokens=max_tokens,
+            current_tokens=current_tokens,
+            model_name=model_name,
+            session_cost=session_cost,
+            memory_bytes=memory_bytes,
+            total_memory_bytes=_get_total_memory(),
         )
 
     def _start_post_ready_startup(self) -> None:
@@ -1676,6 +1723,7 @@ class VibeApp(App):  # noqa: PLR0904
             return
         await self.app_server.resources.config.update({"active_model": message.alias})
         await self._reload_config()
+        self._refresh_context_progress(model_name=message.alias)
         await self._switch_to_input_app()
 
     async def on_model_picker_app_cancelled(
@@ -1986,6 +2034,7 @@ class VibeApp(App):  # noqa: PLR0904
                 await handler(cmd_args=cmd_args, command_message=command_message)
             else:
                 handler(cmd_args=cmd_args, command_message=command_message)
+            self._refresh_context_progress()
             return True
         return False
 
@@ -4455,13 +4504,6 @@ class VibeApp(App):  # noqa: PLR0904
 
     def _refresh_profile_widgets(self) -> None:
         self._update_profile_widgets(self.app_server.resources.agents.active)
-
-    def _refresh_context_progress(self) -> None:
-        runtime = self.app_server.resources.runtime
-        self.query_one(ContextProgress).tokens = TokenState(
-            max_tokens=runtime.context_window,
-            current_tokens=runtime.stats.context_tokens,
-        )
 
     def _on_profile_changed(self) -> None:
         self._refresh_profile_widgets()

--- a/vibe/cli/textual_ui/widgets/context_progress.py
+++ b/vibe/cli/textual_ui/widgets/context_progress.py
@@ -10,11 +10,9 @@ from vibe.cli.textual_ui.widgets.no_markup_static import NoMarkupStatic
 _THOUSAND = 1_000
 _MILLION = 1_000_000
 
-
-@dataclass
-class TokenState:
-    max_tokens: int = 0
-    current_tokens: int = 0
+_KIBI = 1024
+_MEBI = 1024 * 1024
+_GIBI = 1024 * 1024 * 1024
 
 
 def _format_token_count(tokens: int) -> str:
@@ -23,6 +21,58 @@ def _format_token_count(tokens: int) -> str:
     if tokens >= _THOUSAND:
         return f"{tokens // _THOUSAND}k"
     return str(tokens)
+
+
+def _format_memory_size(size_bytes: int) -> str:
+    if size_bytes >= _GIBI:
+        return f"{size_bytes / _GIBI:.1f}G"
+    if size_bytes >= _MEBI:
+        return f"{size_bytes / _MEBI:.1f}M"
+    if size_bytes >= _KIBI:
+        return f"{size_bytes / _KIBI:.1f}K"
+    return f"{size_bytes}B"
+
+
+@dataclass
+class TokenState:
+    max_tokens: int = 0
+    current_tokens: int = 0
+    model_name: str = ""
+    session_cost: float = 0.0
+    memory_bytes: int = 0
+    total_memory_bytes: int = 0
+
+
+def _get_total_memory() -> int:
+    """Return total RSS of this process + all direct children in bytes.
+
+    Uses ``psutil`` when available; falls back to the main process only
+    (same as ``memory_bytes``) when psutil is not installed.
+    """
+    try:
+        import psutil
+    except Exception:
+        try:
+            import resource
+            import sys
+
+            rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            return rss if sys.platform == "darwin" else rss * 1024
+        except Exception:
+            return 0
+
+    try:
+        parent = psutil.Process()
+        children = parent.children(recursive=False)
+        total = parent.memory_info().rss
+        for child in children:
+            try:
+                total += child.memory_info().rss
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        return total
+    except Exception:
+        return 0
 
 
 class ContextProgress(NoMarkupStatic):
@@ -37,8 +87,19 @@ class ContextProgress(NoMarkupStatic):
             return
 
         ratio = min(1, new_state.current_tokens / new_state.max_tokens)
-        text = (
+        parts = [
             f"{_format_token_count(new_state.current_tokens)}/"
             f"{_format_token_count(new_state.max_tokens)} tokens ({ratio:.0%})"
-        )
-        self.update(text)
+        ]
+        if new_state.model_name:
+            parts.append(f"[{new_state.model_name}]")
+        if new_state.session_cost > 0:
+            parts.append(f"${new_state.session_cost:.2f}")
+        if new_state.memory_bytes > 0 or new_state.total_memory_bytes > 0:
+            mem_parts = []
+            if new_state.memory_bytes > 0:
+                mem_parts.append(_format_memory_size(new_state.memory_bytes))
+            if new_state.total_memory_bytes > 0:
+                mem_parts.append(_format_memory_size(new_state.total_memory_bytes))
+            parts.append(mem_parts[0])
+        self.update(" | ".join(parts))


### PR DESCRIPTION
### Summary
Extends the bottom status bar widget (`ContextProgress`) to display:
1. **Active Model Alias** — e.g. `[qwen3.7-flash]` or `[codestral-latest]`.
2. **Session Cost** — real-time accumulated session cost in USD (e.g. `$0.04`).
3. **Consolidated Memory Usage (RAM RSS)** — single clean memory indicator (e.g. `131.2M`), with an automated fallback to Python standard library `resource.getrusage` on macOS/Linux when `psutil` is not installed.

### Motivation
- **Model Awareness**: Users can instantly see which model is currently active without needing to open `/model` or run `/status`.
- **Budget Control**: Provides continuous cost transparency during interactive sessions.
- **Resource Monitoring**: Helps track memory footprint when handling large context windows.

### Changes
- `vibe/cli/textual_ui/widgets/context_progress.py`:
  - Extended `TokenState` with `model_name`, `session_cost`, and `memory_bytes`.
  - Added binary IEC memory formatting (`_format_memory_size`) and child process RAM lookup (`_get_total_memory`).
  - Simplified status bar rendering to display a single consolidated memory metric.
- `vibe/cli/textual_ui/app.py`:
  - Updated `_refresh_context_progress()` and initial `compose()` to pass active model alias, cost, and RSS to `ContextProgress`.
- `tests/cli/textual_ui/test_context_progress.py`:
  - Added unit test coverage for model name, cost, and memory formatting.

### Verification
- `uv run pytest tests/cli/textual_ui/test_context_progress.py` (6 passed)
- `uv run ruff check .` and `uv run ruff format --check .` (passed)
