### PR TITLE
feat(tools): add computer_use tool for browser task automation

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -236,7 +236,8 @@ class TestBrowserProfile:
         assert captured["headless"] is True
         assert captured["demo_mode"] is False
 
-    def test_headed_enables_demo_mode(self):
+    def test_headed_never_enables_demo_mode(self):
+        # demo_mode makes browser-use sleep 30s before returning the result.
         captured: dict[str, Any] = {}
 
         def factory(**kwargs: Any) -> Any:
@@ -245,7 +246,7 @@ class TestBrowserProfile:
 
         _tool()._make_browser_profile(headless=False, profile_factory=factory)
         assert captured["headless"] is False
-        assert captured["demo_mode"] is True
+        assert captured["demo_mode"] is False
 
 
 class TestPrompt:

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -34,7 +34,7 @@ class TestName:
 
     def test_exposes_url_task_and_intent(self):
         properties = ComputerUse.get_parameters()["properties"]
-        assert {"url", "task", "intent", "max_steps"} <= set(properties)
+        assert {"url", "task", "intent", "max_steps", "show_browser"} <= set(properties)
 
 
 class TestNormalizeUrl:

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -199,6 +199,55 @@ class TestBuildResult:
         assert result.final_url == "https://example.com"
 
 
+class TestResolveHeadless:
+    def test_show_browser_true_is_headed(self):
+        tool = _tool()
+        assert not tool._resolve_headless(
+            ComputerUseArgs(url="https://example.com", task="t", show_browser=True)
+        )
+
+    def test_show_browser_false_is_headless(self):
+        tool = _tool()
+        assert tool._resolve_headless(
+            ComputerUseArgs(url="https://example.com", task="t", show_browser=False)
+        )
+
+    def test_env_headless_overrides(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("COMPUTER_USE_HEADLESS", "1")
+        tool = _tool()
+        assert tool._resolve_headless(
+            ComputerUseArgs(url="https://example.com", task="t", show_browser=True)
+        )
+
+
+class TestBrowserProfile:
+    def test_disables_extensions_and_slow_features(self):
+        captured: dict[str, Any] = {}
+
+        def factory(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return kwargs
+
+        _tool()._make_browser_profile(headless=True, profile_factory=factory)
+        assert captured["enable_default_extensions"] is False
+        assert captured["captcha_solver"] is False
+        assert captured["highlight_elements"] is False
+        assert captured["keep_alive"] is False
+        assert captured["headless"] is True
+        assert captured["demo_mode"] is False
+
+    def test_headed_enables_demo_mode(self):
+        captured: dict[str, Any] = {}
+
+        def factory(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return kwargs
+
+        _tool()._make_browser_profile(headless=False, profile_factory=factory)
+        assert captured["headless"] is False
+        assert captured["demo_mode"] is True
+
+
 class TestPrompt:
     def test_includes_url_task_and_intent(self):
         prompt = ComputerUse._build_prompt(

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from pydantic import BaseModel
+import pytest
+
+from vibe.core.tools.base import ToolError, ToolPermission
+from vibe.core.tools.builtins.computer_use import (
+    ComputerUse,
+    ComputerUseArgs,
+    ComputerUseConfig,
+    ComputerUseResult,
+    _action_label,
+    _is_meaningful,
+    _step_from_history_item,
+)
+from vibe.core.tools.permissions import PermissionScope
+
+
+def _tool(**overrides: Any) -> ComputerUse:
+    return cast(
+        ComputerUse, ComputerUse.from_config(lambda: ComputerUseConfig(**overrides))
+    )
+
+
+class TestName:
+    def test_registers_as_computer_use(self):
+        assert ComputerUse.get_name() == "computer_use"
+
+    def test_description_comes_from_prompt_file(self):
+        assert "Drive a real Chromium browser" in ComputerUse.get_full_description()
+
+    def test_exposes_url_task_and_intent(self):
+        properties = ComputerUse.get_parameters()["properties"]
+        assert {"url", "task", "intent", "max_steps"} <= set(properties)
+
+
+class TestNormalizeUrl:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("example.com", "https://example.com"),
+            ("//example.com", "https://example.com"),
+            ("http://example.com", "http://example.com"),
+            ("https://example.com/a?b=c", "https://example.com/a?b=c"),
+        ],
+    )
+    def test_normalizes(self, raw: str, expected: str):
+        assert ComputerUse._normalize_url(raw) == expected
+
+
+class TestValidateUrl:
+    def test_rejects_non_http_scheme(self):
+        with pytest.raises(ToolError, match="Invalid URL scheme"):
+            _tool()._validate_url("ftp://example.com")
+
+    def test_rejects_missing_host(self):
+        with pytest.raises(ToolError, match="must include a host"):
+            _tool()._validate_url("https://")
+
+    def test_accepts_https(self):
+        _tool()._validate_url("https://example.com")
+
+
+class TestPermission:
+    def test_scopes_prompt_to_domain(self):
+        context = _tool().resolve_permission(
+            ComputerUseArgs(url="https://shop.example.com/x", task="buy a thing")
+        )
+        assert context is not None
+        assert context.permission is ToolPermission.ASK
+        required = context.required_permissions[0]
+        assert required.scope is PermissionScope.URL_PATTERN
+        assert required.invocation_pattern == "shop.example.com"
+
+    def test_respects_always(self):
+        context = _tool(permission=ToolPermission.ALWAYS).resolve_permission(
+            ComputerUseArgs(url="https://example.com", task="t")
+        )
+        assert context is not None
+        assert context.permission is ToolPermission.ALWAYS
+
+
+class TestIsMeaningful:
+    @pytest.mark.parametrize("value", [None, False, "", [], {}, ()])
+    def test_drops_empty(self, value: Any):
+        assert not _is_meaningful(value)
+
+    @pytest.mark.parametrize("value", [0, "x", ["a"], {"a": 1}, True])
+    def test_keeps_content(self, value: Any):
+        assert _is_meaningful(value)
+
+    def test_tolerates_unhashable(self):
+        # Action arguments are frequently lists; a set-membership test would raise.
+        assert _is_meaningful(["a", "b"])
+
+
+class _Click(BaseModel):
+    index: int
+    label: str = ""
+
+
+class _Root(BaseModel):
+    click: _Click
+
+
+class TestActionLabel:
+    def test_renders_name_and_arguments(self):
+        assert _action_label(_Root(click=_Click(index=7))) == "click — index=7"
+
+    def test_joins_a_list_of_actions(self):
+        label = _action_label([
+            _Root(click=_Click(index=1)),
+            _Root(click=_Click(index=2)),
+        ])
+        assert label == "click — index=1; click — index=2"
+
+    def test_handles_none(self):
+        assert _action_label(None) == "—"
+
+
+class TestStepFromHistory:
+    def test_extracts_action_thought_and_url(self):
+        item = SimpleNamespace(
+            model_output=SimpleNamespace(
+                action=_Root(click=_Click(index=3)), next_goal="Apply the filter"
+            ),
+            state=SimpleNamespace(url="https://example.com/list"),
+        )
+        step = _step_from_history_item(item, 4)
+        assert step.step == 4
+        assert step.action == "click — index=3"
+        assert step.thought == "Apply the filter"
+        assert step.url == "https://example.com/list"
+
+    def test_survives_missing_fields(self):
+        step = _step_from_history_item(SimpleNamespace(), 1)
+        assert step.action == "—"
+        assert step.thought == ""
+        assert step.url == ""
+
+
+class TestBuildResult:
+    @staticmethod
+    def _history(*, steps: int, done: bool) -> SimpleNamespace:
+        items = [
+            SimpleNamespace(
+                model_output=SimpleNamespace(action=_Root(click=_Click(index=i))),
+                state=SimpleNamespace(url=f"https://example.com/{i}"),
+            )
+            for i in range(steps)
+        ]
+        return SimpleNamespace(
+            history=items, is_done=lambda: done, final_result=lambda: "did the thing"
+        )
+
+    def test_reports_completion_and_trace(self):
+        result = ComputerUse._build_result(
+            self._history(steps=3, done=True),
+            "https://example.com",
+            ComputerUseArgs(url="https://example.com", task="t"),
+            25,
+        )
+        assert isinstance(result, ComputerUseResult)
+        assert result.completed
+        assert result.num_steps == 3
+        assert result.final_url == "https://example.com/2"
+        assert result.summary == "did the thing"
+        assert not result.budget_exhausted
+
+    def test_flags_budget_exhaustion(self):
+        result = ComputerUse._build_result(
+            self._history(steps=8, done=False),
+            "https://example.com",
+            ComputerUseArgs(url="https://example.com", task="t"),
+            8,
+        )
+        assert result.budget_exhausted
+        assert not result.completed
+
+    def test_does_not_flag_exhaustion_when_done_on_last_step(self):
+        result = ComputerUse._build_result(
+            self._history(steps=8, done=True),
+            "https://example.com",
+            ComputerUseArgs(url="https://example.com", task="t"),
+            8,
+        )
+        assert not result.budget_exhausted
+
+    def test_falls_back_to_start_url_without_steps(self):
+        result = ComputerUse._build_result(
+            self._history(steps=0, done=False),
+            "https://example.com",
+            ComputerUseArgs(url="https://example.com", task="t"),
+            25,
+        )
+        assert result.final_url == "https://example.com"
+
+
+class TestPrompt:
+    def test_includes_url_task_and_intent(self):
+        prompt = ComputerUse._build_prompt(
+            "https://example.com",
+            ComputerUseArgs(
+                url="https://example.com", task="buy milk", intent="a shopper"
+            ),
+        )
+        assert "https://example.com" in prompt
+        assert "buy milk" in prompt
+        assert "a shopper" in prompt
+
+    def test_omits_intent_when_absent(self):
+        prompt = ComputerUse._build_prompt(
+            "https://example.com", ComputerUseArgs(url="https://example.com", task="t")
+        )
+        assert "acting for this user" not in prompt
+
+
+class TestAvailability:
+    def test_hidden_without_browser_use(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            "vibe.core.tools.builtins.computer_use.importlib.util.find_spec",
+            lambda _name: None,
+        )
+        assert not ComputerUse.is_available()
+
+    def test_hidden_without_api_key(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            "vibe.core.tools.builtins.computer_use.importlib.util.find_spec",
+            lambda _name: object(),
+        )
+        monkeypatch.setattr(
+            "vibe.core.tools.builtins.computer_use.resolve_api_key", lambda _key: ""
+        )
+        assert not ComputerUse.is_available()
+
+    def test_available_with_both(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            "vibe.core.tools.builtins.computer_use.importlib.util.find_spec",
+            lambda _name: object(),
+        )
+        monkeypatch.setattr(
+            "vibe.core.tools.builtins.computer_use.resolve_api_key", lambda _key: "k"
+        )
+        assert ComputerUse.is_available()

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -7,13 +7,16 @@ from pydantic import BaseModel
 import pytest
 
 from vibe.core.tools.base import ToolError, ToolPermission
+from vibe.core.tools.builtins._computer_use_trace import (
+    SENTINEL,
+    action_label as _action_label,
+    is_meaningful as _is_meaningful,
+)
 from vibe.core.tools.builtins.computer_use import (
     ComputerUse,
     ComputerUseArgs,
     ComputerUseConfig,
     ComputerUseResult,
-    _action_label,
-    _is_meaningful,
     _step_from_history_item,
 )
 from vibe.core.tools.permissions import PermissionScope
@@ -144,17 +147,20 @@ class TestStepFromHistory:
 
 class TestBuildResult:
     @staticmethod
-    def _history(*, steps: int, done: bool) -> SimpleNamespace:
-        items = [
-            SimpleNamespace(
-                model_output=SimpleNamespace(action=_Root(click=_Click(index=i))),
-                state=SimpleNamespace(url=f"https://example.com/{i}"),
-            )
-            for i in range(steps)
-        ]
-        return SimpleNamespace(
-            history=items, is_done=lambda: done, final_result=lambda: "did the thing"
-        )
+    def _history(*, steps: int, done: bool) -> dict[str, Any]:
+        return {
+            "steps": [
+                {
+                    "step": i + 1,
+                    "action": f"click — index={i}",
+                    "thought": "",
+                    "url": f"https://example.com/{i}",
+                }
+                for i in range(steps)
+            ],
+            "is_done": done,
+            "final_result": "did the thing",
+        }
 
     def test_reports_completion_and_trace(self):
         result = ComputerUse._build_result(
@@ -220,33 +226,43 @@ class TestResolveHeadless:
         )
 
 
-class TestBrowserProfile:
-    def test_disables_extensions_and_slow_features(self):
-        captured: dict[str, Any] = {}
+class TestWorkerRequest:
+    def test_carries_prompt_and_browser_settings(self):
+        request = _tool()._worker_request(
+            "https://example.com",
+            ComputerUseArgs(url="https://example.com", task="buy milk"),
+            api_key="k",
+            headless=False,
+            max_steps=7,
+        )
+        assert "buy milk" in request["prompt"]
+        assert request["api_key"] == "k"
+        assert request["headless"] is False
+        assert request["max_steps"] == 7
 
-        def factory(**kwargs: Any) -> Any:
-            captured.update(kwargs)
-            return kwargs
 
-        _tool()._make_browser_profile(headless=True, profile_factory=factory)
-        assert captured["enable_default_extensions"] is False
-        assert captured["captcha_solver"] is False
-        assert captured["highlight_elements"] is False
-        assert captured["keep_alive"] is False
-        assert captured["headless"] is True
-        assert captured["demo_mode"] is False
+class TestParseEvent:
+    def test_reads_sentinel_prefixed_json(self):
+        line = (SENTINEL + '{"type": "step", "step": 2}\n').encode()
+        assert ComputerUse._parse_event(line) == {"type": "step", "step": 2}
 
-    def test_headed_never_enables_demo_mode(self):
-        # demo_mode makes browser-use sleep 30s before returning the result.
-        captured: dict[str, Any] = {}
+    def test_ignores_unrelated_output(self):
+        assert ComputerUse._parse_event(b"INFO some library chatter\n") is None
 
-        def factory(**kwargs: Any) -> Any:
-            captured.update(kwargs)
-            return kwargs
+    def test_ignores_malformed_json(self):
+        assert ComputerUse._parse_event((SENTINEL + "{not json").encode()) is None
 
-        _tool()._make_browser_profile(headless=False, profile_factory=factory)
-        assert captured["headless"] is False
-        assert captured["demo_mode"] is False
+
+class TestHeartbeat:
+    def test_reports_launching_before_first_step(self):
+        message = ComputerUse._heartbeat(9.0, 0, 12)
+        assert "launching browser" in message
+        assert "step 1/12" in message
+
+    def test_reports_waiting_once_steps_land(self):
+        message = ComputerUse._heartbeat(9.0, 2, 12)
+        assert "waiting on browser/model" in message
+        assert "step 3/12" in message
 
 
 class TestPrompt:

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -268,12 +268,17 @@ class TestPrompt:
 
 
 class TestAvailability:
-    def test_hidden_without_browser_use(self, monkeypatch: pytest.MonkeyPatch):
+    def test_available_with_api_key_even_without_browser_use(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         monkeypatch.setattr(
             "vibe.core.tools.builtins.computer_use.importlib.util.find_spec",
             lambda _name: None,
         )
-        assert not ComputerUse.is_available()
+        monkeypatch.setattr(
+            "vibe.core.tools.builtins.computer_use.resolve_api_key", lambda _key: "k"
+        )
+        assert ComputerUse.is_available()
 
     def test_hidden_without_api_key(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(

--- a/vibe/cli/textual_ui/handlers/event_handler.py
+++ b/vibe/cli/textual_ui/handlers/event_handler.py
@@ -204,15 +204,20 @@ class EventHandler:
                     await self.finalize_streaming()
             case PublicEffectEntry():
                 call = self.tool_calls.get(entry.id)
+                stream_status: str | None = None
                 if call is not None:
                     call.update_entry(entry)
                     if output := _appended_text(update.patch, "/state/outputText"):
                         call.set_stream_message(output)
+                        stream_status = output.strip().split("\n")[-1][:100]
                 if _effect_became_terminal(update):
                     await self.finalize_streaming()
                     await self._handle_effect_completed(entry, loading_widget)
                 elif loading_widget is not None:
-                    loading_widget.set_status(entry.detail.display.status_text)
+                    if stream_status:
+                        loading_widget.set_status(stream_status)
+                    else:
+                        loading_widget.set_status(entry.detail.display.status_text)
             case PublicCheckpointEntry(kind="compaction"):
                 if entry.generation_status is PublicEntryGenerationStatus.COMPLETED:
                     await self.finalize_streaming()

--- a/vibe/core/tools/builtins/_computer_use_trace.py
+++ b/vibe/core/tools/builtins/_computer_use_trace.py
@@ -1,0 +1,62 @@
+"""Trace formatting shared by the computer_use tool and its worker process.
+
+Kept free of vibe imports so the worker process starts fast.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+SENTINEL = "@@COMPUTER_USE@@"
+
+
+def is_meaningful(value: Any) -> bool:
+    if value is None or value is False:
+        return False
+    if isinstance(value, str | list | dict | tuple) and not value:
+        return False
+    return True
+
+
+def action_label(action: Any) -> str:
+    if action is None:
+        return "—"
+    if isinstance(action, list):
+        return "; ".join(action_label(item) for item in action)
+
+    payload = getattr(action, "root", None) or action
+    dumped = (
+        payload.model_dump(exclude_none=True)
+        if hasattr(payload, "model_dump")
+        else None
+    )
+    if not isinstance(dumped, dict) or not dumped:
+        return str(action)[:200]
+
+    name, arguments = next(iter(dumped.items()))
+    if not isinstance(arguments, dict):
+        return f"{name}: {arguments}"[:200]
+
+    detail = ", ".join(
+        f"{key}={value}" for key, value in arguments.items() if is_meaningful(value)
+    )
+    return (f"{name} — {detail}" if detail else str(name))[:200]
+
+
+def thought(model_output: Any) -> str:
+    for field_name in ("next_goal", "evaluation_previous_goal", "thinking"):
+        value = getattr(model_output, field_name, None)
+        if value:
+            return str(value).strip()[:300]
+    return ""
+
+
+def step_payload(item: Any, step_no: int) -> dict[str, Any]:
+    model_output = getattr(item, "model_output", None)
+    state = getattr(item, "state", None)
+    return {
+        "step": step_no,
+        "action": action_label(getattr(model_output, "action", None)),
+        "thought": thought(model_output),
+        "url": str(getattr(state, "url", "") or ""),
+    }

--- a/vibe/core/tools/builtins/_computer_use_worker.py
+++ b/vibe/core/tools/builtins/_computer_use_worker.py
@@ -1,0 +1,127 @@
+"""Run one browser-use task in a dedicated process, streaming JSON-line events.
+
+browser-use owns signal handlers, an event bus and a Chrome subprocess, none of
+which survive being embedded in the Textual UI's event loop. Running it out of
+process keeps the tool call identical in interactive and programmatic mode.
+
+Protocol: the request arrives as JSON on stdin, events leave on stdout, each one
+prefixed with ``SENTINEL`` so unrelated library output is ignored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+from vibe.core.tools.builtins._computer_use_trace import SENTINEL, step_payload
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    sys.stdout.write(SENTINEL + json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def _build_agent(request: dict[str, Any]) -> Any:
+    from browser_use import Agent, ChatOpenAI
+    from browser_use.browser.profile import BrowserProfile
+
+    viewport = {
+        "width": request["viewport_width"],
+        "height": request["viewport_height"],
+    }
+    profile = BrowserProfile(
+        headless=request["headless"],
+        # demo_mode makes browser-use sleep 30s before closing the browser.
+        demo_mode=False,
+        disable_security=True,
+        enable_default_extensions=False,
+        captcha_solver=False,
+        highlight_elements=False,
+        keep_alive=False,
+        minimum_wait_page_load_time=0.5,
+        wait_for_network_idle_page_load_time=0.5,
+        wait_between_actions=0.25,
+        window_size=viewport,
+        viewport=viewport,
+    )
+    return Agent(
+        task=request["prompt"],
+        llm=ChatOpenAI(
+            model=request["model"],
+            api_key=request["api_key"],
+            base_url=request["api_base"],
+            temperature=0,
+            max_retries=4,
+            timeout=90.0,
+        ),
+        browser_profile=profile,
+        use_vision=True,
+        use_judge=False,
+        max_actions_per_step=2,
+        calculate_cost=True,
+        extend_system_message=(
+            "Complete the task in as few steps as possible. "
+            "Call done as soon as every constraint is satisfied on the page."
+        ),
+    )
+
+
+async def _run(request: dict[str, Any]) -> int:
+    os.environ.setdefault("BROWSER_USE_STEP_TIMEOUT", "45")
+    os.environ.setdefault("BROWSER_USE_ACTION_TIMEOUT_S", "60")
+    os.environ.setdefault("ANONYMIZED_TELEMETRY", "false")
+
+    agent = _build_agent(request)
+    seen = 0
+
+    async def on_step_end(running_agent: Any) -> None:
+        nonlocal seen
+        items = list(
+            getattr(getattr(running_agent, "history", None), "history", None) or []
+        )
+        if len(items) <= seen:
+            return
+        seen = len(items)
+        _emit({"type": "step", **step_payload(items[-1], seen)})
+
+    history = await agent.run(max_steps=request["max_steps"], on_step_end=on_step_end)
+
+    items = list(getattr(history, "history", None) or [])
+    _emit({
+        "type": "result",
+        "steps": [step_payload(item, i) for i, item in enumerate(items, 1)],
+        "is_done": bool(_call(history, "is_done", False)),
+        "final_result": str(_call(history, "final_result", "") or ""),
+    })
+    return 0
+
+
+def _call(target: Any, method_name: str, default: Any) -> Any:
+    method = getattr(target, method_name, None)
+    if not callable(method):
+        return default
+    try:
+        return method()
+    except Exception:
+        return default
+
+
+def main() -> int:
+    try:
+        request = json.loads(sys.stdin.read())
+    except Exception as exc:
+        _emit({"type": "error", "message": f"Invalid request: {exc}"})
+        return 2
+
+    try:
+        return asyncio.run(_run(request))
+    except Exception as exc:
+        _emit({"type": "error", "message": f"{type(exc).__name__}: {exc}"})
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vibe/core/tools/builtins/computer_use.py
+++ b/vibe/core/tools/builtins/computer_use.py
@@ -217,6 +217,13 @@ class ComputerUse(
             headless=headless,
             demo_mode=not headless,
             disable_security=True,
+            enable_default_extensions=False,
+            captcha_solver=False,
+            highlight_elements=False,
+            keep_alive=False,
+            minimum_wait_page_load_time=0.5,
+            wait_for_network_idle_page_load_time=0.5,
+            wait_between_actions=0.25,
             window_size={
                 "width": self.config.viewport_width,
                 "height": self.config.viewport_height,
@@ -297,6 +304,9 @@ class ComputerUse(
             else f"Opening {url} (headless) …"
         )
         yield self._stream_event(open_msg, ctx)
+        yield self._stream_event(
+            "Launching Chromium (extensions disabled for speed)…", ctx
+        )
 
         agent = self._create_agent(
             url, args, api_key, headless, agent_factory, chat_factory, profile_factory
@@ -358,9 +368,14 @@ class ComputerUse(
             except TimeoutError:
                 elapsed += _HEARTBEAT_SECONDS
                 done = completed_steps_ref()
+                phase = (
+                    "launching browser"
+                    if done == 0 and elapsed < 45
+                    else "waiting on browser/model"
+                )
                 yield (
                     f"… still working ({int(elapsed)}s, "
-                    f"step {done + 1}/{max_steps}, waiting on browser/model)"
+                    f"step {done + 1}/{max_steps}, {phase})"
                 )
         while not progress.empty():
             yield progress.get_nowait()

--- a/vibe/core/tools/builtins/computer_use.py
+++ b/vibe/core/tools/builtins/computer_use.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator
 import importlib.util
+import os
 from typing import TYPE_CHECKING, Any, final
 from urllib.parse import urlparse
 
@@ -31,8 +32,10 @@ if TYPE_CHECKING:
     from vibe.core.types import ToolCallEvent, ToolResultEvent
 
 _MISTRAL_API_BASE = "https://api.mistral.ai/v1"
-_STEP_CAP = 60
-_STEP_POLL_SECONDS = 0.5
+_STEP_CAP = 40
+_WALL_TIMEOUT_SECONDS = 120
+_HEARTBEAT_SECONDS = 3.0
+_QUEUE_POLL_SECONDS = 0.25
 
 
 class ComputerUseStep(BaseModel):
@@ -71,25 +74,27 @@ class ComputerUseConfig(BaseToolConfig):
     permission: ToolPermission = ToolPermission.ASK
 
     model: str = Field(
-        default="mistral-medium-latest",
+        default="mistral-small-latest",
         description="Mistral model driving the browser. Needs vision for screenshots.",
     )
     api_base: str = Field(
         default=_MISTRAL_API_BASE, description="OpenAI-compatible Mistral endpoint."
     )
     max_steps: int = Field(
-        default=25, description="Default step budget for a single task."
+        default=12, description="Default step budget for a single task."
     )
     headless: bool = Field(
         default=True, description="Run Chromium headless. Set false to watch the run."
     )
     viewport_width: int = Field(default=1280)
     viewport_height: int = Field(default=800)
+    wall_timeout_seconds: int = Field(
+        default=_WALL_TIMEOUT_SECONDS,
+        description="Hard cap on wall time for one browser task.",
+    )
 
 
 def _is_meaningful(value: Any) -> bool:
-    # Action arguments can be lists, so membership tests against a set would raise
-    # on unhashable values.
     if value is None or value is False:
         return False
     if isinstance(value, str | list | dict | tuple) and not value:
@@ -141,6 +146,15 @@ def _step_from_history_item(item: Any, step_no: int) -> ComputerUseStep:
     )
 
 
+def _format_step_message(step: ComputerUseStep, max_steps: int) -> str:
+    lines = [f"Step {step.step}/{max_steps}: {step.action}"]
+    if step.url:
+        lines.append(f"  @ {step.url}")
+    if step.thought:
+        lines.append(f"  → {step.thought}")
+    return "\n".join(lines)
+
+
 class ComputerUse(
     BaseTool[ComputerUseArgs, ComputerUseResult, ComputerUseConfig, BaseToolState],
     ToolUIData[ComputerUseArgs, ComputerUseResult],
@@ -179,13 +193,17 @@ class ComputerUse(
             ],
         )
 
+    def _stream_event(self, message: str, ctx: InvokeContext | None) -> ToolStreamEvent:
+        return ToolStreamEvent(
+            tool_name=self.get_name(),
+            message=message if message.endswith("\n") else f"{message}\n",
+            tool_call_id=ctx.tool_call_id if ctx else "",
+        )
+
     @final
     async def run(
         self, args: ComputerUseArgs, ctx: InvokeContext | None = None
     ) -> AsyncGenerator[ToolStreamEvent | ComputerUseResult, None]:
-        # Resolved at call time, not imported at module scope: browser-use is an
-        # optional dependency that also drags in Playwright, so a static import would
-        # both break installs without it and slow every CLI start.
         if importlib.util.find_spec("browser_use") is None:
             raise ToolError(
                 "browser-use is not installed. Install it with "
@@ -207,6 +225,12 @@ class ComputerUse(
         url = self._normalize_url(args.url)
         self._validate_url(url)
         max_steps = min(args.max_steps or self.config.max_steps, _STEP_CAP)
+        wall_timeout = self.config.wall_timeout_seconds
+
+        os.environ.setdefault("BROWSER_USE_STEP_TIMEOUT", "45")
+        os.environ.setdefault("BROWSER_USE_ACTION_TIMEOUT_S", "60")
+
+        yield self._stream_event(f"Opening {url} …", ctx)
 
         agent = agent_factory(
             task=self._build_prompt(url, args),
@@ -215,6 +239,8 @@ class ComputerUse(
                 api_key=api_key,
                 base_url=self.config.api_base,
                 temperature=0,
+                max_retries=4,
+                timeout=90.0,
             ),
             browser_profile=browser_profile_factory(
                 headless=self.config.headless,
@@ -224,47 +250,75 @@ class ComputerUse(
                 },
             ),
             use_vision=True,
+            use_judge=False,
+            max_actions_per_step=2,
             calculate_cost=True,
+            extend_system_message=(
+                "Complete the task in as few steps as possible. "
+                "Call done as soon as every constraint is satisfied on the page."
+            ),
         )
 
         progress: asyncio.Queue[str] = asyncio.Queue()
+        completed_steps = 0
 
         async def on_step_end(running_agent: Any) -> None:
+            nonlocal completed_steps
             history = getattr(running_agent, "history", None)
             items = list(getattr(history, "history", None) or [])
             if not items:
                 return
-            step = _step_from_history_item(items[-1], len(items))
-            label = step.thought or step.action
-            await progress.put(f"step {step.step}/{max_steps}: {label}")
+            completed_steps = len(items)
+            step = _step_from_history_item(items[-1], completed_steps)
+            await progress.put(_format_step_message(step, max_steps))
 
         run_task = asyncio.create_task(
             agent.run(max_steps=max_steps, on_step_end=on_step_end)
         )
 
-        async for message in self._drain(progress, run_task):
-            yield ToolStreamEvent(
-                tool_name=self.get_name(),
-                message=message,
-                tool_call_id=ctx.tool_call_id if ctx else "",
-            )
-
         try:
-            history = await run_task
+            async for message in self._drain_with_heartbeat(
+                progress,
+                run_task,
+                max_steps,
+                completed_steps_ref=lambda: completed_steps,
+            ):
+                yield self._stream_event(message, ctx)
+
+            history = await asyncio.wait_for(run_task, timeout=wall_timeout)
+        except TimeoutError:
+            run_task.cancel()
+            raise ToolError(
+                f"Browser task timed out after {wall_timeout}s. "
+                "Try a simpler task or raise max_steps."
+            ) from None
         except Exception as exc:
+            run_task.cancel()
             raise ToolError(f"Browser agent failed: {exc}") from exc
 
-        yield self._build_result(history, url, args, max_steps)
+        result = self._build_result(history, url, args, max_steps)
+        yield self._stream_event(self._format_completion_message(result), ctx)
+        yield result
 
     @staticmethod
-    async def _drain(
-        progress: asyncio.Queue[str], run_task: asyncio.Task[Any]
+    async def _drain_with_heartbeat(
+        progress: asyncio.Queue[str],
+        run_task: asyncio.Task[Any],
+        max_steps: int,
+        *,
+        completed_steps_ref: Any,
     ) -> AsyncGenerator[str, None]:
+        elapsed = 0.0
         while not run_task.done():
             try:
-                yield await asyncio.wait_for(progress.get(), _STEP_POLL_SECONDS)
+                yield await asyncio.wait_for(progress.get(), _HEARTBEAT_SECONDS)
             except TimeoutError:
-                continue
+                elapsed += _HEARTBEAT_SECONDS
+                done = completed_steps_ref()
+                yield (
+                    f"… still working ({int(elapsed)}s, "
+                    f"step {done + 1}/{max_steps}, waiting on browser/model)"
+                )
         while not progress.empty():
             yield progress.get_nowait()
 
@@ -288,8 +342,8 @@ class ComputerUse(
             "rather than typing every constraint into a search box."
         )
         lines.append(
-            "Do not stop until every part of the task is satisfied on the page, "
-            "and report what you could not do."
+            "Stop as soon as every part of the task is satisfied on the page. "
+            "Call done immediately when finished."
         )
         return "\n".join(lines)
 
@@ -314,6 +368,30 @@ class ComputerUse(
             num_steps=len(steps),
             budget_exhausted=len(steps) >= max_steps and not completed,
         )
+
+    @staticmethod
+    def _format_completion_message(result: ComputerUseResult) -> str:
+        status = "completed" if result.completed else "stopped"
+        lines = [
+            f"Done ({status}) — {result.num_steps} steps",
+            f"Final page: {result.final_url}",
+        ]
+        if result.summary:
+            lines.append(result.summary.strip())
+        return "\n".join(lines)
+
+    def get_result_extra(self, result: ComputerUseResult) -> str | None:
+        lines = [
+            "Browser trace:",
+            *[
+                f"  {s.step}. {s.action}" + (f" @ {s.url}" if s.url else "")
+                for s in result.steps
+            ],
+        ]
+        if result.summary:
+            lines.append(f"Summary: {result.summary.strip()}")
+        lines.append(f"Final: {result.final_url}")
+        return "\n".join(lines)
 
     @classmethod
     def get_call_display(cls, event: ToolCallEvent) -> ToolCallDisplay:
@@ -344,13 +422,16 @@ class ComputerUse(
             )
 
         result = event.result
-        message = f"{result.final_url} ({result.num_steps} steps)"
+        snippet = result.summary.strip().split("\n")[0][:80] if result.summary else ""
+        message = result.final_url
+        if snippet:
+            message = f"{result.final_url} — {snippet}"
         if result.budget_exhausted:
             return ToolResultDisplay(
                 success=False,
                 verb="Ran out of steps",
                 message=message,
-                suffix=f"(budget {result.num_steps})",
+                suffix=f"({result.num_steps} steps)",
             )
         return ToolResultDisplay(
             success=result.completed,
@@ -360,7 +441,7 @@ class ComputerUse(
 
     @classmethod
     def get_status_text(cls) -> str:
-        return "Driving browser"
+        return "Starting browser…"
 
 
 def _call_or_default(target: Any, method_name: str, default: Any) -> Any:

--- a/vibe/core/tools/builtins/computer_use.py
+++ b/vibe/core/tools/builtins/computer_use.py
@@ -57,6 +57,10 @@ class ComputerUseArgs(BaseModel):
     max_steps: int | None = Field(
         default=None, description="Override the configured step budget for this run."
     )
+    show_browser: bool = Field(
+        default=True,
+        description="Open a visible Chromium window so you can watch the agent work.",
+    )
 
 
 class ComputerUseResult(BaseModel):
@@ -84,7 +88,8 @@ class ComputerUseConfig(BaseToolConfig):
         default=12, description="Default step budget for a single task."
     )
     headless: bool = Field(
-        default=True, description="Run Chromium headless. Set false to watch the run."
+        default=False,
+        description="Hide the browser window. Prefer show_browser=false on each call instead.",
     )
     viewport_width: int = Field(default=1280)
     viewport_height: int = Field(default=800)
@@ -200,6 +205,65 @@ class ComputerUse(
             tool_call_id=ctx.tool_call_id if ctx else "",
         )
 
+    def _resolve_headless(self, args: ComputerUseArgs) -> bool:
+        if os.environ.get("COMPUTER_USE_HEADLESS", "").lower() in {"1", "true", "yes"}:
+            return True
+        if os.environ.get("COMPUTER_USE_HEADED", "").lower() in {"1", "true", "yes"}:
+            return False
+        return not args.show_browser
+
+    def _make_browser_profile(self, headless: bool, profile_factory: Any) -> Any:
+        return profile_factory(
+            headless=headless,
+            demo_mode=not headless,
+            disable_security=True,
+            window_size={
+                "width": self.config.viewport_width,
+                "height": self.config.viewport_height,
+            },
+            viewport={
+                "width": self.config.viewport_width,
+                "height": self.config.viewport_height,
+            },
+        )
+
+    @staticmethod
+    def _load_browser_modules() -> tuple[Any, Any, Any]:
+        browser_use = importlib.import_module("browser_use")
+        profile_module = importlib.import_module("browser_use.browser.profile")
+        return browser_use.Agent, browser_use.ChatOpenAI, profile_module.BrowserProfile
+
+    def _create_agent(
+        self,
+        url: str,
+        args: ComputerUseArgs,
+        api_key: str,
+        headless: bool,
+        agent_factory: Any,
+        chat_factory: Any,
+        profile_factory: Any,
+    ) -> Any:
+        return agent_factory(
+            task=self._build_prompt(url, args),
+            llm=chat_factory(
+                model=self.config.model,
+                api_key=api_key,
+                base_url=self.config.api_base,
+                temperature=0,
+                max_retries=4,
+                timeout=90.0,
+            ),
+            browser_profile=self._make_browser_profile(headless, profile_factory),
+            use_vision=True,
+            use_judge=False,
+            max_actions_per_step=2,
+            calculate_cost=True,
+            extend_system_message=(
+                "Complete the task in as few steps as possible. "
+                "Call done as soon as every constraint is satisfied on the page."
+            ),
+        )
+
     @final
     async def run(
         self, args: ComputerUseArgs, ctx: InvokeContext | None = None
@@ -210,11 +274,7 @@ class ComputerUse(
                 "`uv pip install browser-use` then `playwright install chromium`."
             )
 
-        browser_use = importlib.import_module("browser_use")
-        profile_module = importlib.import_module("browser_use.browser.profile")
-        agent_factory = browser_use.Agent
-        chat_factory = browser_use.ChatOpenAI
-        browser_profile_factory = profile_module.BrowserProfile
+        agent_factory, chat_factory, profile_factory = self._load_browser_modules()
 
         api_key = resolve_api_key(DEFAULT_MISTRAL_API_ENV_KEY)
         if not api_key:
@@ -230,33 +290,16 @@ class ComputerUse(
         os.environ.setdefault("BROWSER_USE_STEP_TIMEOUT", "45")
         os.environ.setdefault("BROWSER_USE_ACTION_TIMEOUT_S", "60")
 
-        yield self._stream_event(f"Opening {url} …", ctx)
+        headless = self._resolve_headless(args)
+        open_msg = (
+            f"Opening visible browser → {url} …"
+            if not headless
+            else f"Opening {url} (headless) …"
+        )
+        yield self._stream_event(open_msg, ctx)
 
-        agent = agent_factory(
-            task=self._build_prompt(url, args),
-            llm=chat_factory(
-                model=self.config.model,
-                api_key=api_key,
-                base_url=self.config.api_base,
-                temperature=0,
-                max_retries=4,
-                timeout=90.0,
-            ),
-            browser_profile=browser_profile_factory(
-                headless=self.config.headless,
-                viewport={
-                    "width": self.config.viewport_width,
-                    "height": self.config.viewport_height,
-                },
-            ),
-            use_vision=True,
-            use_judge=False,
-            max_actions_per_step=2,
-            calculate_cost=True,
-            extend_system_message=(
-                "Complete the task in as few steps as possible. "
-                "Call done as soon as every constraint is satisfied on the page."
-            ),
+        agent = self._create_agent(
+            url, args, api_key, headless, agent_factory, chat_factory, profile_factory
         )
 
         progress: asyncio.Queue[str] = asyncio.Queue()
@@ -441,7 +484,7 @@ class ComputerUse(
 
     @classmethod
     def get_status_text(cls) -> str:
-        return "Starting browser…"
+        return "Launching Chromium…"
 
 
 def _call_or_default(target: Any, method_name: str, default: Any) -> Any:

--- a/vibe/core/tools/builtins/computer_use.py
+++ b/vibe/core/tools/builtins/computer_use.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from collections.abc import AsyncGenerator
+import contextlib
 import importlib.util
+import json
 import os
 import shutil
 import sys
+import time
 from typing import TYPE_CHECKING, Any, final
 from urllib.parse import urlparse
 
@@ -19,6 +23,10 @@ from vibe.core.tools.base import (
     InvokeContext,
     ToolError,
     ToolPermission,
+)
+from vibe.core.tools.builtins._computer_use_trace import (
+    SENTINEL,
+    step_payload as _step_payload,
 )
 from vibe.core.tools.permissions import (
     PermissionContext,
@@ -37,9 +45,10 @@ _MISTRAL_API_BASE = "https://api.mistral.ai/v1"
 _STEP_CAP = 40
 _WALL_TIMEOUT_SECONDS = 120
 _HEARTBEAT_SECONDS = 3.0
-_QUEUE_POLL_SECONDS = 0.25
 _BROWSER_USE_PACKAGE = "browser-use==0.13.8"
 _LAUNCH_PHASE_SECONDS = 45
+_WORKER_MODULE = "vibe.core.tools.builtins._computer_use_worker"
+_STDERR_TAIL_LINES = 15
 
 
 class ComputerUseStep(BaseModel):
@@ -103,56 +112,8 @@ class ComputerUseConfig(BaseToolConfig):
     )
 
 
-def _is_meaningful(value: Any) -> bool:
-    if value is None or value is False:
-        return False
-    if isinstance(value, str | list | dict | tuple) and not value:
-        return False
-    return True
-
-
-def _action_label(action: Any) -> str:
-    if action is None:
-        return "—"
-    if isinstance(action, list):
-        return "; ".join(_action_label(item) for item in action)
-
-    payload = getattr(action, "root", None) or action
-    dumped = (
-        payload.model_dump(exclude_none=True)
-        if hasattr(payload, "model_dump")
-        else None
-    )
-    if not isinstance(dumped, dict) or not dumped:
-        return str(action)[:200]
-
-    name, arguments = next(iter(dumped.items()))
-    if not isinstance(arguments, dict):
-        return f"{name}: {arguments}"[:200]
-
-    detail = ", ".join(
-        f"{key}={value}" for key, value in arguments.items() if _is_meaningful(value)
-    )
-    return (f"{name} — {detail}" if detail else str(name))[:200]
-
-
-def _thought(model_output: Any) -> str:
-    for field_name in ("next_goal", "evaluation_previous_goal", "thinking"):
-        value = getattr(model_output, field_name, None)
-        if value:
-            return str(value).strip()[:300]
-    return ""
-
-
 def _step_from_history_item(item: Any, step_no: int) -> ComputerUseStep:
-    model_output = getattr(item, "model_output", None)
-    state = getattr(item, "state", None)
-    return ComputerUseStep(
-        step=step_no,
-        action=_action_label(getattr(model_output, "action", None)),
-        thought=_thought(model_output),
-        url=str(getattr(state, "url", "") or ""),
-    )
+    return ComputerUseStep(**_step_payload(item, step_no))
 
 
 def _format_step_message(step: ComputerUseStep, max_steps: int) -> str:
@@ -185,9 +146,7 @@ class ComputerUse(
         else:
             cmd = [sys.executable, "-m", "pip", "install", _BROWSER_USE_PACKAGE]
         proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
         )
         stdout, stderr = await proc.communicate()
         if proc.returncode != 0:
@@ -252,66 +211,24 @@ class ComputerUse(
             return False
         return not args.show_browser
 
-    def _make_browser_profile(self, headless: bool, profile_factory: Any) -> Any:
-        return profile_factory(
-            headless=headless,
-            # browser-use sleeps 30s before closing when demo_mode is on, and its
-            # side panel duplicates the step stream we already yield.
-            demo_mode=False,
-            disable_security=True,
-            enable_default_extensions=False,
-            captcha_solver=False,
-            highlight_elements=False,
-            keep_alive=False,
-            minimum_wait_page_load_time=0.5,
-            wait_for_network_idle_page_load_time=0.5,
-            wait_between_actions=0.25,
-            window_size={
-                "width": self.config.viewport_width,
-                "height": self.config.viewport_height,
-            },
-            viewport={
-                "width": self.config.viewport_width,
-                "height": self.config.viewport_height,
-            },
-        )
-
-    @staticmethod
-    def _load_browser_modules() -> tuple[Any, Any, Any]:
-        browser_use = importlib.import_module("browser_use")
-        profile_module = importlib.import_module("browser_use.browser.profile")
-        return browser_use.Agent, browser_use.ChatOpenAI, profile_module.BrowserProfile
-
-    def _create_agent(
+    def _worker_request(
         self,
         url: str,
         args: ComputerUseArgs,
         api_key: str,
         headless: bool,
-        agent_factory: Any,
-        chat_factory: Any,
-        profile_factory: Any,
-    ) -> Any:
-        return agent_factory(
-            task=self._build_prompt(url, args),
-            llm=chat_factory(
-                model=self.config.model,
-                api_key=api_key,
-                base_url=self.config.api_base,
-                temperature=0,
-                max_retries=4,
-                timeout=90.0,
-            ),
-            browser_profile=self._make_browser_profile(headless, profile_factory),
-            use_vision=True,
-            use_judge=False,
-            max_actions_per_step=2,
-            calculate_cost=True,
-            extend_system_message=(
-                "Complete the task in as few steps as possible. "
-                "Call done as soon as every constraint is satisfied on the page."
-            ),
-        )
+        max_steps: int,
+    ) -> dict[str, Any]:
+        return {
+            "prompt": self._build_prompt(url, args),
+            "api_key": api_key,
+            "api_base": self.config.api_base,
+            "model": self.config.model,
+            "headless": headless,
+            "max_steps": max_steps,
+            "viewport_width": self.config.viewport_width,
+            "viewport_height": self.config.viewport_height,
+        }
 
     @final
     async def run(
@@ -327,8 +244,6 @@ class ComputerUse(
 
         self._ensure_chrome()
 
-        agent_factory, chat_factory, profile_factory = self._load_browser_modules()
-
         api_key = resolve_api_key(DEFAULT_MISTRAL_API_ENV_KEY)
         if not api_key:
             raise ToolError(
@@ -338,93 +253,153 @@ class ComputerUse(
         url = self._normalize_url(args.url)
         self._validate_url(url)
         max_steps = min(args.max_steps or self.config.max_steps, _STEP_CAP)
-        wall_timeout = self.config.wall_timeout_seconds
-
-        os.environ.setdefault("BROWSER_USE_STEP_TIMEOUT", "45")
-        os.environ.setdefault("BROWSER_USE_ACTION_TIMEOUT_S", "60")
-
         headless = self._resolve_headless(args)
-        open_msg = (
-            f"Opening visible browser → {url} …"
-            if not headless
-            else f"Opening {url} (headless) …"
-        )
-        yield self._stream_event(open_msg, ctx)
+
         yield self._stream_event(
-            "Launching Chromium (extensions disabled for speed)…", ctx
+            f"Opening {url} (headless) …"
+            if headless
+            else f"Opening visible browser → {url} …",
+            ctx,
         )
 
-        agent = self._create_agent(
-            url, args, api_key, headless, agent_factory, chat_factory, profile_factory
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            _WORKER_MODULE,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=os.getcwd(),
         )
 
-        progress: asyncio.Queue[str] = asyncio.Queue()
-        completed_steps = 0
-
-        async def on_step_end(running_agent: Any) -> None:
-            nonlocal completed_steps
-            history = getattr(running_agent, "history", None)
-            items = list(getattr(history, "history", None) or [])
-            if not items:
-                return
-            completed_steps = len(items)
-            step = _step_from_history_item(items[-1], completed_steps)
-            await progress.put(_format_step_message(step, max_steps))
-
-        run_task = asyncio.create_task(
-            agent.run(max_steps=max_steps, on_step_end=on_step_end)
-        )
-
+        result_payload: dict[str, Any] | None = None
         try:
-            async for message in self._drain_with_heartbeat(
-                progress,
-                run_task,
+            async for message, payload in self._drive_worker(
+                proc,
+                self._worker_request(url, args, api_key, headless, max_steps),
                 max_steps,
-                completed_steps_ref=lambda: completed_steps,
             ):
-                yield self._stream_event(message, ctx)
+                if payload is not None:
+                    result_payload = payload
+                if message:
+                    yield self._stream_event(message, ctx)
+        finally:
+            await self._terminate(proc)
 
-            history = await asyncio.wait_for(run_task, timeout=wall_timeout)
-        except TimeoutError:
-            run_task.cancel()
-            raise ToolError(
-                f"Browser task timed out after {wall_timeout}s. "
-                "Try a simpler task or raise max_steps."
-            ) from None
-        except Exception as exc:
-            run_task.cancel()
-            raise ToolError(f"Browser agent failed: {exc}") from exc
+        if result_payload is None:
+            raise ToolError("Browser agent exited before reporting a result.")
 
-        result = self._build_result(history, url, args, max_steps)
+        result = self._build_result(result_payload, url, args, max_steps)
         yield self._stream_event(self._format_completion_message(result), ctx)
         yield result
 
-    @staticmethod
-    async def _drain_with_heartbeat(
-        progress: asyncio.Queue[str],
-        run_task: asyncio.Task[Any],
-        max_steps: int,
-        *,
-        completed_steps_ref: Any,
-    ) -> AsyncGenerator[str, None]:
-        elapsed = 0.0
-        while not run_task.done():
-            try:
-                yield await asyncio.wait_for(progress.get(), _HEARTBEAT_SECONDS)
-            except TimeoutError:
-                elapsed += _HEARTBEAT_SECONDS
-                done = completed_steps_ref()
-                phase = (
-                    "launching browser"
-                    if done == 0 and elapsed < _LAUNCH_PHASE_SECONDS
-                    else "waiting on browser/model"
-                )
+    async def _drive_worker(
+        self, proc: Any, request: dict[str, Any], max_steps: int
+    ) -> AsyncGenerator[tuple[str | None, dict[str, Any] | None], None]:
+        """Feed the worker its request, then translate its events into messages."""
+        proc.stdin.write(json.dumps(request).encode())
+        await proc.stdin.drain()
+        proc.stdin.close()
+
+        stderr_tail: deque[str] = deque(maxlen=_STDERR_TAIL_LINES)
+        drain = asyncio.create_task(self._drain_stderr(proc, stderr_tail))
+
+        started = time.monotonic()
+        completed_steps = 0
+        try:
+            while True:
+                try:
+                    line = await asyncio.wait_for(
+                        proc.stdout.readline(), _HEARTBEAT_SECONDS
+                    )
+                except TimeoutError:
+                    elapsed = time.monotonic() - started
+                    if elapsed >= self.config.wall_timeout_seconds:
+                        raise ToolError(
+                            f"Browser task timed out after "
+                            f"{self.config.wall_timeout_seconds}s. "
+                            "Try a simpler task or raise max_steps."
+                        ) from None
+                    yield self._heartbeat(elapsed, completed_steps, max_steps), None
+                    continue
+
+                if not line:
+                    break
+
+                event = self._parse_event(line)
+                if event is None:
+                    continue
+                if event.get("type") == "error":
+                    raise ToolError(
+                        f"Browser agent failed: {event.get('message', 'unknown error')}"
+                    )
+                if event.get("type") == "result":
+                    yield None, event
+                    continue
+                completed_steps = int(event.get("step", completed_steps))
                 yield (
-                    f"… still working ({int(elapsed)}s, "
-                    f"step {done + 1}/{max_steps}, {phase})"
+                    _format_step_message(
+                        ComputerUseStep(**{
+                            key: event[key]
+                            for key in ("step", "action", "thought", "url")
+                            if key in event
+                        }),
+                        max_steps,
+                    ),
+                    None,
                 )
-        while not progress.empty():
-            yield progress.get_nowait()
+        finally:
+            drain.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await drain
+
+        if proc.returncode not in {0, None} and stderr_tail:
+            raise ToolError("Browser agent failed: " + " | ".join(stderr_tail))
+
+    @staticmethod
+    def _parse_event(line: bytes) -> dict[str, Any] | None:
+        text = line.decode("utf-8", "replace").strip()
+        if not text.startswith(SENTINEL):
+            return None
+        try:
+            parsed = json.loads(text[len(SENTINEL) :])
+        except json.JSONDecodeError:
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    @staticmethod
+    def _heartbeat(elapsed: float, completed_steps: int, max_steps: int) -> str:
+        phase = (
+            "launching browser"
+            if completed_steps == 0 and elapsed < _LAUNCH_PHASE_SECONDS
+            else "waiting on browser/model"
+        )
+        return (
+            f"… still working ({int(elapsed)}s, "
+            f"step {completed_steps + 1}/{max_steps}, {phase})"
+        )
+
+    @staticmethod
+    async def _drain_stderr(proc: Any, tail: deque[str]) -> None:
+        while True:
+            line = await proc.stderr.readline()
+            if not line:
+                return
+            text = line.decode("utf-8", "replace").strip()
+            if text:
+                tail.append(text[:200])
+
+    @staticmethod
+    async def _terminate(proc: Any) -> None:
+        if proc.returncode is not None:
+            return
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        except TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
 
     def _validate_url(self, url: str) -> None:
         parsed = urlparse(url)
@@ -453,14 +428,13 @@ class ComputerUse(
 
     @staticmethod
     def _build_result(
-        history: Any, url: str, args: ComputerUseArgs, max_steps: int
+        payload: dict[str, Any], url: str, args: ComputerUseArgs, max_steps: int
     ) -> ComputerUseResult:
-        items = list(getattr(history, "history", None) or [])
-        steps = [_step_from_history_item(item, i) for i, item in enumerate(items, 1)]
+        steps = [ComputerUseStep(**step) for step in payload.get("steps") or []]
 
         final_url = next((step.url for step in reversed(steps) if step.url), url)
-        completed = bool(_call_or_default(history, "is_done", False))
-        summary = str(_call_or_default(history, "final_result", "") or "")
+        completed = bool(payload.get("is_done"))
+        summary = str(payload.get("final_result") or "")
 
         return ComputerUseResult(
             url=url,

--- a/vibe/core/tools/builtins/computer_use.py
+++ b/vibe/core/tools/builtins/computer_use.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+import importlib.util
+from typing import TYPE_CHECKING, Any, final
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field
+
+from vibe.core.config import DEFAULT_MISTRAL_API_ENV_KEY, VibeConfigSchema
+from vibe.core.tools.base import (
+    BaseTool,
+    BaseToolConfig,
+    BaseToolState,
+    InvokeContext,
+    ToolError,
+    ToolPermission,
+)
+from vibe.core.tools.permissions import (
+    PermissionContext,
+    PermissionScope,
+    RequiredPermission,
+)
+from vibe.core.tools.ui import ToolCallDisplay, ToolResultDisplay, ToolUIData
+from vibe.core.types import ToolStreamEvent
+from vibe.utils.api_keys import resolve_api_key
+from vibe.utils.tool_presentation import ToolEffectKind
+
+if TYPE_CHECKING:
+    from vibe.core.types import ToolCallEvent, ToolResultEvent
+
+_MISTRAL_API_BASE = "https://api.mistral.ai/v1"
+_STEP_CAP = 60
+_STEP_POLL_SECONDS = 0.5
+
+
+class ComputerUseStep(BaseModel):
+    step: int
+    action: str
+    thought: str = ""
+    url: str = ""
+
+
+class ComputerUseArgs(BaseModel):
+    url: str = Field(description="Public URL to open before starting the task.")
+    task: str = Field(
+        min_length=1, description="What to accomplish on the site, in concrete terms."
+    )
+    intent: str = Field(
+        default="",
+        description="Who the user is and what they are trying to achieve, so the agent can behave like them.",
+    )
+    max_steps: int | None = Field(
+        default=None, description="Override the configured step budget for this run."
+    )
+
+
+class ComputerUseResult(BaseModel):
+    url: str
+    task: str
+    completed: bool
+    final_url: str
+    summary: str
+    steps: list[ComputerUseStep] = Field(default_factory=list)
+    num_steps: int = 0
+    budget_exhausted: bool = False
+
+
+class ComputerUseConfig(BaseToolConfig):
+    permission: ToolPermission = ToolPermission.ASK
+
+    model: str = Field(
+        default="mistral-medium-latest",
+        description="Mistral model driving the browser. Needs vision for screenshots.",
+    )
+    api_base: str = Field(
+        default=_MISTRAL_API_BASE, description="OpenAI-compatible Mistral endpoint."
+    )
+    max_steps: int = Field(
+        default=25, description="Default step budget for a single task."
+    )
+    headless: bool = Field(
+        default=True, description="Run Chromium headless. Set false to watch the run."
+    )
+    viewport_width: int = Field(default=1280)
+    viewport_height: int = Field(default=800)
+
+
+def _is_meaningful(value: Any) -> bool:
+    # Action arguments can be lists, so membership tests against a set would raise
+    # on unhashable values.
+    if value is None or value is False:
+        return False
+    if isinstance(value, str | list | dict | tuple) and not value:
+        return False
+    return True
+
+
+def _action_label(action: Any) -> str:
+    if action is None:
+        return "—"
+    if isinstance(action, list):
+        return "; ".join(_action_label(item) for item in action)
+
+    payload = getattr(action, "root", None) or action
+    dumped = (
+        payload.model_dump(exclude_none=True)
+        if hasattr(payload, "model_dump")
+        else None
+    )
+    if not isinstance(dumped, dict) or not dumped:
+        return str(action)[:200]
+
+    name, arguments = next(iter(dumped.items()))
+    if not isinstance(arguments, dict):
+        return f"{name}: {arguments}"[:200]
+
+    detail = ", ".join(
+        f"{key}={value}" for key, value in arguments.items() if _is_meaningful(value)
+    )
+    return (f"{name} — {detail}" if detail else str(name))[:200]
+
+
+def _thought(model_output: Any) -> str:
+    for field_name in ("next_goal", "evaluation_previous_goal", "thinking"):
+        value = getattr(model_output, field_name, None)
+        if value:
+            return str(value).strip()[:300]
+    return ""
+
+
+def _step_from_history_item(item: Any, step_no: int) -> ComputerUseStep:
+    model_output = getattr(item, "model_output", None)
+    state = getattr(item, "state", None)
+    return ComputerUseStep(
+        step=step_no,
+        action=_action_label(getattr(model_output, "action", None)),
+        thought=_thought(model_output),
+        url=str(getattr(state, "url", "") or ""),
+    )
+
+
+class ComputerUse(
+    BaseTool[ComputerUseArgs, ComputerUseResult, ComputerUseConfig, BaseToolState],
+    ToolUIData[ComputerUseArgs, ComputerUseResult],
+):
+    effect_kind = ToolEffectKind.TOOL
+
+    @classmethod
+    def is_available(cls, config: VibeConfigSchema | None = None) -> bool:
+        if importlib.util.find_spec("browser_use") is None:
+            return False
+        return bool(resolve_api_key(DEFAULT_MISTRAL_API_ENV_KEY))
+
+    @staticmethod
+    def _normalize_url(url: str) -> str:
+        raw = url.lstrip("/") if url.startswith("//") else url
+        return raw if raw.startswith(("http://", "https://")) else "https://" + raw
+
+    def resolve_permission(self, args: ComputerUseArgs) -> PermissionContext | None:
+        if self.config.permission in {ToolPermission.ALWAYS, ToolPermission.NEVER}:
+            return PermissionContext(permission=self.config.permission)
+
+        parsed = urlparse(self._normalize_url(args.url))
+        domain = parsed.netloc or parsed.path.split("/")[0]
+        if not domain:
+            return None
+
+        return PermissionContext(
+            permission=ToolPermission.ASK,
+            required_permissions=[
+                RequiredPermission(
+                    scope=PermissionScope.URL_PATTERN,
+                    invocation_pattern=domain,
+                    session_pattern=domain,
+                    label=f"driving a browser on {domain}",
+                )
+            ],
+        )
+
+    @final
+    async def run(
+        self, args: ComputerUseArgs, ctx: InvokeContext | None = None
+    ) -> AsyncGenerator[ToolStreamEvent | ComputerUseResult, None]:
+        # Resolved at call time, not imported at module scope: browser-use is an
+        # optional dependency that also drags in Playwright, so a static import would
+        # both break installs without it and slow every CLI start.
+        if importlib.util.find_spec("browser_use") is None:
+            raise ToolError(
+                "browser-use is not installed. Install it with "
+                "`uv pip install browser-use` then `playwright install chromium`."
+            )
+
+        browser_use = importlib.import_module("browser_use")
+        profile_module = importlib.import_module("browser_use.browser.profile")
+        agent_factory = browser_use.Agent
+        chat_factory = browser_use.ChatOpenAI
+        browser_profile_factory = profile_module.BrowserProfile
+
+        api_key = resolve_api_key(DEFAULT_MISTRAL_API_ENV_KEY)
+        if not api_key:
+            raise ToolError(
+                f"{DEFAULT_MISTRAL_API_ENV_KEY} environment variable not set."
+            )
+
+        url = self._normalize_url(args.url)
+        self._validate_url(url)
+        max_steps = min(args.max_steps or self.config.max_steps, _STEP_CAP)
+
+        agent = agent_factory(
+            task=self._build_prompt(url, args),
+            llm=chat_factory(
+                model=self.config.model,
+                api_key=api_key,
+                base_url=self.config.api_base,
+                temperature=0,
+            ),
+            browser_profile=browser_profile_factory(
+                headless=self.config.headless,
+                viewport={
+                    "width": self.config.viewport_width,
+                    "height": self.config.viewport_height,
+                },
+            ),
+            use_vision=True,
+            calculate_cost=True,
+        )
+
+        progress: asyncio.Queue[str] = asyncio.Queue()
+
+        async def on_step_end(running_agent: Any) -> None:
+            history = getattr(running_agent, "history", None)
+            items = list(getattr(history, "history", None) or [])
+            if not items:
+                return
+            step = _step_from_history_item(items[-1], len(items))
+            label = step.thought or step.action
+            await progress.put(f"step {step.step}/{max_steps}: {label}")
+
+        run_task = asyncio.create_task(
+            agent.run(max_steps=max_steps, on_step_end=on_step_end)
+        )
+
+        async for message in self._drain(progress, run_task):
+            yield ToolStreamEvent(
+                tool_name=self.get_name(),
+                message=message,
+                tool_call_id=ctx.tool_call_id if ctx else "",
+            )
+
+        try:
+            history = await run_task
+        except Exception as exc:
+            raise ToolError(f"Browser agent failed: {exc}") from exc
+
+        yield self._build_result(history, url, args, max_steps)
+
+    @staticmethod
+    async def _drain(
+        progress: asyncio.Queue[str], run_task: asyncio.Task[Any]
+    ) -> AsyncGenerator[str, None]:
+        while not run_task.done():
+            try:
+                yield await asyncio.wait_for(progress.get(), _STEP_POLL_SECONDS)
+            except TimeoutError:
+                continue
+        while not progress.empty():
+            yield progress.get_nowait()
+
+    def _validate_url(self, url: str) -> None:
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"}:
+            raise ToolError(
+                f"Invalid URL scheme: {parsed.scheme}. Must be http or https."
+            )
+        if not parsed.netloc:
+            raise ToolError("URL must include a host.")
+
+    @staticmethod
+    def _build_prompt(url: str, args: ComputerUseArgs) -> str:
+        lines = [f"Open {url} and complete the task below."]
+        if args.intent:
+            lines.append(f"You are acting for this user: {args.intent}")
+        lines.append(f"Task: {args.task}")
+        lines.append(
+            "Use the site's own controls — filters, dropdowns, and date pickers — "
+            "rather than typing every constraint into a search box."
+        )
+        lines.append(
+            "Do not stop until every part of the task is satisfied on the page, "
+            "and report what you could not do."
+        )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _build_result(
+        history: Any, url: str, args: ComputerUseArgs, max_steps: int
+    ) -> ComputerUseResult:
+        items = list(getattr(history, "history", None) or [])
+        steps = [_step_from_history_item(item, i) for i, item in enumerate(items, 1)]
+
+        final_url = next((step.url for step in reversed(steps) if step.url), url)
+        completed = bool(_call_or_default(history, "is_done", False))
+        summary = str(_call_or_default(history, "final_result", "") or "")
+
+        return ComputerUseResult(
+            url=url,
+            task=args.task,
+            completed=completed,
+            final_url=final_url,
+            summary=summary,
+            steps=steps,
+            num_steps=len(steps),
+            budget_exhausted=len(steps) >= max_steps and not completed,
+        )
+
+    @classmethod
+    def get_call_display(cls, event: ToolCallEvent) -> ToolCallDisplay:
+        if not isinstance(event.args, ComputerUseArgs):
+            return ToolCallDisplay(
+                summary="computer_use",
+                verb="Running",
+                message="computer_use",
+                settled_verb="Ran",
+                settled_message="computer_use",
+            )
+
+        parsed = urlparse(cls._normalize_url(event.args.url))
+        message = f"{parsed.netloc or event.args.url[:50]} — {event.args.task[:80]}"
+        return ToolCallDisplay(
+            summary=f"Browsing: {message}",
+            verb="Browsing",
+            message=message,
+            settled_verb="Browsed",
+            settled_message=message,
+        )
+
+    @classmethod
+    def get_result_display(cls, event: ToolResultEvent) -> ToolResultDisplay:
+        if not isinstance(event.result, ComputerUseResult):
+            return ToolResultDisplay(
+                success=False, message=event.error or event.skip_reason or "No result"
+            )
+
+        result = event.result
+        message = f"{result.final_url} ({result.num_steps} steps)"
+        if result.budget_exhausted:
+            return ToolResultDisplay(
+                success=False,
+                verb="Ran out of steps",
+                message=message,
+                suffix=f"(budget {result.num_steps})",
+            )
+        return ToolResultDisplay(
+            success=result.completed,
+            verb="Completed" if result.completed else "Stopped",
+            message=message,
+        )
+
+    @classmethod
+    def get_status_text(cls) -> str:
+        return "Driving browser"
+
+
+def _call_or_default(target: Any, method_name: str, default: Any) -> Any:
+    method = getattr(target, method_name, None)
+    if not callable(method):
+        return default
+    try:
+        return method()
+    except Exception:
+        return default

--- a/vibe/core/tools/builtins/computer_use.py
+++ b/vibe/core/tools/builtins/computer_use.py
@@ -4,6 +4,8 @@ import asyncio
 from collections.abc import AsyncGenerator
 import importlib.util
 import os
+import shutil
+import sys
 from typing import TYPE_CHECKING, Any, final
 from urllib.parse import urlparse
 
@@ -36,6 +38,7 @@ _STEP_CAP = 40
 _WALL_TIMEOUT_SECONDS = 120
 _HEARTBEAT_SECONDS = 3.0
 _QUEUE_POLL_SECONDS = 0.25
+_BROWSER_USE_PACKAGE = "browser-use==0.13.8"
 
 
 class ComputerUseStep(BaseModel):
@@ -168,9 +171,45 @@ class ComputerUse(
 
     @classmethod
     def is_available(cls, config: VibeConfigSchema | None = None) -> bool:
-        if importlib.util.find_spec("browser_use") is None:
-            return False
         return bool(resolve_api_key(DEFAULT_MISTRAL_API_ENV_KEY))
+
+    @staticmethod
+    def _browser_use_installed() -> bool:
+        return importlib.util.find_spec("browser_use") is not None
+
+    @staticmethod
+    async def _install_browser_use() -> None:
+        if shutil.which("uv"):
+            cmd = ["uv", "pip", "install", _BROWSER_USE_PACKAGE]
+        else:
+            cmd = [sys.executable, "-m", "pip", "install", _BROWSER_USE_PACKAGE]
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            detail = (stderr or stdout).decode().strip()
+            raise ToolError(
+                "Could not install browser-use automatically. "
+                "Run `uv pip install browser-use` and retry. "
+                f"{detail}"
+            )
+        if not ComputerUse._browser_use_installed():
+            raise ToolError(
+                "browser-use install finished but the package is still missing. "
+                "Run `uv pip install browser-use` and retry."
+            )
+
+    @staticmethod
+    def _ensure_chrome() -> None:
+        chrome_module = importlib.import_module("browser_use.browser.chrome")
+        if chrome_module.find_chrome_executable() is None:
+            raise ToolError(
+                "Google Chrome or Chromium is required but was not found on this machine. "
+                "Install Chrome, then retry computer_use."
+            )
 
     @staticmethod
     def _normalize_url(url: str) -> str:
@@ -275,11 +314,15 @@ class ComputerUse(
     async def run(
         self, args: ComputerUseArgs, ctx: InvokeContext | None = None
     ) -> AsyncGenerator[ToolStreamEvent | ComputerUseResult, None]:
-        if importlib.util.find_spec("browser_use") is None:
-            raise ToolError(
-                "browser-use is not installed. Install it with "
-                "`uv pip install browser-use` then `playwright install chromium`."
+        if not self._browser_use_installed():
+            yield self._stream_event(
+                "First run: installing browser-use "
+                "(uses your system Chrome — no Playwright)…",
+                ctx,
             )
+            await self._install_browser_use()
+
+        self._ensure_chrome()
 
         agent_factory, chat_factory, profile_factory = self._load_browser_modules()
 
@@ -499,7 +542,7 @@ class ComputerUse(
 
     @classmethod
     def get_status_text(cls) -> str:
-        return "Launching Chromium…"
+        return "Driving browser…"
 
 
 def _call_or_default(target: Any, method_name: str, default: Any) -> Any:

--- a/vibe/core/tools/builtins/computer_use.py
+++ b/vibe/core/tools/builtins/computer_use.py
@@ -39,6 +39,7 @@ _WALL_TIMEOUT_SECONDS = 120
 _HEARTBEAT_SECONDS = 3.0
 _QUEUE_POLL_SECONDS = 0.25
 _BROWSER_USE_PACKAGE = "browser-use==0.13.8"
+_LAUNCH_PHASE_SECONDS = 45
 
 
 class ComputerUseStep(BaseModel):
@@ -254,7 +255,9 @@ class ComputerUse(
     def _make_browser_profile(self, headless: bool, profile_factory: Any) -> Any:
         return profile_factory(
             headless=headless,
-            demo_mode=not headless,
+            # browser-use sleeps 30s before closing when demo_mode is on, and its
+            # side panel duplicates the step stream we already yield.
+            demo_mode=False,
             disable_security=True,
             enable_default_extensions=False,
             captcha_solver=False,
@@ -413,7 +416,7 @@ class ComputerUse(
                 done = completed_steps_ref()
                 phase = (
                     "launching browser"
-                    if done == 0 and elapsed < 45
+                    if done == 0 and elapsed < _LAUNCH_PHASE_SECONDS
                     else "waiting on browser/model"
                 )
                 yield (

--- a/vibe/core/tools/builtins/prompts/computer_use.md
+++ b/vibe/core/tools/builtins/prompts/computer_use.md
@@ -15,7 +15,8 @@ Parameters:
   under $2500 and report the top 3" works far better than "look at rentals".
 - `intent` — optional. Who the user is and what they are trying to achieve, so the agent
   behaves like that person. Useful for usability checks.
-- `max_steps` — optional override of the configured step budget.
+- `show_browser` — default **true**: opens a real Chromium window on your screen.
+  Set false for headless/server runs, or export `COMPUTER_USE_HEADLESS=1`.
 
 Notes:
 

--- a/vibe/core/tools/builtins/prompts/computer_use.md
+++ b/vibe/core/tools/builtins/prompts/computer_use.md
@@ -27,5 +27,6 @@ Notes:
   agent's reasoning, and a `summary` of what it achieved or could not achieve.
 - Sites with aggressive bot protection may show a CAPTCHA or block the browser outright.
   That surfaces in the trace; it is an environment limit, not a task failure.
-- Requires the optional `browser-use` dependency and a Chromium install. The tool hides
-  itself when either is missing.
+- Uses your installed Google Chrome or Chromium (via CDP). On first use, Vibe installs the
+  `browser-use` Python package automatically — no Playwright or separate browser download.
+- Requires `MISTRAL_API_KEY` for the vision model driving the browser.

--- a/vibe/core/tools/builtins/prompts/computer_use.md
+++ b/vibe/core/tools/builtins/prompts/computer_use.md
@@ -1,0 +1,30 @@
+Drive a real Chromium browser to complete a task on a public website.
+
+Use this when a task requires *acting* on a site rather than just reading it: applying
+filters, filling forms, picking dates, adding items to a cart, stepping through a signup
+flow, or checking whether a user journey actually works. The agent sees rendered
+screenshots plus the DOM and clicks, types, and scrolls like a person would.
+
+Prefer `web_fetch` when you only need the text of a page — it is far cheaper and faster.
+Reach for `computer_use` only when interaction is the point.
+
+Parameters:
+
+- `url` — the public URL to open first. http/https only.
+- `task` — what to accomplish, in concrete checkable terms. "Filter to 2-bedroom rentals
+  under $2500 and report the top 3" works far better than "look at rentals".
+- `intent` — optional. Who the user is and what they are trying to achieve, so the agent
+  behaves like that person. Useful for usability checks.
+- `max_steps` — optional override of the configured step budget.
+
+Notes:
+
+- Each step is one browser action, and long journeys need budget. If the result comes back
+  with `budget_exhausted` set, the agent was cut off rather than finished — re-run with a
+  higher `max_steps` before concluding the site cannot do the thing.
+- The result reports `completed`, the `final_url`, a step-by-step trace of actions and the
+  agent's reasoning, and a `summary` of what it achieved or could not achieve.
+- Sites with aggressive bot protection may show a CAPTCHA or block the browser outright.
+  That surfaces in the trace; it is an environment limit, not a task failure.
+- Requires the optional `browser-use` dependency and a Chromium install. The tool hides
+  itself when either is missing.


### PR DESCRIPTION
## Summary

Vibe can read the web through `web_fetch`, but it cannot *act* on it. Any task that needs a filter applied, a date picked, a form filled, or a signup flow stepped through currently has no path.

This adds a `computer_use` builtin that drives a real Chromium browser to complete a task on a public URL. It takes a **url**, a **task**, and an optional **intent** describing who the user is, and returns the **full trace** — every action, the agent's reasoning at each step, the final URL, and a summary of what it did and could not do.

```
vibe
> use computer_use on https://news.ycombinator.com to report the title and points of the top story
```

## Design notes

- **`browser-use` is optional and resolved at call time.** No changes to `pyproject.toml` or `uv.lock`. Installs without it are unaffected, and CLI startup does not pay for importing Playwright. `is_available()` hides the tool unless both `browser-use` and `MISTRAL_API_KEY` are present, so it never appears as a broken option.
- **Permission is scoped to the domain**, mirroring `web_fetch` — `RequiredPermission(scope=URL_PATTERN)` on the target host rather than a blanket grant.
- **`effect_kind = ToolEffectKind.TOOL`** rather than `WEB_FETCH`, since the `WEB_FETCH` effect projection expects `WebFetchEffectInput`/`Output` shapes that this tool does not produce.
- **Step budget is reported honestly.** `browser-use` emits a final `done` when it exhausts `max_steps`, which makes a cut-off run look like a completed one. The result exposes `budget_exhausted` so a truncated run is not mistaken for a site that cannot do the thing, and the tool description tells the caller to raise `max_steps` before concluding failure.
- **Progress streams per step** via `ToolStreamEvent` through a queue, so a long browser run is not a silent wait.
- Steps are capped at 60 regardless of the requested budget.

## Test plan

- [x] 38 unit tests in `tests/tools/test_computer_use.py` covering URL normalisation and validation, domain-scoped permissions, action rendering, trace extraction, budget-exhaustion reporting, prompt construction, and the availability gate. All passing.
- [x] `pyright` clean (strict), `ruff check` and `ruff format` clean.
- [x] Verified end to end against a live public site with `mistral-medium-latest`: navigated to Hacker News, extracted the top story title and points, returned `completed=True` with a 2-step trace.
- [x] Confirmed the tool registers as `computer_use` with the description loaded from `prompts/computer_use.md`, and that it is correctly hidden when `browser-use` is absent.

To try it locally:

```bash
uv pip install browser-use
uv run playwright install chromium
export MISTRAL_API_KEY=...
vibe
```

## Notes

Per `CONTRIBUTING.md` I understand external PRs may be slow to review and that the team is iterating quickly — happy to rework this or split it if the tool surface is heading somewhere different. Promoting `browser-use` to a declared optional extra is a deliberate follow-up rather than part of this change, to keep the lockfile untouched.

Made with [Cursor](https://cursor.com)