### PR TITLE
fingerprint: detect same-length rewrites within one timestamp tick

### DIFF
--- a/vibe/core/config/fingerprint.py
+++ b/vibe/core/config/fingerprint.py
@@ -27,10 +27,35 @@ def capture_stable_file(path: Path) -> Iterator[tuple[IO[bytes], str]]:
         raise ConcurrencyConflictError(expected_fp=before, actual_fp=after)
 
 
+_FINGERPRINT_CHUNK_SIZE = 1 << 16
+
+
 def create_file_fingerprint(file: IO) -> str:
-    """Return an opaque token representing the current state of a file."""
-    stat = os.fstat(file.fileno())
-    return f"{stat.st_dev}:{stat.st_ino}:{stat.st_mtime_ns}:{stat.st_size}"
+    """Return an opaque token representing the current state of a file.
+
+    The token covers both the file's identity and its contents. Identity alone
+    is not sufficient: replacing a file's contents with different data of the
+    same length within a single filesystem timestamp tick leaves st_size,
+    st_mtime_ns and st_ctime_ns all unchanged (both timestamps come from the
+    same clock), so a stat-only token cannot observe the change and a config
+    reload silently keeps serving stale values.
+
+    Contents are read with os.pread() so that the caller's file position is
+    left untouched -- capture_stable_file() hands the same open file to its
+    caller -- and so that the O_RDWR handle from tempfile.NamedTemporaryFile()
+    used by the atomic-write path can be fingerprinted as well.
+    """
+    fd = file.fileno()
+    stat = os.fstat(fd)
+    digest = hashlib.sha256()
+    offset = 0
+    while chunk := os.pread(fd, _FINGERPRINT_CHUNK_SIZE, offset):
+        digest.update(chunk)
+        offset += len(chunk)
+    return (
+        f"{stat.st_dev}:{stat.st_ino}:{stat.st_mtime_ns}:{stat.st_size}"
+        f":{digest.hexdigest()}"
+    )
 
 
 def create_dict_fingerprint(source: dict[str, Any]) -> str:


### PR DESCRIPTION
`create_file_fingerprint()` returns `dev:ino:mtime_ns:size`. If a config file is
rewritten with different data of the same length inside a single filesystem
timestamp tick, all four components are unchanged, so the change is invisible:
`capture_stable_file()` fails to notice a concurrent write, and a config reload
keeps serving stale values.

This is not a narrow edge case. On a local filesystem, writing `key = 1` then
`key = 2` in a tight loop:

| | undetected out of 2000 |
|---|---|
| before | 1959 |
| after | 0 |

`st_ctime_ns` is not a fix — it comes from the same clock as `st_mtime_ns` and
does not tick either. Measured over the same 2000 rewrites, `st_ctime_ns` was
unchanged in exactly the same 1959 cases.

So the fingerprint now also hashes the file contents. Contents are read with
`os.pread()` for two reasons:

* it leaves the caller's file position untouched, which matters because
  `capture_stable_file()` hands the same open file to its caller; and
* it works on the `O_RDWR` handle that `tempfile.NamedTemporaryFile()` gives
  `_write_toml_snapshot()`, which fingerprints the temp file before renaming it
  into place.

The stat fields are kept, so the token is strictly more discriminating than
before — this can only reduce missed changes, never add false ones.

The existing test `TestCreateFileFingerprint::test_changes_when_file_changes`
already covered exactly this and fails on fast filesystems. It passes now, and
is unmodified. Full `tests/core/config/` run: 711 passed.
