### PR TITLE
fix(tools): bound managed shell session log growth

### DIFF
--- a/tests/core/tools/builtins/test_experimental_bash_log_growth.py
+++ b/tests/core/tools/builtins/test_experimental_bash_log_growth.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+import time
+from typing import cast
+
+import pytest
+
+from vibe.core.tools.builtins import experimental_bash
+from vibe.core.tools.builtins.experimental_bash import (
+    ManagedTerminal,
+    TerminalSession,
+    TerminalSessionManager,
+)
+
+
+@pytest.fixture
+def small_cap(monkeypatch: pytest.MonkeyPatch) -> int:
+    cap = 4096
+    # raising=False so the assertions below fail on the unbounded behaviour
+    # rather than erroring on a missing symbol.
+    monkeypatch.setattr(experimental_bash, "DEFAULT_MAX_LOG_BYTES", cap, raising=False)
+    return cap
+
+
+def _session(tmp_path: Path) -> TerminalSession:
+    output_path = tmp_path / "session.log"
+    output_path.touch()
+    return TerminalSession(
+        session_id="s1",
+        command="yes",
+        cwd=tmp_path,
+        shell="/bin/sh",
+        terminal=cast(ManagedTerminal, object()),
+        output_path=output_path,
+        manifest_path=tmp_path / "session.json",
+        created_at=time.time(),
+    )
+
+
+def test_session_log_stops_growing_once_it_passes_the_cap(
+    tmp_path: Path, small_cap: int
+) -> None:
+    manager = TerminalSessionManager()
+    session = _session(tmp_path)
+
+    for _ in range(200):
+        manager._append_output(session, b"x" * 1024)
+
+    assert session.output_path.stat().st_size <= small_cap
+
+
+def test_trimmed_log_keeps_the_most_recent_output(
+    tmp_path: Path, small_cap: int
+) -> None:
+    manager = TerminalSessionManager()
+    session = _session(tmp_path)
+
+    manager._append_output(session, b"a" * (small_cap * 2))
+    manager._append_output(session, b"newest-output\n")
+
+    contents = session.output_path.read_bytes()
+    assert contents.endswith(b"newest-output\n")
+    assert b"earlier output dropped" in contents
+
+
+def test_trimmed_log_stays_decodable_when_a_cut_splits_a_character(
+    tmp_path: Path, small_cap: int
+) -> None:
+    manager = TerminalSessionManager()
+    session = _session(tmp_path)
+
+    # Three-byte characters guarantee some cut lands mid-sequence.
+    manager._append_output(session, "字".encode() * 2048)
+
+    session.output_path.read_bytes().decode()
+
+
+def test_log_under_the_cap_is_left_alone(tmp_path: Path, small_cap: int) -> None:
+    manager = TerminalSessionManager()
+    session = _session(tmp_path)
+
+    manager._append_output(session, b"short output\n")
+
+    assert session.output_path.read_bytes() == b"short output\n"

--- a/vibe/core/tools/builtins/experimental_bash.py
+++ b/vibe/core/tools/builtins/experimental_bash.py
@@ -76,6 +76,12 @@ DEFAULT_MAX_POLL_SECONDS = 300.0
 KILL_GRACE_SECONDS = 2.0
 FORCE_TERMINATION_TIMEOUT_SECONDS = 2.0
 READER_SELECT_SECONDS = 0.1
+# A runaway command can emit output for as long as it runs, and the session log
+# was appended to unconditionally, so a single session could fill the disk. Keep
+# the most recent output: inspect_session and the tool's own tail reads are what
+# surface this file, and the newest bytes are the ones they ask for.
+DEFAULT_MAX_LOG_BYTES = 64 * 1024 * 1024
+_LOG_TRUNCATION_NOTICE = b"[vibe] earlier output dropped to bound log size\n"
 FOREGROUND_STREAM_SECONDS = 0.2
 
 CONTROL_SEQUENCES: dict[str, bytes] = {
@@ -546,6 +552,16 @@ def _skip_utf8_continuation_prefix(path: Path, cursor: int) -> int:
     return cursor + len(prefix)
 
 
+def _strip_utf8_continuation_prefix(data: bytes) -> bytes:
+    # A byte-offset cut can land inside a multi-byte character; drop the orphaned
+    # continuation bytes so the retained tail still decodes.
+    for index, byte in enumerate(data):
+        if _UTF8_CONTINUATION_MIN <= byte < _UTF8_LEAD_2:
+            continue
+        return data[index:]
+    return b""
+
+
 def _safe_stat_size(path: Path) -> int:
     try:
         return path.stat().st_size
@@ -895,8 +911,29 @@ class TerminalSessionManager:
         with session.condition:
             with session.output_path.open("ab") as handle:
                 handle.write(data)
+            self._trim_output_locked(session)
             session.updated_at = time.time()
             session.condition.notify_all()
+
+    # Readers clamp a stale cursor with min(cursor, size), so dropping the head
+    # costs a reader the bytes it had not fetched yet rather than breaking it.
+    def _trim_output_locked(self, session: TerminalSession) -> None:
+        path = session.output_path
+        size = _safe_stat_size(path)
+        if size <= DEFAULT_MAX_LOG_BYTES:
+            return
+        keep = DEFAULT_MAX_LOG_BYTES // 2
+        try:
+            with path.open("rb") as handle:
+                handle.seek(size - keep)
+                tail = handle.read()
+            path.write_bytes(
+                _LOG_TRUNCATION_NOTICE + _strip_utf8_continuation_prefix(tail)
+            )
+        except OSError:
+            # Bounding the log is best effort: a failure here must not take down
+            # the reader thread and with it the session's output.
+            return
 
     def _terminate_sessions(
         self, sessions: list[TerminalSession], *, force: bool = False


### PR DESCRIPTION
Fixes #1023

## Repro

`TerminalSessionManager._append_output` appended every chunk the reader thread produced, with no ceiling:

```python
def _append_output(self, session: TerminalSession, data: bytes) -> None:
    with session.condition:
        with session.output_path.open("ab") as handle:
            handle.write(data)
```

Nothing pruned the file afterwards either. `clear_logs` only runs on an explicit kill-all, and `max_bytes` bounds *reads* (`read_output`, `inspect_session`, `_read_file_chunk`), not writes. The only guards on the path are containment checks (`"log path must stay under ~/.vibe/shell-tool"`) — traversal, not growth.

So any long-running command that keeps writing grows `~/.vibe/shell-tool/sessions/<id>.log` until the disk fills. The reporter lost 600GB.

## Fix

Cap the file and keep the most recent output.

Two properties of the existing code make tail-retention the right shape rather than a compromise:

- `inspect_session` already reads the **tail** (`cursor = size - max_bytes`), so the newest bytes are what the tool actually surfaces.
- `_read_file_chunk` clamps with `safe_cursor = min(cursor, size)`, so a reader holding a stale offset into a shrunk file reads nothing new instead of erroring. Dropping the head costs a reader the bytes it had not fetched yet; it does not break it.

Details worth reviewing:

- The retained tail is cut at a byte offset, so it can begin inside a multi-byte character. `_strip_utf8_continuation_prefix` drops the orphaned continuation bytes, reusing the `_UTF8_CONTINUATION_MIN` / `_UTF8_LEAD_2` constants already defined in this module rather than introducing new ones.
- Trimming is **best effort**: an `OSError` while rewriting returns quietly, because this runs on the reader thread and an exception there would take out the session's output entirely.
- The cap is a module constant (`DEFAULT_MAX_LOG_BYTES = 64 MiB`), so there is no new public API. Happy to promote it to a config field if you'd like it user-tunable — I left it out to keep the change to one file.

## Tests

New `tests/core/tools/builtins/test_experimental_bash_log_growth.py` (4 cases): the cap holds under repeated appends, the newest output survives with a truncation notice, a cut that splits a multi-byte character still decodes, and a log under the cap is left byte-for-byte alone.

**On `main` the first two fail on the unbounded behaviour**, not on a missing symbol — the fixture patches the cap with `raising=False` specifically so the assertion demonstrates the bug:

```
$ git stash push vibe/core/tools/builtins/experimental_bash.py
$ uv run pytest tests/core/tools/builtins/test_experimental_bash_log_growth.py -n0
FAILED test_session_log_stops_growing_once_it_passes_the_cap - AssertionError: assert 204800 <= 4096
FAILED test_trimmed_log_keeps_the_most_recent_output - AssertionError: assert b'earlier output dropped' in b'aaaa...'
2 failed, 2 passed
```

## Local verification

CI does not run on fork PRs here, so I ran the project's gate locally (macOS, Python 3.12):

```
uv run pytest tests/core/tools tests/core/test_worktree.py -n0  ->  229 passed
uv run pyright vibe/core/tools/builtins/experimental_bash.py \
               tests/core/tools/builtins/test_experimental_bash_log_growth.py
                                                                ->  0 errors, 0 warnings
uv run ruff check .                                             ->  All checks passed
uv run ruff format --check .                                    ->  1042 files already formatted
```

One unrelated pre-existing failure in this environment: `tests/tools/test_grep.py::test_preserves_accents_when_matching_latin1_encoded_file` fails on a clean checkout of `main` here too (macOS `grep` vs GNU `grep` on latin1 input), so it is not from this change.

Note this path is behind the `vibe_cli_managed_shell_tools` experiment, which defaults to `legacy` — so the blast radius is small, but so is the fix.
