### PR TITLE
fix(git): disable repository hooks during worktree creation

### DIFF
--- a/tests/core/test_worktree.py
+++ b/tests/core/test_worktree.py
@@ -67,6 +67,14 @@ def _release(cwd: Path, session_id: str | None = None) -> WorktreeRelease:
     return managed.release(session_id)
 
 
+def _write_post_checkout_hook(repo: Repo, marker: Path) -> None:
+    hooks = Path(repo.git_dir) / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    hook = hooks / "post-checkout"
+    hook.write_text(f'#!/bin/sh\necho ran > "{marker}"\n')
+    hook.chmod(0o755)
+
+
 def _init_repo(root: Path, *, separate_git_dir: Path | None = None) -> Repo:
     repo = Repo.init(
         root,
@@ -105,6 +113,43 @@ def _claim(repo: Repo, name: str) -> WorktreeClaim:
     paths = git_repo_module.GitRepo(repo).paths
     bucket = managed_bucket_name(paths.repo_root, paths.common_git_dir)
     return WorktreeClaim(bucket=bucket, name=name)
+
+
+def test_worktree_creation_does_not_run_repository_hooks(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    marker = tmp_path / "hook-ran"
+    _write_post_checkout_hook(repo, marker)
+    # Control: `git worktree add` is what runs post-checkout, so confirm this
+    # environment executes the hook at all. Without it the assertion below
+    # could pass on a machine that never runs hooks.
+    subprocess.run(
+        ["git", "worktree", "add", str(tmp_path / "control"), "-b", "control"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    if not marker.exists():
+        pytest.skip("git hooks do not execute in this environment")
+    marker.unlink()
+
+    worktree = _prepare("hooked-worktree", tmp_path, branch="feat/hooked")
+
+    assert not marker.exists()
+    assert Path(worktree.root).is_dir()
+
+
+def test_worktree_reuse_of_existing_branch_does_not_run_repository_hooks(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    repo.create_head("feat/existing")
+    marker = tmp_path / "hook-ran"
+    _write_post_checkout_hook(repo, marker)
+
+    worktree = _prepare("existing-worktree", tmp_path, branch="feat/existing")
+
+    assert not marker.exists()
+    assert Path(worktree.root).is_dir()
 
 
 def test_creates_named_worktree_for_separate_branch(tmp_path: Path) -> None:

--- a/vibe/core/git/repo.py
+++ b/vibe/core/git/repo.py
@@ -29,6 +29,16 @@ _FETCH_TIMEOUT_SECONDS = 10
 # notices. Failing is the right answer for a refresh the caller treats as
 # optional.
 _NON_INTERACTIVE_GIT_ENV = {"GIT_TERMINAL_PROMPT": "0", "GCM_INTERACTIVE": "never"}
+# `git worktree add` checks the new tree out, which runs the repository's own
+# post-checkout hook. Worktree creation happens before any trust prompt, so a
+# malicious repository the user merely opened could otherwise get a hook
+# executed with the user's full privileges. -c on the command line takes
+# precedence over the repository's config, so the repository being checked out
+# cannot override this. The value is an absolute path that cannot exist rather
+# than an empty one, because git resolves a relative core.hooksPath against the
+# directory the hooks would run in -- which is the untrusted worktree itself.
+# This mirrors the `-c core.fsmonitor=` guard in vibe/core/system_prompt.py.
+_NO_HOOKS_CONFIG = "core.hooksPath=/nonexistent-vibe-disabled-git-hooks"
 
 
 @dataclass(frozen=True)
@@ -236,9 +246,9 @@ class GitRepo:
                 # a repository with no remote to start from.
                 if start_point is not None:
                     create.append(start_point)
-                self._repo.git.worktree(*create)
+                self._repo.git(c=_NO_HOOKS_CONFIG).worktree(*create)
             else:
-                self._repo.git.worktree("add", str(target), branch)
+                self._repo.git(c=_NO_HOOKS_CONFIG).worktree("add", str(target), branch)
         except self._gitpy.git_command_error as e:
             raise GitError(
                 f"Failed to create worktree {target.name!r} for branch {branch!r}: {e}"


### PR DESCRIPTION
Fixes #996

## Repro

`git worktree add` checks out the new tree, so it runs the repository's own `post-checkout` hook. Vibe creates the worktree **before** the trust gate: `vibe/cli/entrypoint.py` calls `_enter_worktree(args)` at line 396, while `init_harness_files_manager("user", "project")` is at line 421. So `vibe --worktree` inside an untrusted repository runs attacker-controlled code with the user's full privileges, with no prompt.

Verified locally against `main` (git 2.52.0, GitPython 3.1.58), calling through GitPython exactly as `GitRepo.add_worktree` does:

| Invocation | `post-checkout` ran? |
| --- | --- |
| `repo.git.worktree("add", ...)` — current code | **yes** |
| `repo.git(c="core.hooksPath=<nonexistent>").worktree("add", ...)` | no (worktree still created) |

The hook also fires when it is committed at the repository root rather than placed in `.git/hooks`, so cloning is enough to arm it.

## Fix

Thread `-c core.hooksPath=<nonexistent path>` through both worktree-creating invocations in `vibe/core/git/repo.py`. Fixing it there covers the CLI path and the app-server path (`vibe/app_server/_worktree_effects.py`) in one place.

This mirrors the `-c core.fsmonitor=` guard already in `vibe/core/system_prompt.py:55-64`, added for the same threat model — its comment notes the call "runs unconditionally on session start, before any trust prompt, so a malicious repo … could otherwise use `[core] fsmonitor = <payload>` to get its command executed". `-c` on the command line outranks the repository's own config, so the repo being checked out cannot override it.

Two deliberate choices worth flagging for review:

- **An absolute path that cannot exist, not an empty value.** `git help config` states a relative `core.hooksPath` "is taken as relative to the directory where the hooks are run" — i.e. the untrusted worktree. An empty value happens to be safe on git 2.52, but the semantics are version-dependent in a way a security guard should not rely on.
- **Scoped to worktree creation.** The other `git` calls in this file (`rev-parse`, `check-ref-format`, `show-ref`, `symbolic-ref`, `branch -D`, `fetch`, `worktree list/remove`) do not run hooks. Happy to widen it to every invocation in `GitRepo` as defence-in-depth if you'd prefer that — say the word and I'll push it.

## Tests

`tests/core/test_worktree.py` gains two cases, covering both branches of `add_worktree` (new branch and existing branch). **Both fail on `main` and pass with the fix:**

```
$ git stash push vibe/core/git/repo.py && uv run pytest tests/core/test_worktree.py -k hook -n0
FAILED test_worktree_creation_does_not_run_repository_hooks - AssertionError: assert not True
FAILED test_worktree_reuse_of_existing_branch_does_not_run_repository_hooks - AssertionError: assert not True
2 failed
```

The first test runs `git worktree add` directly as a control and `pytest.skip`s if hooks do not execute in the environment, so it cannot pass vacuously.

## Local verification

CI does not run on fork PRs here, so I ran the project's gate locally (macOS, Python 3.12):

```
uv run pytest tests/core tests/app_server   ->  5171 passed, 25 skipped
uv run pytest tests/app_server -n0          ->  543 passed, 23 skipped
uv run pyright vibe/core/git/repo.py tests/core/test_worktree.py
                                            ->  0 errors, 0 warnings
uv run ruff check .                         ->  All checks passed
uv run ruff format --check .                ->  1042 files already formatted
pre-commit (trailing-whitespace, end-of-file-fixer, typos, ruff-check, ruff-format)
                                            ->  all Passed
```

Three tests failed only under `-n auto` (`test_child_auto_compaction_keeps_live_and_persisted_session`, `test_closing_shell_stream_interrupts_process_and_allows_next_command`, `test_interrupting_task_leaves_child_idle_and_closes_runtime`) and pass serially both with and without this change — parallel-load timeouts against the 10s `pytest-timeout`, unrelated to this diff.

No CHANGELOG, ADR, or README changes: this is a bug fix with no user-facing surface change.

## Note on disclosure

There is no `SECURITY.md` and no private reporting channel in this repository, which is presumably why #996 was filed publicly with a working PoC. Happy to open a separate docs PR adding one if that would help.
