### PR TITLE
fix(cli): let slash commands that need an argument be typed from the dropdown

### DIFF
--- a/tests/autocompletion/test_slash_command_controller.py
+++ b/tests/autocompletion/test_slash_command_controller.py
@@ -11,6 +11,7 @@ from vibe.cli.autocompletion.base import (
 )
 from vibe.cli.autocompletion.completers import CommandCompleter
 from vibe.cli.autocompletion.slash_command import SlashCommandController
+from vibe.cli.commands import CommandRegistry
 
 
 class SuggestionEvent(NamedTuple):
@@ -349,3 +350,51 @@ def test_callable_entries_reflects_enabled_disabled_skills() -> None:
     controller.on_text_changed("/", cursor_index=1)
     suggestions, _ = view.suggestion_events[-1]
     assert [s.label for s in suggestions] == ["/review", "/deploy"]
+
+
+def _argument_controller(prefix: str) -> tuple[SlashCommandController, StubView]:
+    commands = [
+        CompletionEntry("/rename", "Rename the current session", True),
+        CompletionEntry("/reload", "Reload configuration"),
+    ]
+    completer = CommandCompleter(lambda: commands)
+    view = StubView()
+    controller = SlashCommandController(completer, view)
+    controller.on_text_changed(prefix, cursor_index=len(prefix))
+    view.suggestion_events.clear()
+    return controller, view
+
+
+def test_enter_accepts_a_command_needing_an_argument_without_submitting() -> None:
+    controller, view = _argument_controller("/rename")
+
+    result = controller.on_key(key_event("enter"), "/rename", cursor_index=7)
+
+    assert result is CompletionResult.HANDLED
+    assert view.replacements[-1].replacement == "/rename "
+
+
+def test_enter_still_submits_a_command_that_takes_no_argument() -> None:
+    controller, view = _argument_controller("/reload")
+
+    result = controller.on_key(key_event("enter"), "/reload", cursor_index=7)
+
+    assert result is CompletionResult.SUBMIT
+    assert view.replacements[-1].replacement == "/reload"
+
+
+def test_tab_accepts_a_command_needing_an_argument_and_leaves_a_space() -> None:
+    controller, view = _argument_controller("/rename")
+
+    result = controller.on_key(key_event("tab"), "/rename", cursor_index=7)
+
+    assert result is CompletionResult.HANDLED
+    assert view.replacements[-1].replacement == "/rename"
+
+
+def test_rename_is_registered_as_needing_an_argument() -> None:
+    # /rename reports `Usage: /rename <title>` when it runs with empty args, so
+    # the dropdown must not submit it. Guards the registration, not the flag.
+    registry = CommandRegistry()
+
+    assert registry.commands["rename"].requires_argument is True

--- a/vibe/cli/autocompletion/base.py
+++ b/vibe/cli/autocompletion/base.py
@@ -13,6 +13,7 @@ class CompletionResult(StrEnum):
 class CompletionEntry(NamedTuple):
     label: str
     description: str
+    requires_argument: bool = False
 
 
 class CompletionView(Protocol):

--- a/vibe/cli/autocompletion/slash_command.py
+++ b/vibe/cli/autocompletion/slash_command.py
@@ -66,7 +66,18 @@ class SlashCommandController:
                 else:
                     result = CompletionResult.IGNORED
             case "enter":
-                if self._apply_selected_completion(text, cursor_index):
+                # Enter both accepts the highlighted completion and submits, so a
+                # command that needs an argument was unreachable from the
+                # dropdown: it submitted with empty args and reported its usage.
+                # Accept it followed by a space and let the user type the
+                # argument instead.
+                needs_argument = self._suggestions[
+                    self._selected_index
+                ].requires_argument
+                applied = self._apply_selected_completion(
+                    text, cursor_index, suffix=" " if needs_argument else ""
+                )
+                if applied and not needs_argument:
                     result = CompletionResult.SUBMIT
                 else:
                     result = CompletionResult.HANDLED
@@ -91,11 +102,13 @@ class SlashCommandController:
             self._suggestions, self._selected_index
         )
 
-    def _apply_selected_completion(self, text: str, cursor_index: int) -> bool:
+    def _apply_selected_completion(
+        self, text: str, cursor_index: int, *, suffix: str = ""
+    ) -> bool:
         if not self._suggestions:
             return False
 
-        alias = self._suggestions[self._selected_index].label
+        alias = self._suggestions[self._selected_index].label + suffix
         replacement_range = self._completer.get_replacement_range(text, cursor_index)
         if replacement_range is None:
             self.reset()

--- a/vibe/cli/commands.py
+++ b/vibe/cli/commands.py
@@ -22,6 +22,10 @@ class Command:
     handler: str
     exits: bool = False
     side_channel: bool = False
+    # Accepting this command from the completion dropdown must not submit it: the
+    # command is unusable without an argument, so Enter has to leave the input
+    # open for the user to type one.
+    requires_argument: bool = False
     # A command that resets the conversation (e.g. /clear) supersedes any
     # prompts queued before it: at drain time the queue drops those pending
     # prompts instead of running an LLM turn on the widgets the command is
@@ -168,6 +172,7 @@ class CommandRegistry:
                 description="Rename the current session",
                 handler="_rename_session",
                 side_channel=True,
+                requires_argument=True,
             ),
             "mcp": Command(
                 aliases=frozenset(["/mcp", "/connectors"]),

--- a/vibe/cli/textual_ui/widgets/chat_input/container.py
+++ b/vibe/cli/textual_ui/widgets/chat_input/container.py
@@ -81,7 +81,7 @@ class ChatInputContainer(Vertical):
 
     def _get_slash_entries(self) -> list[CompletionEntry]:
         entries = [
-            CompletionEntry(alias, command.description)
+            CompletionEntry(alias, command.description, command.requires_argument)
             for command in self._command_registry.commands.values()
             for alias in sorted(command.aliases)
         ]


### PR DESCRIPTION
Fixes #1014

## Root cause

The issue reads as broken argument parsing, but parsing is fine. I ran the repo's own registry:

```
parse_command("/rename My Title")  ->  ("rename", Command(...), "My Title")
get_replacement_range("/rename My Title", 16)  ->  (0, 7)   # args preserved
```

The bug is in the completion controller. `vibe/cli/autocompletion/slash_command.py`:

```python
case "enter":
    if self._apply_selected_completion(text, cursor_index):
        result = CompletionResult.SUBMIT
```

Enter **both accepts the highlighted completion and submits**. A user who types `/ren`, sees `/rename` highlighted, and presses Enter to accept it gets the command submitted with empty args — so `_rename_session` takes its guard branch and prints `Usage: /rename <title>` (`vibe/cli/textual_ui/app.py:3415`).

The dropdown also stays open while arguments are typed, because `CommandCompleter._head_word` matches only the head word:

```
top completions for "/rename My Title"  ->  ['/rename']    # dropdown still open
```

So there was no keystroke that accepted the completion and left the input open — `/rename` was unreachable from the dropdown by any path. Typing the whole command by hand and never triggering the popup works, which is why the report says it "always" errors: that is the flow everyone actually uses.

## Fix

Add `Command.requires_argument`, carry it through `CompletionEntry` to the controller, and when the accepted command needs an argument, insert it with a trailing space and return `HANDLED` instead of `SUBMIT`.

Four small edits: the flag on the dataclass, the flag on the `CompletionEntry` NamedTuple (defaulted, so the other construction sites are untouched), one field passed in `_get_slash_entries`, and the `enter` branch.

**Scope:** marked on `/rename` only — the command that is unusable without an argument. Commands whose argument is optional (`/compact`, `/retry`, `/clear`, `/mcp`, `/log-level`) are deliberately left alone, so Enter keeps running them immediately and no existing muscle memory changes. `/loop` looks like it belongs here too, but its no-arg path goes through `LoopCommands.handle_command` and I did not want to guess at the intended behaviour — happy to add it if you confirm.

## Tests

`tests/autocompletion/test_slash_command_controller.py` gains four cases, using a local fixture so the shared `make_controller` list (and the existing count assertions on it) are untouched:

- Enter on a command needing an argument returns `HANDLED` and inserts `"/rename "`
- Enter on a command that takes no argument still returns `SUBMIT` — regression guard for the existing behaviour
- Tab keeps its current semantics
- `/rename` is registered with `requires_argument=True` — guards the registration rather than the flag

**Honest note on these tests:** three of them reference the new field, so on `main` they fail with `TypeError: CompletionEntry.__new__() takes 3 positional arguments but 4 were given` rather than on the buggy behaviour. The user-visible bug is reproduced manually: launch `vibe`, type `/ren`, press Enter on the highlighted `/rename`, and you get the usage error with no way to supply a title.

## Local verification

CI does not run on fork PRs here, so I ran the project's gate locally (macOS, Python 3.12):

```
uv run pytest tests/autocompletion tests/cli -n0   ->  1533 passed, 4 warnings
uv run pyright <the 5 changed files>               ->  0 errors, 0 warnings
uv run ruff check .                                ->  All checks passed
uv run ruff format --check .                       ->  1042 files already formatted
```

No CHANGELOG, ADR, or README changes. Per ADR 0012 this touches only how a completion is accepted in the input box, not slash-command execution or queueing.
