### PR TITLE
fix(tools): cap managed shell logs and prune stale sessions (#1023)

### DIFF
--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -2127,3 +2127,101 @@ def test_experimental_bash_standalone_denylisted_with_redirect_not_denied(comman
     assert result.permission is not ToolPermission.NEVER, (
         f"Command with redirect should not be denied: {command!r}"
     )
+
+
+def test_append_output_caps_log_size_at_maximum_limit(tmp_path, monkeypatch):
+    import vibe.core.tools.builtins.experimental_bash as exp_bash_mod
+
+    monkeypatch.setattr(exp_bash_mod, "_MAX_SESSION_LOG_BYTES", 50)
+    manager = TerminalSessionManager()
+    output_path = tmp_path / "out.log"
+    output_path.touch()
+
+    session = TerminalSession(
+        session_id="cap_test",
+        command="cmd",
+        cwd=tmp_path,
+        shell="/bin/sh",
+        terminal=_RunningTerminal(),
+        output_path=output_path,
+        manifest_path=tmp_path / "cap_test.json",
+        created_at=0.0,
+    )
+
+    manager._append_output(session, b"a" * 30)
+    assert output_path.stat().st_size == 30
+    assert not session.truncated_log
+
+    manager._append_output(session, b"b" * 30)
+    assert session.truncated_log
+    content = output_path.read_bytes()
+    assert content.startswith(b"a" * 30 + b"b" * 20)
+    assert exp_bash_mod._LOG_TRUNCATION_MARKER in content
+
+    # Further appends should be ignored
+    current_size = output_path.stat().st_size
+    manager._append_output(session, b"c" * 30)
+    assert output_path.stat().st_size == current_size
+
+
+def test_write_log_file_rejects_exceeding_max_session_log_bytes(tmp_path, monkeypatch):
+    import vibe.core.tools.builtins.experimental_bash as exp_bash_mod
+
+    monkeypatch.setattr(exp_bash_mod, "_MAX_SESSION_LOG_BYTES", 50)
+    manager = TerminalSessionManager()
+    manager.base_dir = tmp_path
+    manager.sessions_dir = tmp_path / "sessions"
+    manager.sessions_dir.mkdir(parents=True, exist_ok=True)
+
+    log_path = manager.sessions_dir / "bash_manual.log"
+
+    with pytest.raises(ManagedShellError, match="limit"):
+        manager.write_log_file(log_path, action="write", content="x" * 60)
+
+    manager.write_log_file(log_path, action="write", content="x" * 40)
+
+    with pytest.raises(ManagedShellError, match="limit"):
+        manager.write_log_file(log_path, action="append", content="y" * 20)
+
+
+def test_prune_stale_sessions_removes_old_and_oversized_sessions(tmp_path, monkeypatch):
+    import os
+    import time
+
+    import vibe.core.tools.builtins.experimental_bash as exp_bash_mod
+
+    sessions_dir = tmp_path / "shell-tool" / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1. Create old session (> 7 days)
+    old_log = sessions_dir / "bash_old.log"
+    old_json = sessions_dir / "bash_old.json"
+    old_log.write_text("old output")
+    old_json.write_text('{"session_id": "bash_old", "status": "completed"}')
+    eight_days_ago = time.time() - (8 * 24 * 3600)
+    os.utime(old_log, (eight_days_ago, eight_days_ago))
+    os.utime(old_json, (eight_days_ago, eight_days_ago))
+
+    # 2. Create recent sessions
+    for i in range(5):
+        log = sessions_dir / f"bash_recent_{i}.log"
+        json_file = sessions_dir / f"bash_recent_{i}.json"
+        log.write_text(f"output {i}")
+        json_file.write_text(
+            f'{{"session_id": "bash_recent_{i}", "status": "completed"}}'
+        )
+
+    monkeypatch.setattr(exp_bash_mod, "_MAX_SAVED_SESSIONS", 3)
+    monkeypatch.setattr(
+        exp_bash_mod, "VIBE_HOME", type("VibeHome", (), {"path": tmp_path})()
+    )
+
+    manager = TerminalSessionManager()
+
+    # Old session should be pruned
+    assert not old_log.exists()
+    assert not old_json.exists()
+
+    # Saved sessions count should be capped to 3
+    remaining_logs = list(manager.sessions_dir.glob("*.log"))
+    assert len(remaining_logs) <= 3

--- a/vibe/core/tools/builtins/experimental_bash.py
+++ b/vibe/core/tools/builtins/experimental_bash.py
@@ -78,6 +78,14 @@ FORCE_TERMINATION_TIMEOUT_SECONDS = 2.0
 READER_SELECT_SECONDS = 0.1
 FOREGROUND_STREAM_SECONDS = 0.2
 
+_MAX_SESSION_LOG_BYTES = 50 * 1024 * 1024
+_MAX_TOTAL_SESSIONS_BYTES = 500 * 1024 * 1024
+_MAX_SESSION_LOG_AGE_SECONDS = 7 * 24 * 3600
+_MAX_SAVED_SESSIONS = 100
+_LOG_TRUNCATION_MARKER = (
+    b"\n[Output truncated: session log reached maximum size limit (50MB)]\n"
+)
+
 CONTROL_SEQUENCES: dict[str, bytes] = {
     "ctrl_@": b"\x00",
     "ctrl_a": b"\x01",
@@ -453,6 +461,7 @@ class TerminalSession:
         default_factory=lambda: threading.Condition(threading.RLock())
     )
     reader_thread: threading.Thread | None = None
+    truncated_log: bool = False
 
 
 class SessionInfo(BaseModel):
@@ -572,6 +581,7 @@ class TerminalSessionManager:
         self._sessions: dict[str, TerminalSession] = {}
         self._orphaned: dict[str, dict[str, Any]] = {}
         self._lock = threading.RLock()
+        self._prune_stale_sessions()
         self._load_orphaned_manifests()
 
     def start(
@@ -800,14 +810,24 @@ class TerminalSessionManager:
         self._reject_other_family_session_log(resolved)
         self._reject_live_session_log_write(resolved)
         resolved.parent.mkdir(parents=True, exist_ok=True)
+        raw_bytes = content.encode("utf-8")
         if action == "write":
+            if len(raw_bytes) > _MAX_SESSION_LOG_BYTES:
+                raise ManagedShellError(
+                    f"log content exceeds {_MAX_SESSION_LOG_BYTES} bytes limit"
+                )
             resolved.write_text(content, encoding="utf-8")
         elif action == "append":
+            current_size = _safe_stat_size(resolved)
+            if current_size + len(raw_bytes) > _MAX_SESSION_LOG_BYTES:
+                raise ManagedShellError(
+                    f"appending to log would exceed {_MAX_SESSION_LOG_BYTES} bytes limit"
+                )
             with resolved.open("a", encoding="utf-8") as handle:
                 handle.write(content)
         else:
             raise ManagedShellError(f"unsupported write action: {action}")
-        return len(content.encode("utf-8"))
+        return len(raw_bytes)
 
     def _reject_live_session_log_write(self, path: Path) -> None:
         with self._lock:
@@ -893,8 +913,27 @@ class TerminalSessionManager:
 
     def _append_output(self, session: TerminalSession, data: bytes) -> None:
         with session.condition:
-            with session.output_path.open("ab") as handle:
-                handle.write(data)
+            if session.truncated_log:
+                return
+            current_size = _safe_stat_size(session.output_path)
+            if current_size >= _MAX_SESSION_LOG_BYTES:
+                session.truncated_log = True
+                with session.output_path.open("ab") as handle:
+                    handle.write(_LOG_TRUNCATION_MARKER)
+                session.updated_at = time.time()
+                session.condition.notify_all()
+                return
+
+            remaining_budget = _MAX_SESSION_LOG_BYTES - current_size
+            if len(data) > remaining_budget:
+                to_write = data[:remaining_budget]
+                session.truncated_log = True
+                with session.output_path.open("ab") as handle:
+                    handle.write(to_write)
+                    handle.write(_LOG_TRUNCATION_MARKER)
+            else:
+                with session.output_path.open("ab") as handle:
+                    handle.write(data)
             session.updated_at = time.time()
             session.condition.notify_all()
 
@@ -1095,6 +1134,71 @@ class TerminalSessionManager:
                 except OSError:
                     pass
             self._orphaned[session_id] = metadata
+
+    def _prune_stale_sessions(self) -> None:
+        if not self.sessions_dir.exists():
+            return
+        now = time.time()
+        session_files: dict[str, list[Path]] = {}
+        session_mtimes: dict[str, float] = {}
+
+        try:
+            children = list(self.sessions_dir.iterdir())
+        except OSError:
+            return
+
+        for child in children:
+            if not child.is_file():
+                continue
+            name = child.name
+            if not (name.endswith(".log") or name.endswith(".json")):
+                continue
+            session_id = child.stem
+            session_files.setdefault(session_id, []).append(child)
+            try:
+                mtime = child.stat().st_mtime
+            except OSError:
+                mtime = now
+            session_mtimes[session_id] = max(session_mtimes.get(session_id, 0.0), mtime)
+
+        with self._lock:
+            live_ids = set(self._sessions.keys())
+
+        orphaned_ids = [sid for sid in session_files if sid not in live_ids]
+
+        # 1. Prune by age
+        for session_id in list(orphaned_ids):
+            mtime = session_mtimes.get(session_id, 0.0)
+            if now - mtime > _MAX_SESSION_LOG_AGE_SECONDS:
+                for path in session_files.get(session_id, []):
+                    try:
+                        path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+                session_files.pop(session_id, None)
+                session_mtimes.pop(session_id, None)
+                orphaned_ids.remove(session_id)
+
+        # 2. Prune by count and total size
+        orphaned_ids.sort(key=lambda sid: session_mtimes.get(sid, 0.0))
+
+        def _total_size() -> int:
+            return sum(
+                _safe_stat_size(p) for paths in session_files.values() for p in paths
+            )
+
+        while orphaned_ids and (
+            len(session_files) > _MAX_SAVED_SESSIONS
+            or _total_size() > _MAX_TOTAL_SESSIONS_BYTES
+        ):
+            oldest_id = orphaned_ids.pop(0)
+            for path in session_files.get(oldest_id, []):
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            session_files.pop(oldest_id, None)
+            session_mtimes.pop(oldest_id, None)
 
     def _info_from_manifest(self, metadata: dict[str, Any]) -> SessionInfo:
         return SessionInfo.model_validate(metadata)


### PR DESCRIPTION
### Summary

Fixes #1023

Managed shell tools previously wrote PTY output to `~/.vibe/shell-tool/sessions/{session_id}.log` without write caps, rotation, or pruning. Long-running or output-heavy processes accumulated hundreds of gigabytes over time, causing severe disk exhaustion.

This PR introduces:
1. **Per-Session Log Cap**: Enforces `_MAX_SESSION_LOG_BYTES` (50 MiB per session). Once reached, an output truncation marker is appended and further writes are ignored.
2. **Automated Session Pruning**: Prunes orphaned session logs and manifests older than 7 days on startup, while enforcing a 500 MiB aggregate storage cap and 100-session limit (evicting oldest first).

---

### Changes

- **`vibe/core/tools/builtins/experimental_bash.py`**:
  - Added constants: `_MAX_SESSION_LOG_BYTES`, `_MAX_TOTAL_SESSIONS_BYTES`, `_MAX_SESSION_LOG_AGE_SECONDS`, `_MAX_SAVED_SESSIONS`, and `_LOG_TRUNCATION_MARKER`.
  - Updated `_append_output` and `write_log_file` to enforce session log size limits.
  - Added `_prune_stale_sessions` to `TerminalSessionManager` and wired it into `__init__`.
- **`tests/tools/test_bash.py`**:
  - Added `test_append_output_caps_log_size_at_maximum_limit`.
  - Added `test_write_log_file_rejects_exceeding_max_session_log_bytes`.
  - Added `test_prune_stale_sessions_removes_old_and_oversized_sessions`.

---

### Verification

- `uv run pytest tests/tools/test_bash.py` (131 passed)
- `uv run pytest tests/tools/test_windows_shell.py tests/core/tools/test_terminal_runtime.py` (99 passed)
- `uv run ruff check --fix . && uv run ruff format .` (Clean)
- `uv run pyright` (0 errors, 0 warnings)
