### PR TITLE
fix(config): recreate asyncio.Lock on ConfigLayer deepcopy

### DIFF
--- a/tests/core/config/test_config_layer.py
+++ b/tests/core/config/test_config_layer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import copy
 from pathlib import Path
 import tomllib
 from typing import Annotated, Any
@@ -657,3 +659,37 @@ def test_toml_snapshot_drops_none_optional_fields_and_round_trips(
     reloaded_models = reloaded["models"]
     assert reloaded_models["paid"]["cached_input_price"] == 0.15
     assert "cached_input_price" not in reloaded_models["free"]
+
+
+@pytest.mark.asyncio
+async def test_deepcopy_does_not_pickle_contended_asyncio_lock() -> None:
+    """A contended asyncio.Lock holds a pending Future; deepcopy must not pickle it.
+
+    Regression for the mode-switch crash where ConfigBuilder.copy() deep-copied
+    layers whose base ConfigLayer._lock had waiters, raising
+    "cannot pickle '_asyncio.Future' object".
+    """
+    layer = StubLayer(name="stub")
+
+    async def hold_lock() -> None:
+        async with layer._lock:
+            await asyncio.sleep(0.5)
+
+    async def queue_waiter() -> None:
+        async with layer._lock:
+            pass
+
+    holder = asyncio.create_task(hold_lock())
+    await asyncio.sleep(0.05)  # let it acquire
+    waiter = asyncio.create_task(queue_waiter())
+    await asyncio.sleep(0.02)  # now a Future is pending on the lock
+    try:
+        copied = copy.deepcopy(layer)
+        assert copied is not layer
+        assert copied._lock is not layer._lock  # fresh lock, not pickled
+    finally:
+        holder.cancel()
+        waiter.cancel()
+        for task in (holder, waiter):
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task

--- a/vibe/core/config/layer.py
+++ b/vibe/core/config/layer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import asyncio
+import copy
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
@@ -136,6 +137,24 @@ class ConfigLayer[S: BaseModel](ABC):
 
         self._state: _LayerState[S] = _LayerState()
         self._lock = asyncio.Lock()
+
+    def __deepcopy__(self, memo: dict[int, object]) -> ConfigLayer[S]:
+        # An orchestrator copy (e.g. the agent/mode-switch config preview in
+        # ConfigBuilder.copy()) deep-copies its layers. The per-layer asyncio.Lock
+        # is event-loop-bound: once it has a pending waiter it holds an
+        # asyncio.Future, and deepcopy falls back to pickling it, raising
+        # "cannot pickle '_asyncio.Future' object". Recreate the lock fresh on the
+        # independent copy instead. Subclasses with extra asyncio primitives or
+        # bespoke copy semantics override this (see ProjectConfigLayer).
+        cls = type(self)
+        new = cls.__new__(cls)
+        memo[id(self)] = new
+        for key, value in self.__dict__.items():
+            if isinstance(value, asyncio.Lock):
+                new.__dict__[key] = asyncio.Lock()
+            else:
+                new.__dict__[key] = copy.deepcopy(value, memo)
+        return new
 
     # --- Overridable ---
 


### PR DESCRIPTION
Fixes #1069

## Root cause

`ConfigBuilder.copy()` deep-copies every config layer via `copy.deepcopy(layer)`. The base `ConfigLayer` holds `self._lock = asyncio.Lock()`, but only `ProjectConfigLayer` defines `__deepcopy__`. All other layers (admin, default, discovered, overrides, user, agent_profile, …) fall through to the default deepcopy, which pickles `asyncio` primitives. When a layer lock has a pending waiter it holds an `asyncio.Future`, and pickling raises:

```
TypeError: cannot pickle _asyncio.Future object
```

This surfaces as a frozen mode switcher in Zed's ACP UI: any `session/set_config_option("mode", …)` that coincides with an in-flight layer load/trust/patch fails the whole agent switch:

```
ERROR [agent_ui::config_options] Failed to set config option: cannot pickle _asyncio.Future object
```

## Repro

```python
import asyncio, copy
from vibe.core.config.layers.admin import AdminConfigLayer

async def main():
    layer = AdminConfigLayer()
    async def hold():
        async with layer._lock:
            await asyncio.sleep(0.5)
    async def queue():
        async with layer._lock:
            pass
    t = asyncio.create_task(hold()); await asyncio.sleep(0.05)
    w = asyncio.create_task(queue()); await asyncio.sleep(0.02)
    try:
        copy.deepcopy(layer)   # raises TypeError: cannot pickle _asyncio.Future object
    finally:
        t.cancel(); w.cancel()

asyncio.run(main())
```

## Fix

Add a base `ConfigLayer.__deepcopy__` that recreates `asyncio.Lock` instances fresh on the copy (matching the existing `ProjectConfigLayer` precedent) and deep-copies everything else. This is the minimal change that covers every layer subclass without bespoke copy semantics.

## Test

Adds `test_deepcopy_does_not_pickle_contended_asyncio_lock` to `tests/core/config/test_config_layer.py`: creates a layer whose lock holds a pending waiter, then asserts `copy.deepcopy` succeeds and the copy's lock is a fresh instance.

```
$ uv run pytest tests/core/config/test_config_layer.py -q
39 passed
$ uv run pytest tests/core/config/test_config_orchestrator.py tests/core/config/test_config_builder.py tests/core/config/test_project_config_layer.py -q
83 passed
```