### PR TITLE
Add /usage for cross-session cost and token reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `/usage` aggregates cost and token usage across local session logs by day and by model, with optional windows (`7d`/`30d`/`all`), CSV export, and a Mistral insight line
+
+
 ## [2.24.3] - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -338,6 +338,20 @@ If a model response is interrupted by a backend error, use `/retry` to continue
 from the partial response. Add optional guidance after the command, for example
 `/retry keep the conclusion concise`.
 
+Use `/usage` to review spend across local session history (not just the current
+session). Optional windows and export:
+
+```
+> /usage
+> /usage 7d
+> /usage 30d --csv ~/vibe-usage.csv
+> /usage all --insight
+```
+
+`/usage` is read-only over files under your Vibe session log directory (honors
+`$VIBE_HOME`). `--insight` asks a Mistral model for a one-line spend takeaway
+when `MISTRAL_API_KEY` is available.
+
 ### Custom Slash Commands via Skills
 
 You can define your own slash commands through the skills system. Skills are reusable components that extend Vibe's functionality.

--- a/tests/core/session/test_usage_report.py
+++ b/tests/core/session/test_usage_report.py
@@ -254,10 +254,14 @@ class TestFormatters:
         )
         report = build_usage_report(tmp_path, since=date(2026, 8, 1))
         text = format_usage_markdown(report, insight="Spend spiked on medium.")
+        assert "### Cost by day" in text
+        assert "### Cost by model" in text
         assert "### By day" in text
         assert "### By model" in text
         assert "devstral-2" in text
-        assert "▁" in text or "█" in text or "▇" in text
+        assert "█" in text
+        assert "░" in text
+        assert "▁" in text or "▇" in text
         assert "Spend spiked on medium." in text
         assert "since 2026-08-01" in text
 

--- a/tests/core/session/test_usage_report.py
+++ b/tests/core/session/test_usage_report.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from vibe.core.session.usage_report import (
+    UNPINNED_MODEL_LABEL,
+    UsageBucket,
+    build_usage_report,
+    format_usage_csv,
+    format_usage_markdown,
+    generate_usage_insight,
+    parse_usage_args,
+    parse_usage_window,
+)
+
+
+def _write_meta(
+    root: Path,
+    *,
+    name: str,
+    start_time: str,
+    model: str,
+    cost: float,
+    prompt: int,
+    completion: int,
+    cached: int = 0,
+    input_price: float = 1.0,
+    output_price: float = 2.0,
+) -> Path:
+    session_dir = root / name
+    session_dir.mkdir(parents=True)
+    meta = session_dir / "meta.json"
+    meta.write_text(
+        (
+            "{\n"
+            f'  "session_id": "{name}",\n'
+            f'  "start_time": "{start_time}",\n'
+            f'  "config": {{"active_model": "{model}"}},\n'
+            '  "stats": {\n'
+            f'    "session_prompt_tokens": {prompt},\n'
+            f'    "session_completion_tokens": {completion},\n'
+            f'    "session_cached_tokens": {cached},\n'
+            f'    "session_cost": {cost},\n'
+            f'    "input_price_per_million": {input_price},\n'
+            f'    "output_price_per_million": {output_price}\n'
+            "  }\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+    return meta
+
+
+class TestParseUsageWindow:
+    def test_all_and_empty(self) -> None:
+        assert parse_usage_window("all") is None
+        assert parse_usage_window("") is None
+        assert parse_usage_window("  ALL  ") is None
+
+    def test_day_windows(self) -> None:
+        today = date(2026, 8, 22)
+        assert parse_usage_window("7d", today=today) == date(2026, 8, 16)
+        assert parse_usage_window("30d", today=today) == today - timedelta(days=29)
+        assert parse_usage_window("1d", today=today) == today
+
+    def test_invalid_window(self) -> None:
+        with pytest.raises(ValueError, match="Unknown usage window"):
+            parse_usage_window("week")
+        with pytest.raises(ValueError, match="positive"):
+            parse_usage_window("0d")
+
+
+class TestParseUsageArgs:
+    def test_window_and_csv(self, tmp_path: Path) -> None:
+        today = date(2026, 8, 22)
+        parsed = parse_usage_args(
+            f"7d --csv {tmp_path / 'out.csv'} --insight", today=today
+        )
+        assert parsed.error is None
+        assert parsed.since == date(2026, 8, 16)
+        assert parsed.csv_path == tmp_path / "out.csv"
+        assert parsed.insight is True
+
+    def test_csv_requires_path(self) -> None:
+        parsed = parse_usage_args("--csv")
+        assert parsed.error is not None
+        assert "requires a file path" in parsed.error
+
+    def test_unknown_flag(self) -> None:
+        parsed = parse_usage_args("--json")
+        assert parsed.error is not None
+        assert "Unknown flag" in parsed.error
+
+
+class TestBuildUsageReport:
+    def test_aggregates_by_day_and_model(self, tmp_path: Path) -> None:
+        _write_meta(
+            tmp_path,
+            name="session_20260820_aaa",
+            start_time="2026-08-20T10:00:00+00:00",
+            model="devstral-2",
+            cost=0.10,
+            prompt=1000,
+            completion=200,
+        )
+        _write_meta(
+            tmp_path,
+            name="session_20260820_bbb",
+            start_time="2026-08-20T18:00:00+00:00",
+            model="mistral-medium-3.5",
+            cost=0.25,
+            prompt=2000,
+            completion=400,
+            cached=100,
+        )
+        _write_meta(
+            tmp_path,
+            name="session_20260821_ccc",
+            start_time="2026-08-21T09:00:00+00:00",
+            model="devstral-2",
+            cost=0.05,
+            prompt=500,
+            completion=50,
+        )
+
+        report = build_usage_report(tmp_path)
+        assert report.session_count == 3
+        assert report.total.cost == pytest.approx(0.40)
+        assert report.total.prompt_tokens == 3500
+        assert report.total.completion_tokens == 650
+        assert report.total.cached_tokens == 100
+        assert report.by_day["2026-08-20"].sessions == 2
+        assert report.by_day["2026-08-20"].cost == pytest.approx(0.35)
+        assert report.by_model["devstral-2"].sessions == 2
+        assert report.by_model["devstral-2"].cost == pytest.approx(0.15)
+        assert report.by_model["mistral-medium-3.5"].cost == pytest.approx(0.25)
+
+    def test_date_filter(self, tmp_path: Path) -> None:
+        _write_meta(
+            tmp_path,
+            name="session_old",
+            start_time="2026-08-01T00:00:00+00:00",
+            model="devstral-2",
+            cost=1.0,
+            prompt=10,
+            completion=1,
+        )
+        _write_meta(
+            tmp_path,
+            name="session_new",
+            start_time="2026-08-20T00:00:00+00:00",
+            model="devstral-2",
+            cost=0.2,
+            prompt=20,
+            completion=2,
+        )
+        report = build_usage_report(tmp_path, since=date(2026, 8, 15))
+        assert report.session_count == 1
+        assert report.total.cost == pytest.approx(0.2)
+        assert "2026-08-01" not in report.by_day
+
+    def test_unpinned_model_label(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session_unpinned"
+        session_dir.mkdir()
+        (session_dir / "meta.json").write_text(
+            (
+                "{\n"
+                '  "session_id": "unpinned",\n'
+                '  "start_time": "2026-08-22T12:00:00+00:00",\n'
+                '  "config": {"active_model": ""},\n'
+                '  "stats": {"session_prompt_tokens": 10, "session_completion_tokens": 1,'
+                ' "session_cost": 0.01}\n'
+                "}\n"
+            ),
+            encoding="utf-8",
+        )
+        report = build_usage_report(tmp_path)
+        assert UNPINNED_MODEL_LABEL in report.by_model
+        assert report.by_model[UNPINNED_MODEL_LABEL].sessions == 1
+
+    def test_skips_corrupt_meta(self, tmp_path: Path) -> None:
+        _write_meta(
+            tmp_path,
+            name="session_ok",
+            start_time="2026-08-22T00:00:00+00:00",
+            model="devstral-2",
+            cost=0.01,
+            prompt=5,
+            completion=1,
+        )
+        bad = tmp_path / "session_bad"
+        bad.mkdir()
+        (bad / "meta.json").write_text("{not-json", encoding="utf-8")
+        report = build_usage_report(tmp_path)
+        assert report.session_count == 1
+        assert report.skipped_files == 1
+
+    def test_recomputes_cost_when_missing(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "session_recompute"
+        session_dir.mkdir()
+        (session_dir / "meta.json").write_text(
+            (
+                "{\n"
+                '  "session_id": "recompute",\n'
+                '  "start_time": "2026-08-22T00:00:00+00:00",\n'
+                '  "config": {"active_model": "devstral-2"},\n'
+                '  "stats": {\n'
+                '    "session_prompt_tokens": 1000000,\n'
+                '    "session_completion_tokens": 500000,\n'
+                '    "session_cached_tokens": 0,\n'
+                '    "input_price_per_million": 1.0,\n'
+                '    "output_price_per_million": 2.0\n'
+                "  }\n"
+                "}\n"
+            ),
+            encoding="utf-8",
+        )
+        report = build_usage_report(tmp_path)
+        # 1M * $1 + 0.5M * $2 = $2
+        assert report.total.cost == pytest.approx(2.0)
+
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        report = build_usage_report(tmp_path / "missing")
+        assert report.session_count == 0
+        assert report.total == UsageBucket()
+
+
+class TestFormatters:
+    def test_markdown_empty(self) -> None:
+        text = format_usage_markdown(build_usage_report(Path("/no/such/dir")))
+        assert "No saved sessions" in text
+
+    def test_markdown_tables_and_bars(self, tmp_path: Path) -> None:
+        _write_meta(
+            tmp_path,
+            name="session_a",
+            start_time="2026-08-20T00:00:00+00:00",
+            model="devstral-2",
+            cost=0.10,
+            prompt=100,
+            completion=10,
+        )
+        _write_meta(
+            tmp_path,
+            name="session_b",
+            start_time="2026-08-21T00:00:00+00:00",
+            model="mistral-medium-3.5",
+            cost=0.40,
+            prompt=400,
+            completion=40,
+        )
+        report = build_usage_report(tmp_path, since=date(2026, 8, 1))
+        text = format_usage_markdown(report, insight="Spend spiked on medium.")
+        assert "### By day" in text
+        assert "### By model" in text
+        assert "devstral-2" in text
+        assert "▁" in text or "█" in text or "▇" in text
+        assert "Spend spiked on medium." in text
+        assert "since 2026-08-01" in text
+
+    def test_csv_export(self, tmp_path: Path) -> None:
+        _write_meta(
+            tmp_path,
+            name="session_a",
+            start_time="2026-08-20T00:00:00+00:00",
+            model="devstral-2",
+            cost=0.10,
+            prompt=100,
+            completion=10,
+        )
+        csv_text = format_usage_csv(build_usage_report(tmp_path))
+        assert "dimension,key,cost_usd" in csv_text
+        assert "day,2026-08-20" in csv_text
+        assert "model,devstral-2" in csv_text
+        assert "total,all" in csv_text
+
+
+class TestGenerateUsageInsight:
+    def test_skips_without_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+        report = build_usage_report(Path("/no/such"))
+        assert generate_usage_insight(report) is None

--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -134,6 +134,15 @@ class CommandRegistry:
                 handler="_show_status",
                 side_channel=True,
             ),
+            "usage": Command(
+                aliases=frozenset(["/usage"]),
+                description=(
+                    "Show cost and token usage across local sessions "
+                    "(/usage 7d|30d|all [--csv path] [--insight])"
+                ),
+                handler="_show_usage",
+                side_channel=True,
+            ),
             "whoami": Command(
                 aliases=frozenset(["/whoami"]),
                 description="Display the Mistral signed-in user, workspace, and plan",

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -3285,6 +3285,64 @@ class VibeApp(App):  # noqa: PLR0904
 """
         await self._mount_and_scroll(UserCommandMessage(status_text))
 
+    async def _show_usage(self, cmd_args: str = "", **kwargs: Any) -> None:
+        # ADR 0009 note: delivery surfaces normally talk to core only through
+        # app-server resources. `/usage` is an intentional exception — a
+        # stateless, read-only scan of local session logs (no live session
+        # state). A dedicated app-server RPC would be the by-the-book follow-up
+        # if this needs to be exposed to ACP/programmatic clients later.
+        # ConfigView also does not expose session_logging, so we read the
+        # default SESSION_LOG_DIR (honors $VIBE_HOME). Custom
+        # session_logging.save_dir overrides in config.toml are not resolved yet.
+        from vibe.core.paths import SESSION_LOG_DIR
+        from vibe.core.session.usage_report import (
+            build_usage_report,
+            format_usage_csv,
+            format_usage_markdown,
+            generate_usage_insight,
+            parse_usage_args,
+        )
+
+        parsed = parse_usage_args(cmd_args)
+        if parsed.error:
+            await self._mount_and_scroll(UserCommandMessage(parsed.error))
+            return
+
+        report = build_usage_report(
+            SESSION_LOG_DIR.path, session_prefix="session", since=parsed.since
+        )
+
+        if parsed.csv_path is not None:
+            try:
+                parsed.csv_path.parent.mkdir(parents=True, exist_ok=True)
+                parsed.csv_path.write_text(format_usage_csv(report), encoding="utf-8")
+            except OSError as exc:
+                await self._mount_and_scroll(
+                    UserCommandMessage(
+                        f"Failed to write CSV to `{parsed.csv_path}`: {exc}"
+                    )
+                )
+                return
+
+        insight: str | None = None
+        if parsed.insight and report.session_count > 0:
+            loading = LoadingWidget(status="Generating insight", show_hint=False)
+            await self._loading_area.mount(loading)
+            try:
+                insight = await asyncio.to_thread(generate_usage_insight, report)
+            finally:
+                if loading.parent:
+                    await loading.remove()
+            if insight is None:
+                insight = (
+                    "_Insight unavailable (set `MISTRAL_API_KEY` or try again later)._"
+                )
+
+        message = format_usage_markdown(report, insight=insight)
+        if parsed.csv_path is not None:
+            message = f"{message}\n\nCSV written to `{parsed.csv_path}`."
+        await self._mount_and_scroll(UserCommandMessage(message))
+
     async def _show_whoami(self, **kwargs: Any) -> None:
         loading = LoadingWidget(status="Loading", show_hint=False)
         await self._loading_area.mount(loading)

--- a/vibe/core/session/usage_report.py
+++ b/vibe/core/session/usage_report.py
@@ -1,0 +1,480 @@
+"""Cross-session cost and token usage aggregation from local session logs.
+
+Reads ``meta.json`` files under the session save directory. Stateless and
+UI-free so it is easy to unit test. Does not write telemetry or mutate logs.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
+from io import StringIO
+import json
+import os
+from pathlib import Path
+import re
+from typing import Any
+
+from vibe.utils.io import read_safe
+from vibe.utils.pricing import session_token_cost
+
+METADATA_FILENAME = "meta.json"
+UNPINNED_MODEL_LABEL = "default (unpinned)"
+
+_BAR_CHARS = "▁▂▃▄▅▆▇█"
+_WINDOW_RE = re.compile(r"^(\d+)d$", re.IGNORECASE)
+_USAGE_HELP = (
+    "Usage: `/usage [7d|30d|all]` optional `--csv <path>` "
+    "optional `--insight` / `--no-insight`"
+)
+
+
+@dataclass(frozen=True)
+class UsageBucket:
+    """Aggregated cost and token counts for one day or one model."""
+
+    cost: float = 0.0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cached_tokens: int = 0
+    sessions: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+    def add(
+        self,
+        *,
+        cost: float,
+        prompt_tokens: int,
+        completion_tokens: int,
+        cached_tokens: int,
+    ) -> UsageBucket:
+        return UsageBucket(
+            cost=self.cost + cost,
+            prompt_tokens=self.prompt_tokens + prompt_tokens,
+            completion_tokens=self.completion_tokens + completion_tokens,
+            cached_tokens=self.cached_tokens + cached_tokens,
+            sessions=self.sessions + 1,
+        )
+
+
+@dataclass
+class UsageReport:
+    """Cross-session usage snapshot."""
+
+    by_day: dict[str, UsageBucket] = field(default_factory=dict)
+    by_model: dict[str, UsageBucket] = field(default_factory=dict)
+    total: UsageBucket = field(default_factory=UsageBucket)
+    session_count: int = 0
+    skipped_files: int = 0
+    since: date | None = None
+    save_dir: Path | None = None
+
+
+@dataclass(frozen=True)
+class UsageCommandArgs:
+    """Parsed `/usage` arguments."""
+
+    since: date | None
+    csv_path: Path | None
+    insight: bool
+    error: str | None = None
+
+
+def parse_usage_window(raw: str, *, today: date | None = None) -> date | None:
+    """Parse a window token into an inclusive lower-bound date.
+
+    Accepted values: ``7d``, ``30d``, ``all`` (or empty → no lower bound).
+    Raises ``ValueError`` for anything else.
+    """
+    token = raw.strip().lower()
+    if not token or token == "all":
+        return None
+    match = _WINDOW_RE.fullmatch(token)
+    if match is None:
+        raise ValueError(f"Unknown usage window {raw!r}. Use 7d, 30d, or all.")
+    days = int(match.group(1))
+    if days <= 0:
+        raise ValueError(f"Usage window must be a positive day count, got {raw!r}.")
+    ref = today or datetime.now(UTC).date()
+    return ref - timedelta(days=days - 1)
+
+
+def parse_usage_args(cmd_args: str, *, today: date | None = None) -> UsageCommandArgs:
+    """Parse `/usage` args: optional window, optional ``--csv path``, insight flags."""
+    tokens = cmd_args.split()
+    since: date | None = None
+    csv_path: Path | None = None
+    insight = False
+    window_seen = False
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token in {"--csv", "-o"}:
+            if i + 1 >= len(tokens):
+                return UsageCommandArgs(
+                    since=None,
+                    csv_path=None,
+                    insight=insight,
+                    error=f"`{token}` requires a file path. {_USAGE_HELP}",
+                )
+            csv_path = Path(tokens[i + 1]).expanduser()
+            i += 2
+            continue
+        if token == "--insight":
+            insight = True
+            i += 1
+            continue
+        if token == "--no-insight":
+            insight = False
+            i += 1
+            continue
+        if token.startswith("-"):
+            return UsageCommandArgs(
+                since=None,
+                csv_path=None,
+                insight=insight,
+                error=f"Unknown flag {token!r}. {_USAGE_HELP}",
+            )
+        if window_seen:
+            return UsageCommandArgs(
+                since=None,
+                csv_path=None,
+                insight=insight,
+                error=f"Unexpected argument {token!r}. {_USAGE_HELP}",
+            )
+        try:
+            since = parse_usage_window(token, today=today)
+        except ValueError as exc:
+            return UsageCommandArgs(
+                since=None, csv_path=None, insight=insight, error=f"{exc} {_USAGE_HELP}"
+            )
+        window_seen = True
+        i += 1
+    return UsageCommandArgs(since=since, csv_path=csv_path, insight=insight)
+
+
+def _model_label(config: Any) -> str:
+    if not isinstance(config, dict):
+        return UNPINNED_MODEL_LABEL
+    active = config.get("active_model")
+    if not isinstance(active, str) or not active.strip():
+        return UNPINNED_MODEL_LABEL
+    return active.strip()
+
+
+def _day_key(start_time: Any) -> str | None:
+    if not isinstance(start_time, str) or not start_time:
+        return None
+    try:
+        dt = datetime.fromisoformat(start_time)
+    except ValueError:
+        # Fall back to the YYYY-MM-DD prefix when present.
+        prefix = start_time[:10]
+        try:
+            date.fromisoformat(prefix)
+        except ValueError:
+            return None
+        return prefix
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC).date().isoformat()
+
+
+def _as_int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, float):
+        return max(0, int(value))
+    return 0
+
+
+def _as_float(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _session_cost_from_stats(stats: dict[str, Any]) -> float:
+    stored = _as_float(stats.get("session_cost"))
+    if stored is not None and stored >= 0:
+        return stored
+    prompt = _as_int(stats.get("session_prompt_tokens"))
+    completion = _as_int(stats.get("session_completion_tokens"))
+    cached = _as_int(stats.get("session_cached_tokens"))
+    input_price = _as_float(stats.get("input_price_per_million")) or 0.0
+    output_price = _as_float(stats.get("output_price_per_million")) or 0.0
+    cached_price = _as_float(stats.get("cached_input_price_per_million"))
+    return session_token_cost(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        cached_tokens=cached,
+        input_price_per_million=input_price,
+        output_price_per_million=output_price,
+        cached_input_price_per_million=cached_price,
+    )
+
+
+def build_usage_report(
+    save_dir: Path, session_prefix: str = "session", *, since: date | None = None
+) -> UsageReport:
+    """Aggregate cost/tokens from every ``<prefix>_*/meta.json`` under *save_dir*."""
+    report = UsageReport(since=since, save_dir=save_dir)
+    if not save_dir.exists():
+        return report
+
+    for meta_path in sorted(save_dir.glob(f"{session_prefix}_*/{METADATA_FILENAME}")):
+        try:
+            meta = json.loads(read_safe(meta_path).text)
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            report.skipped_files += 1
+            continue
+        if not isinstance(meta, dict):
+            report.skipped_files += 1
+            continue
+
+        day = _day_key(meta.get("start_time"))
+        if day is None:
+            report.skipped_files += 1
+            continue
+        if since is not None and date.fromisoformat(day) < since:
+            continue
+
+        stats = meta.get("stats")
+        if not isinstance(stats, dict):
+            stats = {}
+
+        cost = _session_cost_from_stats(stats)
+        prompt = _as_int(stats.get("session_prompt_tokens"))
+        completion = _as_int(stats.get("session_completion_tokens"))
+        cached = _as_int(stats.get("session_cached_tokens"))
+        model = _model_label(meta.get("config"))
+
+        report.by_day[day] = report.by_day.get(day, UsageBucket()).add(
+            cost=cost,
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            cached_tokens=cached,
+        )
+        report.by_model[model] = report.by_model.get(model, UsageBucket()).add(
+            cost=cost,
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            cached_tokens=cached,
+        )
+        report.total = report.total.add(
+            cost=cost,
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            cached_tokens=cached,
+        )
+        report.session_count += 1
+
+    return report
+
+
+def _bar(value: float, maximum: float, *, width: int = 8) -> str:
+    if maximum <= 0 or value <= 0 or width <= 0:
+        return _BAR_CHARS[0] * width
+    ratio = min(value / maximum, 1.0)
+    filled = max(1, int(round(ratio * width)))
+    level = min(len(_BAR_CHARS) - 1, int(ratio * (len(_BAR_CHARS) - 1) + 1e-9))
+    return (_BAR_CHARS[level] * filled).ljust(width, _BAR_CHARS[0])
+
+
+def _window_label(since: date | None) -> str:
+    if since is None:
+        return "all time"
+    return f"since {since.isoformat()}"
+
+
+def format_usage_markdown(report: UsageReport, *, insight: str | None = None) -> str:
+    """Render a camera-friendly markdown usage report with unicode bars."""
+    lines = [
+        "## Usage Report",
+        "",
+        f"_Local session logs · {_window_label(report.since)}_",
+        "",
+    ]
+    if report.session_count == 0:
+        lines.extend([
+            "No saved sessions with usage data found.",
+            "",
+            "Run a few chats, then try `/usage` again. "
+            "History is read-only from your local session logs.",
+        ])
+        return "\n".join(lines)
+
+    total = report.total
+    lines.extend([
+        f"- **Sessions**: {report.session_count:,}",
+        f"- **Total cost**: ${total.cost:.4f}",
+        f"- **Prompt tokens**: {total.prompt_tokens:,}",
+        f"- **Completion tokens**: {total.completion_tokens:,}",
+        f"- **Total tokens**: {total.total_tokens:,}",
+    ])
+    if total.cached_tokens:
+        lines.append(f"- **Cached tokens**: {total.cached_tokens:,}")
+    if report.skipped_files:
+        lines.append(f"- **Skipped unreadable logs**: {report.skipped_files:,}")
+    lines.append("")
+
+    max_day_cost = max((b.cost for b in report.by_day.values()), default=0.0)
+    lines.extend([
+        "### By day",
+        "",
+        "| Day | Cost | Sessions | Tokens | Trend |",
+        "| --- | ---: | ---: | ---: | --- |",
+    ])
+    for day in sorted(report.by_day):
+        bucket = report.by_day[day]
+        lines.append(
+            f"| {day} | ${bucket.cost:.4f} | {bucket.sessions:,} | "
+            f"{bucket.total_tokens:,} | `{_bar(bucket.cost, max_day_cost)}` |"
+        )
+    lines.append("")
+
+    max_model_cost = max((b.cost for b in report.by_model.values()), default=0.0)
+    lines.extend([
+        "### By model",
+        "",
+        "| Model | Cost | Sessions | Tokens | Trend |",
+        "| --- | ---: | ---: | ---: | --- |",
+    ])
+    for model, bucket in sorted(
+        report.by_model.items(), key=lambda item: (-item[1].cost, item[0])
+    ):
+        lines.append(
+            f"| {model} | ${bucket.cost:.4f} | {bucket.sessions:,} | "
+            f"{bucket.total_tokens:,} | `{_bar(bucket.cost, max_model_cost)}` |"
+        )
+
+    if insight:
+        lines.extend(["", "### Insight", "", insight])
+
+    lines.extend([
+        "",
+        "_Tip: `/usage 7d`, `/usage 30d`, `/usage all`, "
+        "`/usage --csv ~/usage.csv`, `/usage --insight`._",
+    ])
+    return "\n".join(lines)
+
+
+def format_usage_csv(report: UsageReport) -> str:
+    """Serialize day and model buckets as CSV for spreadsheet export."""
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow([
+        "dimension",
+        "key",
+        "cost_usd",
+        "sessions",
+        "prompt_tokens",
+        "completion_tokens",
+        "cached_tokens",
+        "total_tokens",
+    ])
+    for day in sorted(report.by_day):
+        bucket = report.by_day[day]
+        writer.writerow([
+            "day",
+            day,
+            f"{bucket.cost:.6f}",
+            bucket.sessions,
+            bucket.prompt_tokens,
+            bucket.completion_tokens,
+            bucket.cached_tokens,
+            bucket.total_tokens,
+        ])
+    for model, bucket in sorted(
+        report.by_model.items(), key=lambda item: (-item[1].cost, item[0])
+    ):
+        writer.writerow([
+            "model",
+            model,
+            f"{bucket.cost:.6f}",
+            bucket.sessions,
+            bucket.prompt_tokens,
+            bucket.completion_tokens,
+            bucket.cached_tokens,
+            bucket.total_tokens,
+        ])
+    writer.writerow([
+        "total",
+        "all",
+        f"{report.total.cost:.6f}",
+        report.session_count,
+        report.total.prompt_tokens,
+        report.total.completion_tokens,
+        report.total.cached_tokens,
+        report.total.total_tokens,
+    ])
+    return buffer.getvalue()
+
+
+def _insight_prompt(report: UsageReport) -> str:
+    day_lines = [
+        f"- {day}: ${bucket.cost:.4f} across {bucket.sessions} session(s), "
+        f"{bucket.total_tokens:,} tokens"
+        for day, bucket in sorted(report.by_day.items())
+    ]
+    model_lines = [
+        f"- {model}: ${bucket.cost:.4f} across {bucket.sessions} session(s), "
+        f"{bucket.total_tokens:,} tokens"
+        for model, bucket in sorted(
+            report.by_model.items(), key=lambda item: (-item[1].cost, item[0])
+        )
+    ]
+    return (
+        "You are a concise spend analyst for a coding CLI.\n"
+        "Given local, already-aggregated session usage, write ONE plain-English "
+        "insight sentence (max 40 words). Mention the standout day or model if "
+        "useful. No markdown, no bullet points, no hedging.\n\n"
+        f"Window: {_window_label(report.since)}\n"
+        f"Sessions: {report.session_count}\n"
+        f"Total cost: ${report.total.cost:.4f}\n"
+        f"Total tokens: {report.total.total_tokens:,}\n\n"
+        "By day:\n"
+        + ("\n".join(day_lines) or "- (none)")
+        + "\n\nBy model:\n"
+        + ("\n".join(model_lines) or "- (none)")
+    )
+
+
+def generate_usage_insight(
+    report: UsageReport,
+    *,
+    api_key: str | None = None,
+    model: str = "mistral-small-latest",
+) -> str | None:
+    """Ask a Mistral model for a one-line spend takeaway. Returns None on skip/fail."""
+    text: str | None = None
+    if report.session_count > 0:
+        key = api_key if api_key is not None else os.environ.get("MISTRAL_API_KEY")
+        if key:
+            try:
+                from mistralai.client import Mistral
+
+                client = Mistral(api_key=key)
+                response = client.chat.complete(
+                    model=model,
+                    messages=[{"role": "user", "content": _insight_prompt(report)}],
+                    temperature=0.2,
+                    max_tokens=80,
+                )
+                choices = getattr(response, "choices", None) or []
+                if choices:
+                    message = getattr(choices[0], "message", None)
+                    content = getattr(message, "content", None)
+                    if isinstance(content, str):
+                        text = " ".join(content.strip().split()) or None
+            except Exception:
+                text = None
+    return text

--- a/vibe/core/session/usage_report.py
+++ b/vibe/core/session/usage_report.py
@@ -289,6 +289,35 @@ def _bar(value: float, maximum: float, *, width: int = 8) -> str:
     return (_BAR_CHARS[level] * filled).ljust(width, _BAR_CHARS[0])
 
 
+def _horizontal_bar(value: float, maximum: float, *, width: int = 24) -> str:
+    """Solid unicode bar for TUI-friendly charts (█ filled, ░ empty)."""
+    if width <= 0:
+        return ""
+    if maximum <= 0 or value <= 0:
+        return "░" * width
+    filled = max(1, int(round(min(value / maximum, 1.0) * width)))
+    return ("█" * filled) + ("░" * (width - filled))
+
+
+def _chart_block(
+    title: str, rows: list[tuple[str, float, UsageBucket]], *, label_width: int
+) -> list[str]:
+    """Render a fenced horizontal bar chart — displays reliably in the TUI."""
+    if not rows:
+        return []
+    maximum = max((cost for _, cost, _ in rows), default=0.0)
+    lines = [f"### {title}", "", "```"]
+    for label, cost, bucket in rows:
+        bar = _horizontal_bar(cost, maximum)
+        padded = label[:label_width].ljust(label_width)
+        lines.append(
+            f"{padded}  ${cost:>8.4f}  {bar}  "
+            f"({bucket.sessions} sess, {bucket.total_tokens:,} tok)"
+        )
+    lines.extend(["```", ""])
+    return lines
+
+
 def _window_label(since: date | None) -> str:
     if since is None:
         return "all time"
@@ -325,6 +354,21 @@ def format_usage_markdown(report: UsageReport, *, insight: str | None = None) ->
     if report.skipped_files:
         lines.append(f"- **Skipped unreadable logs**: {report.skipped_files:,}")
     lines.append("")
+
+    day_rows = [
+        (day, report.by_day[day].cost, report.by_day[day])
+        for day in sorted(report.by_day)
+    ]
+    model_rows = [
+        (model, bucket.cost, bucket)
+        for model, bucket in sorted(
+            report.by_model.items(), key=lambda item: (-item[1].cost, item[0])
+        )
+    ]
+    # Charts first: fenced code blocks render more reliably than markdown tables
+    # in the Textual TUI, and they give a clear visual for demos.
+    lines.extend(_chart_block("Cost by day", day_rows, label_width=12))
+    lines.extend(_chart_block("Cost by model", model_rows, label_width=22))
 
     max_day_cost = max((b.cost for b in report.by_day.values()), default=0.0)
     lines.extend([

--- a/vibe/core/skills/builtins/vibe.py
+++ b/vibe/core/skills/builtins/vibe.py
@@ -734,6 +734,9 @@ Custom agents are TOML files in `~/.vibe/agents/NAME.toml`.
   are passed to the model for the continuation. Relevant error messages also
   hint at this command.
 - `/status` - Display agent statistics
+- `/usage [7d|30d|all] [--csv path] [--insight]` - Aggregate cost and token
+  usage across local session logs (by day and by model). Optional Mistral
+  insight line with `--insight`.
 - `/whoami` - Display the Mistral signed-in user, workspace, and plan
 - `/voice` - Configure voice settings
 - `/mcp` - Display MCP servers and connector status; pass a server or connector


### PR DESCRIPTION
## Summary
- Add a pure, read-only aggregator over local session `meta.json` logs (`vibe/core/session/usage_report.py`) that buckets cost/tokens by day and by model.
- Wire a side-channel `/usage` slash command (`7d` / `30d` / `all`, optional `--csv`, optional `--insight`) so teams can review spend beyond the current session.
- Include TUI-friendly horizontal unicode bar charts (fenced code blocks), unit tests, README/CHANGELOG/skill docs, and an optional Mistral one-line spend insight.

## Architecture note (ADR 0009)
`_show_usage` in the Textual app imports `vibe.core` directly as a disclosed exception: this is a **stateless local-file read**, not live session state. A dedicated app-server RPC would be the by-the-book follow-up if ACP/programmatic clients need the same surface.

`ConfigView` does not expose `session_logging`, so `/usage` currently reads `SESSION_LOG_DIR` (honors `$VIBE_HOME`). Custom `session_logging.save_dir` overrides in `config.toml` are not resolved yet.

## Test plan
- [x] `uv run pytest tests/core/session/test_usage_report.py` (16 passed)
- [x] `uv run ruff check` / `ruff format` / `pyright` on touched files
- [x] Manual: `uv run vibe` → `/usage` shows totals + bar charts against real session logs
- [ ] With `MISTRAL_API_KEY` set: `/usage --insight` returns a one-line takeaway
- [ ] Empty history shows a clean empty-state message