### PR TITLE
fix: preserve coroutine exceptions in run_sync

### DIFF
--- a/tests/core/utils/test_concurrency.py
+++ b/tests/core/utils/test_concurrency.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+
+from vibe.core.utils.concurrency import run_sync
+
+
+def test_run_sync_completes_without_running_loop() -> None:
+    async def operation() -> str:
+        return "completed"
+
+    assert run_sync(operation()) == "completed"
+
+
+def test_run_sync_completes_inside_running_loop() -> None:
+    async def operation() -> str:
+        return "completed"
+
+    async def scenario() -> None:
+        assert run_sync(operation()) == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_run_sync_propagates_runtime_error_without_running_loop() -> None:
+    original = RuntimeError("operation failed")
+
+    async def operation() -> None:
+        raise original
+
+    try:
+        run_sync(operation())
+    except RuntimeError as caught:
+        assert caught is original
+    else:
+        raise AssertionError("run_sync() did not propagate the operation error")
+
+
+def test_run_sync_propagates_runtime_error_inside_running_loop() -> None:
+    original = RuntimeError("operation failed")
+
+    async def operation() -> None:
+        raise original
+
+    async def scenario() -> None:
+        try:
+            run_sync(operation())
+        except RuntimeError as caught:
+            assert caught is original
+        else:
+            raise AssertionError("run_sync() did not propagate the operation error")
+
+    asyncio.run(scenario())
+
+
+def test_run_sync_propagates_other_errors_inside_running_loop_once() -> None:
+    original = ValueError("operation failed")
+    executions = 0
+
+    async def operation() -> None:
+        nonlocal executions
+        executions += 1
+        raise original
+
+    async def scenario() -> None:
+        try:
+            run_sync(operation())
+        except ValueError as caught:
+            assert caught is original
+        else:
+            raise AssertionError("run_sync() did not propagate the operation error")
+
+    asyncio.run(scenario())
+    assert executions == 1

--- a/vibe/core/utils/concurrency.py
+++ b/vibe/core/utils/concurrency.py
@@ -21,11 +21,12 @@ def run_sync[T](coro: Coroutine[Any, Any, T]) -> T:
     """
     try:
         asyncio.get_running_loop()
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(asyncio.run, coro)
-            return future.result()
     except RuntimeError:
         return asyncio.run(coro)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(asyncio.run, coro)
+        return future.result()
 
 
 class AsyncExecutor:


### PR DESCRIPTION
## Summary

- Keep the `run_sync()` event-loop probe separate from coroutine execution.
- Propagate `RuntimeError` and other exceptions raised by the coroutine unchanged instead of treating them as loop-detection failures.
- Add focused regression coverage for nested-loop success, exception identity, and single execution.

Fixes #1062.

## Validation

- `uv run pytest tests/core/utils` — 262 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run pyright vibe/core/utils/concurrency.py tests/core/utils/test_concurrency.py` — passed
- `uv run pre-commit run --files vibe/core/utils/concurrency.py tests/core/utils/test_concurrency.py` — passed
- `git diff --check` — passed

The full suite was also exercised in the Windows checkout: 10,042 passed and 279 skipped; the remaining failures/errors are existing platform-sensitive tests involving POSIX APIs, `time.tzset`, and unrelated integration behavior. The full repository Pyright/pre-commit runs likewise report only pre-existing platform/stub and typo findings outside this change.