### PR TITLE
feat(cli): display total session cost on exit and support JSON report…

### DIFF
--- a/tests/cli/test_session_exit_cost.py
+++ b/tests/cli/test_session_exit_cost.py
@@ -1,0 +1,38 @@
+"""Tests for session cost formatting and JSON report export in session_exit.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from vibe.app_server import SessionExitSummary
+from vibe.app_server.models import TokenUsage
+from vibe.cli.session_exit import format_session_cost, print_session_resume_message
+
+
+def test_format_session_cost_renders_correct_currency():
+    summary = SessionExitSummary(
+        session_id="test-12345",
+        usage=TokenUsage(input_tokens=1000, output_tokens=200, total_tokens=1200),
+        session_cost=0.0345,
+    )
+    assert format_session_cost(summary) == "Session cost: $0.0345"
+
+
+def test_session_report_json_export(tmp_path: Path):
+    report_file = tmp_path / "vibe_report.json"
+    summary = SessionExitSummary(
+        session_id="test-report-id",
+        usage=TokenUsage(input_tokens=500, output_tokens=50, total_tokens=550),
+        session_cost=0.0125,
+    )
+
+    with patch.dict("os.environ", {"VIBE_REPORT_PATH": str(report_file)}):
+        print_session_resume_message(summary)
+
+    assert report_file.exists()
+    data = json.loads(report_file.read_text())
+    assert data["session_id"] == "test-report-id"
+    assert data["session_cost"] == 0.0125
+    assert data["usage"]["total_tokens"] == 550

--- a/vibe/app_server/session.py
+++ b/vibe/app_server/session.py
@@ -113,6 +113,7 @@ class AppServerTurnError(RuntimeError):
 class SessionExitSummary:
     session_id: str | None
     usage: TokenUsage
+    session_cost: float = 0.0
 
 
 class AppServerSession:
@@ -271,8 +272,11 @@ class AppServerSession:
             if session_log.enabled and session_log.persisted
             else None
         )
+        stats = self.resources.runtime.stats
         return SessionExitSummary(
-            session_id=session_id, usage=self._state.usage_since_baseline()
+            session_id=session_id,
+            usage=self._state.usage_since_baseline(),
+            session_cost=stats.session_cost if hasattr(stats, "session_cost") else 0.0,
         )
 
     async def connect(self) -> None:

--- a/vibe/cli/session_exit.py
+++ b/vibe/cli/session_exit.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
+from pathlib import Path
+
 from rich import print as rprint
 
 from vibe.app_server import SessionExitSummary
@@ -16,12 +20,39 @@ def format_session_usage(usage: TokenUsage) -> str:
     )
 
 
+def format_session_cost(summary: SessionExitSummary) -> str:
+    return f"Session cost: ${getattr(summary, 'session_cost', 0.0):.4f}"
+
+
+def _export_session_report(summary: SessionExitSummary) -> None:
+    report_path = os.environ.get("VIBE_REPORT_PATH")
+    if not report_path:
+        return
+    try:
+        data = {
+            "session_id": summary.session_id,
+            "session_cost": getattr(summary, "session_cost", 0.0),
+            "usage": {
+                "input_tokens": summary.usage.input_tokens,
+                "output_tokens": summary.usage.output_tokens,
+                "total_tokens": summary.usage.total_tokens,
+            },
+        }
+        Path(report_path).write_text(json.dumps(data, indent=2))
+    except Exception:
+        pass
+
+
 def print_session_resume_message(summary: SessionExitSummary | None) -> None:
     if summary is None or summary.session_id is None:
         return
 
+    _export_session_report(summary)
+
     print()
     print(format_session_usage(summary.usage))
+    if getattr(summary, "session_cost", 0.0) > 0:
+        print(format_session_cost(summary))
     print()
     rprint("To continue this session, run: [bold dark_orange]vibe --continue[/]")
     session_id = shorten_session_id(summary.session_id)


### PR DESCRIPTION
### Summary
Extends session finalization to display accumulated session cost in USD upon exit and optionally export a structured session summary JSON report when `VIBE_REPORT_PATH` environment variable is defined.

### Motivation
- **Cost Awareness**: Users receive immediate visibility into total API spend when closing an interactive session.
- **Machine Readability**: External orchestrators can ingest structured JSON telemetry (tokens + cost + session ID) for pipeline billing and automated logging.

### Changes
- `vibe/app_server/session.py`: Extended `SessionExitSummary` with `session_cost: float = 0.0`.
- `vibe/cli/session_exit.py`: Formatted session cost in exit message and added optional JSON export via `VIBE_REPORT_PATH`.
- `tests/cli/test_session_exit_cost.py`: Added unit tests for currency formatting and JSON export.

### Verification
- `uv run pytest tests/cli/test_session_exit_cost.py` (2 passed in 1.48s)
- `uv run ruff check .` and `uv run ruff format --check .` (passed)
