### PR TITLE
fix(app_server): project reused tool call ids as distinct entries (fi…

### DIFF
--- a/tests/app_server/test_events.py
+++ b/tests/app_server/test_events.py
@@ -219,6 +219,61 @@ def test_tool_is_one_public_lifecycle_entry() -> None:
     assert reduced.state.output["content"] == "hello"
 
 
+def test_reused_tool_call_id_projects_a_distinct_effect_entry() -> None:
+    projector = EventProjector("session-1", "turn-1")
+    first_call = projector.project(_read_call())
+    first_result = projector.project(_read_result())
+    # Providers outside the official API restart tool call numbering on every
+    # completion, so the settled id comes back for an unrelated call.
+    second_call = projector.project(_read_call())
+    second_result = projector.project(_read_result())
+
+    assert second_call[-1].method == "history/entryAdded"
+    assert len(projector.history) == 2
+    first, second = projector.history
+    assert first.id == "tool-1"
+    assert second.id != first.id
+    assert isinstance(second, PublicEffectEntry)
+    assert isinstance(second.state, CompletedEffectState)
+    assert second.generation_status == "completed"
+    assert projector.effect_entry_id("tool-1") == second.id
+
+    projection = _projection()
+    updates = [*first_call, *first_result, *second_call, *second_result]
+    for sequence, update in enumerate(updates, start=1):
+        assert projection.consume(_notification(sequence, update)) is not None
+    assert [entry.id for entry in projection.history] == [first.id, second.id]
+
+
+def test_reused_tool_call_id_across_turns_projects_a_distinct_entry() -> None:
+    projector = EventProjector("session-1", "turn-1")
+    projector.project(_read_call())
+    projector.project(_read_result())
+
+    resumed = EventProjector(
+        "session-1",
+        "turn-2",
+        reserved_entry_ids=[entry.id for entry in projector.history],
+    )
+    added = resumed.project(_read_call())
+
+    assert added[-1].method == "history/entryAdded"
+    assert resumed.history[0].id != "tool-1"
+
+
+def test_reused_tool_call_id_without_a_call_event_projects_a_result_entry() -> None:
+    projector = EventProjector("session-1", "turn-1")
+    projector.project(_read_result())
+    updates = projector.project(_read_result())
+
+    assert [update.method for update in updates] == [
+        "history/entryAdded",
+        "history/entryUpdated",
+    ]
+    assert len(projector.history) == 2
+    assert projector.history[1].id != projector.history[0].id
+
+
 def test_callback_entry_is_emitted_before_related_effect_is_blocked() -> None:
     projector = EventProjector("session-1", "turn-1")
     projector.project(_read_call())

--- a/vibe/app_server/_projector.py
+++ b/vibe/app_server/_projector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any, assert_never, cast
 from uuid import uuid4
@@ -88,13 +89,19 @@ class ProjectedUpdate:
 
 class EventProjector:
     def __init__(
-        self, session_id: str, turn_id: str | None, *, session_preview: str = ""
+        self,
+        session_id: str,
+        turn_id: str | None,
+        *,
+        session_preview: str = "",
+        reserved_entry_ids: Iterable[str] = (),
     ) -> None:
         self.session_id = session_id
         self.turn_id = turn_id
         self._session_preview = session_preview
         self.history: list[PublicHistoryEntry] = []
         self._entries: dict[str, PublicHistoryEntry] = {}
+        self._reserved_entry_ids = set(reserved_entry_ids)
         self._assistant_entries: dict[str, str] = {}
         self._reasoning_entries: dict[str, str] = {}
         self._effect_entries: dict[str, str] = {}
@@ -245,10 +252,14 @@ class EventProjector:
             raise ValueError(f"History entry is not an effect: {tool_call_id}")
         return entry.detail
 
+    def effect_entry_id(self, tool_call_id: str) -> str:
+        return self._effect_entries.get(tool_call_id, tool_call_id)
+
     def start_effect(
         self, entry_id: str, *, title: str, detail: EffectDetail
     ) -> ProjectedUpdate:
-        if existing_id := self._effect_entries.get(entry_id):
+        existing_id = self._effect_entries.get(entry_id)
+        if existing_id is not None and not self._is_completed(existing_id):
             return self._patch(
                 existing_id,
                 [
@@ -259,10 +270,17 @@ class EventProjector:
                     )
                 ],
             )
-        self._effect_entries[entry_id] = entry_id
+        # Providers outside the official API routinely restart their tool call
+        # numbering (call_0, call_1, ...) on every completion, so the id can name
+        # an effect that already settled. Project the new call as its own entry
+        # instead of patching a frozen one.
+        projected_id = self._unique_entry_id(entry_id)
+        self._effect_entries[entry_id] = projected_id
         return self._add(
             PublicEffectEntry(
-                **self._entry_fields(entry_id, PublicEntryGenerationStatus.IN_PROGRESS),
+                **self._entry_fields(
+                    projected_id, PublicEntryGenerationStatus.IN_PROGRESS
+                ),
                 title=title,
                 detail=detail,
                 state=RunningEffectState(),
@@ -470,6 +488,29 @@ class EventProjector:
             "generation_status": generation_status,
         }
 
+    def _is_completed(self, entry_id: str) -> bool:
+        entry = self._entries.get(entry_id)
+        return (
+            entry is not None
+            and entry.generation_status is PublicEntryGenerationStatus.COMPLETED
+        )
+
+    def _unique_entry_id(self, entry_id: str) -> str:
+        """Return `entry_id`, or a suffixed variant when it is already taken.
+
+        Entry ids are session-scoped, while tool call ids are only unique within
+        one provider completion, so a reused id must not shadow a settled entry.
+        """
+        if not self._is_taken(entry_id):
+            return entry_id
+        attempt = 2
+        while self._is_taken(candidate := f"{entry_id}#{attempt}"):
+            attempt += 1
+        return candidate
+
+    def _is_taken(self, entry_id: str) -> bool:
+        return entry_id in self._entries or entry_id in self._reserved_entry_ids
+
     def _add(self, entry: PublicHistoryEntry) -> ProjectedUpdate:
         if entry.id in self._entries:
             raise ValueError(f"Duplicate public history entry: {entry.id}")
@@ -625,14 +666,14 @@ class EventProjector:
     ) -> list[ProjectedUpdate]:
         updates: list[ProjectedUpdate] = []
         entry_id = self._effect_entries.get(event.tool_call_id)
-        if entry_id is None:
-            entry_id = event.tool_call_id
+        if entry_id is None or self._is_completed(entry_id):
+            entry_id = self._unique_entry_id(event.tool_call_id)
             self._effect_entries[event.tool_call_id] = entry_id
-            updates.append(self._add(_result_only_effect(self, event)))
+            updates.append(self._add(_result_only_effect(self, event, entry_id)))
         entry = cast(PublicEffectEntry, self._entries[entry_id])
         output_text = _effect_output_text(entry)
         state = project_effect_state(event, output_text=output_text)
-        updates.append(self.complete_effect(entry_id, state))
+        updates.append(self.complete_effect(event.tool_call_id, state))
         return updates
 
     def _project_compaction_started(self, event: CompactStartEvent) -> ProjectedUpdate:
@@ -729,7 +770,7 @@ class EventProjector:
 
 
 def _result_only_effect(
-    projector: EventProjector, event: ToolResultEvent
+    projector: EventProjector, event: ToolResultEvent, entry_id: str
 ) -> PublicEffectEntry:
     display = EffectCallDisplay(
         summary=event.tool_name,
@@ -740,9 +781,7 @@ def _result_only_effect(
         status_text=f"Running {event.tool_name}",
     )
     return PublicEffectEntry(
-        **projector._entry_fields(
-            event.tool_call_id, PublicEntryGenerationStatus.IN_PROGRESS
-        ),
+        **projector._entry_fields(entry_id, PublicEntryGenerationStatus.IN_PROGRESS),
         title=event.tool_name,
         detail=GenericEffectDetail(
             tool_name=event.tool_name, input=None, display=display

--- a/vibe/app_server/_turns.py
+++ b/vibe/app_server/_turns.py
@@ -222,6 +222,7 @@ class TurnController:
             params.session_id,
             turn.id,
             session_preview=session_preview(self._agent_loop),
+            reserved_entry_ids=[entry.id for entry in self.history],
         )
 
         def start_turn() -> None:
@@ -598,7 +599,7 @@ class TurnController:
         detail = ApprovalCallbackDetail(
             effect=projector.effect_detail(event.tool_call_id),
             required_permissions=list(event.required_permissions or []),
-            related_entry_id=event.tool_call_id,
+            related_entry_id=projector.effect_entry_id(event.tool_call_id),
         )
         output = await self._open_callback(
             event, detail, title=f"Allow {event.tool_name}?"
@@ -639,10 +640,16 @@ class TurnController:
             raise TypeError(
                 f"Unsupported user-input request: {type(event.args).__name__}"
             )
+        projector = self._projector
+        related_entry_id = (
+            event.tool_call_id
+            if projector is None
+            else projector.effect_entry_id(event.tool_call_id)
+        )
         output = await self._open_callback(
             event,
             UserInputCallbackDetail(
-                request=event.args, related_entry_id=event.tool_call_id
+                request=event.args, related_entry_id=related_entry_id
             ),
             title="User input required",
         )


### PR DESCRIPTION
## Problem

Fixes #980.

Providers outside the official API restart their tool call numbering
(`call_0`, `call_1`, ...) on every completion, so a tool call id can name an
effect entry that has already settled. `EventProjector` looked the id up in
`_effect_entries` and patched that frozen entry, raising
`Completed public history entry is frozen`.

## Fix

Entry ids are session-scoped, while tool call ids are only unique within a
single completion. A reused id now gets its own entry — suffixed when the id is
already taken — instead of shadowing a completed one:

- `start_effect` only patches an existing entry when it is still in progress.
- `_project_tool_result` does the same for result-only effects.
- `TurnController` passes `reserved_entry_ids` so ids from earlier turns in the
  same session are never reused.
- Approval and user-input callbacks resolve `related_entry_id` through
  `effect_entry_id()`, so prompts still point at the running effect.

## Tests

Three regression tests in `tests/app_server/test_events.py` covering a reused id
within one turn, across turns, and without a preceding call event.

`tests/app_server`: 543 → 546 passed, 0 failed (Linux, 3 consecutive runs).
Ruff, Ruff format and Pyright all clean on the changed files.

---

> I saw CONTRIBUTING.md says code contributions aren't being accepted right now.
> Opening this anyway so the diff and a CI run are available if useful — feel
> free to close it and take the patch, or leave it until contributions open up.