### PR TITLE
This PR consolidates the CLI improvements developed across the feature branches and rebases them onto upstream v2.25.0.

### DIFF
--- a/tests/cli/test_auto_exit_arg.py
+++ b/tests/cli/test_auto_exit_arg.py
@@ -1,0 +1,21 @@
+"""Tests for --auto-exit CLI argument."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+from vibe.cli.entrypoint import parse_arguments
+
+
+def test_auto_exit_argument_parsed_correctly():
+    with patch.object(sys, "argv", ["vibe", "-p", "hello", "--auto-exit"]):
+        args = parse_arguments()
+        assert args.prompt == "hello"
+        assert args.auto_exit is True
+
+
+def test_auto_exit_default_is_false():
+    with patch.object(sys, "argv", ["vibe"]):
+        args = parse_arguments()
+        assert args.auto_exit is False

--- a/tests/cli/test_rich_streaming.py
+++ b/tests/cli/test_rich_streaming.py
@@ -1,0 +1,30 @@
+"""Unit tests for VisualStreamingOutput in vibe/cli/rich_streaming.py."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from vibe.app_server.models import PublicEffectEntry
+from vibe.cli.rich_streaming import _format_tool_title
+from vibe.utils.tool_presentation import EffectCallDisplay, ToolEffectKind
+
+
+def test_format_tool_title_preserves_full_length_paths():
+    """Verify that long file paths are not truncated with 70-character ellipsis."""
+    long_path = "/Users/i/src/nan.web/apps/3rdparty/eaukraine.eu/web/src/domain/LongDeeplyNestedPathFile.js"
+    detail = MagicMock()
+    detail.kind = ToolEffectKind.FILE_READ
+    detail.display = EffectCallDisplay(
+        summary=f"Reading {long_path}",
+        verb="Reading",
+        message=long_path,
+        status_text="Reading file",
+    )
+    detail.tool_name = "read_file"
+
+    entry = MagicMock(spec=PublicEffectEntry)
+    entry.detail = detail
+
+    icon, label = _format_tool_title(entry)
+    assert icon == "👀"
+    assert long_path in label
+    assert "..." not in label

--- a/tests/cli/test_rich_streaming.py
+++ b/tests/cli/test_rich_streaming.py
@@ -1,4 +1,5 @@
 """Unit tests for VisualStreamingOutput in vibe/cli/rich_streaming.py."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock

--- a/tests/cli/test_session_exit_cost.py
+++ b/tests/cli/test_session_exit_cost.py
@@ -1,0 +1,38 @@
+"""Tests for session cost formatting and JSON report export in session_exit.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from vibe.app_server import SessionExitSummary
+from vibe.app_server.models import TokenUsage
+from vibe.cli.session_exit import format_session_cost, print_session_resume_message
+
+
+def test_format_session_cost_renders_correct_currency():
+    summary = SessionExitSummary(
+        session_id="test-12345",
+        usage=TokenUsage(input_tokens=1000, output_tokens=200, total_tokens=1200),
+        session_cost=0.0345,
+    )
+    assert format_session_cost(summary) == "Session cost: $0.0345"
+
+
+def test_session_report_json_export(tmp_path: Path):
+    report_file = tmp_path / "vibe_report.json"
+    summary = SessionExitSummary(
+        session_id="test-report-id",
+        usage=TokenUsage(input_tokens=500, output_tokens=50, total_tokens=550),
+        session_cost=0.0125,
+    )
+
+    with patch.dict("os.environ", {"VIBE_REPORT_PATH": str(report_file)}):
+        print_session_resume_message(summary)
+
+    assert report_file.exists()
+    data = json.loads(report_file.read_text())
+    assert data["session_id"] == "test-report-id"
+    assert data["session_cost"] == 0.0125
+    assert data["usage"]["total_tokens"] == 550

--- a/tests/cli/textual_ui/test_context_progress.py
+++ b/tests/cli/textual_ui/test_context_progress.py
@@ -33,3 +33,34 @@ def test_context_progress_uses_compact_integer_m_format() -> None:
     widget.watch_tokens(TokenState(max_tokens=40_000_000, current_tokens=35_900_000))
 
     assert str(widget.render()) == "35.9M/40.0M tokens (90%)"
+
+
+def test_context_progress_renders_model_name() -> None:
+    widget = ContextProgress()
+
+    widget.watch_tokens(
+        TokenState(
+            max_tokens=200_000, current_tokens=10_000, model_name="mistral-large-latest"
+        )
+    )
+
+    assert str(widget.render()) == "10k/200k tokens (5%) | [mistral-large-latest]"
+
+
+def test_context_progress_renders_cost_and_memory() -> None:
+    widget = ContextProgress()
+
+    widget.watch_tokens(
+        TokenState(
+            max_tokens=200_000,
+            current_tokens=20_000,
+            model_name="dev",
+            session_cost=0.035,
+            memory_bytes=100 * 1024 * 1024,
+            total_memory_bytes=250 * 1024 * 1024,
+        )
+    )
+
+    dollar = chr(36)
+    expected = f"20k/200k tokens (10%) | [dev] | {dollar}0.04 | 100.0M"
+    assert str(widget.render()) == expected

--- a/vibe/app_server/session.py
+++ b/vibe/app_server/session.py
@@ -136,6 +136,7 @@ class AppServerTurnError(RuntimeError):
 class SessionExitSummary:
     session_id: str | None
     usage: TokenUsage
+    session_cost: float = 0.0
 
 
 class AppServerSession:  # noqa: PLR0904
@@ -303,8 +304,11 @@ class AppServerSession:  # noqa: PLR0904
             if session_log.enabled and session_log.persisted
             else None
         )
+        stats = self.resources.runtime.stats
         return SessionExitSummary(
-            session_id=session_id, usage=self._state.usage_since_baseline()
+            session_id=session_id,
+            usage=self._state.usage_since_baseline(),
+            session_cost=stats.session_cost if hasattr(stats, "session_cost") else 0.0,
         )
 
     async def connect(self) -> None:

--- a/vibe/cli/entrypoint.py
+++ b/vibe/cli/entrypoint.py
@@ -137,6 +137,12 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="Approves all tool calls without prompting for the selected agent.",
     )
+    parser.add_argument(
+        "--auto-exit",
+        action="store_true",
+        default=False,
+        help="Automatically exit interactive mode after processing initial prompt.",
+    )
     parser.add_argument("--setup", action="store_true", help="Setup API key and exit")
     parser.add_argument(
         "--check-upgrade",

--- a/vibe/cli/entrypoint.py
+++ b/vibe/cli/entrypoint.py
@@ -137,12 +137,6 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="Approves all tool calls without prompting for the selected agent.",
     )
-    parser.add_argument(
-        "--auto-exit",
-        action="store_true",
-        default=False,
-        help="Automatically exit interactive mode after processing initial prompt.",
-    )
     parser.add_argument("--setup", action="store_true", help="Setup API key and exit")
     parser.add_argument(
         "--check-upgrade",

--- a/vibe/cli/entrypoint.py
+++ b/vibe/cli/entrypoint.py
@@ -110,11 +110,16 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--output",
         type=str,
-        choices=["text", "json", "streaming"],
+        choices=["text", "json", "streaming", "rich"],
         default="text",
         help="Output format for programmatic mode (-p): 'text' "
         "for human-readable (default), 'json' for all messages at end, "
-        "'streaming' for newline-delimited JSON per message.",
+        "'streaming' for newline-delimited JSON per message, 'rich' for live styled streaming with progress.",
+    )
+    parser.add_argument(
+        "--auto-exit",
+        action="store_true",
+        help="In interactive TUI mode, automatically exit after completing the initial prompt.",
     )
     parser.add_argument(
         "--agent",

--- a/vibe/cli/programmatic.py
+++ b/vibe/cli/programmatic.py
@@ -31,6 +31,7 @@ from vibe.app_server.models import (
     TeleportSummarizingContext,
 )
 from vibe.app_server.session import AppServerSession
+from vibe.cli.rich_streaming import VisualStreamingOutput
 from vibe.observability.logging import logger
 
 
@@ -38,6 +39,7 @@ class OutputFormat(StrEnum):
     TEXT = auto()
     JSON = auto()
     STREAMING = auto()
+    RICH = auto()
 
 
 class ProgrammaticLimitError(RuntimeError):
@@ -56,14 +58,25 @@ class ProgrammaticOutput:
         self._stream = stream or sys.stdout
         self._emitted: set[str] = set()
         self._teleport_url: str | None = None
+        self._rich_output: VisualStreamingOutput | None = (
+            VisualStreamingOutput(self._stream)
+            if output_format is OutputFormat.RICH
+            else None
+        )
 
     def start(self, history: list[PublicHistoryEntry]) -> None:
+        if self._format is OutputFormat.RICH and self._rich_output:
+            self._rich_output.start(history)
+            return
         if self._format is not OutputFormat.STREAMING:
             return
         for entry in history:
             self._emit_completed(entry)
 
     def consume(self, event: AppServerEvent) -> None:
+        if self._format is OutputFormat.RICH and self._rich_output:
+            self._rich_output.consume(event)
+            return
         if self._format is not OutputFormat.STREAMING:
             return
         match event:
@@ -97,6 +110,8 @@ class ProgrammaticOutput:
                 pass
 
     def finalize(self, history: list[PublicHistoryEntry]) -> str | None:
+        if self._format is OutputFormat.RICH and self._rich_output:
+            return self._rich_output.finalize(history)
         if self._format is OutputFormat.STREAMING:
             return None
         if self._format is OutputFormat.JSON:
@@ -151,6 +166,13 @@ def run_programmatic(
         try:
             await session.resources.runtime.wait_until_ready()
             await _warn_if_workspace_untrusted(session)
+            active_model = getattr(
+                session.resources.config.current, "active_model", None
+            )
+            if active_model and hasattr(output, "_rich_output") and output._rich_output:
+                output._rich_output.set_model_name(
+                    getattr(active_model, "alias", "") or str(active_model)
+                )
             output.start(session.history)
             if teleport and session.resources.config.current.vibe_code_enabled:
                 await _teleport(session, prompt, output)

--- a/vibe/cli/rich_streaming.py
+++ b/vibe/cli/rich_streaming.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import sys
+from typing import TextIO
+
+from rich.console import Console, Group
+from rich.live import Live
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.spinner import Spinner
+from rich.table import Table
+from rich.text import Text
+
+from vibe.app_server.events import (
+    AppServerEvent,
+    HistoryEntryAdded,
+    HistoryEntryUpdated,
+    StatsUpdated,
+    TurnCompleted,
+    TurnStarted,
+)
+from vibe.app_server.models import (
+    CompletedEffectState,
+    FailedEffectState,
+    PendingEffectState,
+    PublicEffectEntry,
+    PublicHistoryEntry,
+    PublicMessageEntry,
+    PublicReasoningEntry,
+    RunningEffectState,
+)
+from vibe.app_server.protocol import StatsUpdatedParams
+from vibe.utils.tool_presentation import ToolEffectKind
+
+TOOL_ICONS: dict[ToolEffectKind | str, str] = {
+    ToolEffectKind.FILE_READ: "👀",
+    ToolEffectKind.FILE_WRITE: "✍️",
+    ToolEffectKind.FILE_EDIT: "📝",
+    ToolEffectKind.FILE_SEARCH: "🔍",
+    ToolEffectKind.SHELL: "⚡",
+    ToolEffectKind.WEB_SEARCH: "🌐",
+    ToolEffectKind.WEB_FETCH: "📥",
+    ToolEffectKind.TODO: "📋",
+    ToolEffectKind.SKILL: "🧠",
+    ToolEffectKind.SUBAGENT: "🤖",
+    ToolEffectKind.USER_QUESTION: "❓",
+    ToolEffectKind.TOOL: "🔧",
+}
+
+
+def _format_tool_title(entry: PublicEffectEntry) -> tuple[str, str]:
+    """Returns (icon, label) for a tool call."""
+    detail = entry.detail
+    icon = TOOL_ICONS.get(detail.kind, "🔧")
+
+    # Try getting summary from display
+    summary = ""
+    if hasattr(detail, "display") and detail.display:
+        if detail.display.summary:
+            summary = detail.display.summary
+        elif detail.display.message:
+            summary = detail.display.message
+
+    if not summary:
+        # Fallback based on input
+        inp = getattr(detail, "input", None)
+        if inp is not None:
+            if hasattr(inp, "file_path"):
+                summary = inp.file_path
+            elif hasattr(inp, "command"):
+                summary = inp.command
+            elif hasattr(inp, "query"):
+                summary = inp.query
+            elif hasattr(inp, "path"):
+                summary = inp.path
+            elif hasattr(inp, "pattern"):
+                summary = inp.pattern
+            elif hasattr(inp, "name"):
+                summary = inp.name
+            else:
+                summary = str(inp)
+
+    tool_name = getattr(detail, "tool_name", detail.kind.value)
+    if summary:
+        label = f"{tool_name}: {summary}"
+    else:
+        label = tool_name
+
+    return icon, label
+
+
+class VisualStreamingOutput:
+    """Renders live streaming text, tool execution badges, and cost/token stats
+    using Rich without taking over the full terminal screen.
+    """
+
+    def __init__(self, stream: TextIO | None = None) -> None:
+        self._stream = stream or sys.stdout
+        self._console = Console(file=self._stream, force_terminal=True, highlight=False)
+        self._live: Live | None = None
+
+        # State tracking
+        self._active_message_id: str | None = None
+        self._current_text: str = ""
+        self._status_text: str = "Thinking..."
+        self._model_name: str = ""
+
+        # Track active and finished tools
+        self._active_tools: dict[str, PublicEffectEntry] = {}
+        self._finished_tools: set[str] = set()
+
+        # Stats tracking
+        self._stats: StatsUpdatedParams | None = None
+        self._turn_count: int = 0
+        self._is_active: bool = False
+
+    def set_model_name(self, model_name: str) -> None:
+        self._model_name = model_name
+
+    def start(self, history: list[PublicHistoryEntry]) -> None:
+        self._is_active = True
+        self._live = Live(
+            self._render_view(),
+            console=self._console,
+            refresh_per_second=12,
+            transient=False,
+            auto_refresh=True,
+        )
+        self._live.start()
+
+    def _render_view(self) -> Group:
+        elements = []
+
+        # 1. Main response streaming markdown or text
+        if self._current_text:
+            elements.append(Markdown(self._current_text))
+
+        # 2. Active spinner / status line if we're generating or running tools
+        if self._is_active:
+            status_line = Text()
+            if self._active_tools:
+                # Show running tool info in spinner
+                first_active = next(iter(self._active_tools.values()))
+                icon, label = _format_tool_title(first_active)
+                status_line.append(f" {icon} Running {label}...", style="bold cyan")
+            else:
+                status_line.append(f" {self._status_text}", style="dim italic cyan")
+            elements.append(Spinner("dots", text=status_line))
+
+        return (
+            Group(*elements)
+            if elements
+            else Group(
+                Spinner("dots", text=Text(" Thinking...", style="dim italic cyan"))
+            )
+        )
+
+    def _print_tool_badge(self, entry: PublicEffectEntry, success: bool = True) -> None:
+        icon, label = _format_tool_title(entry)
+        text = Text()
+        text.append(f"  {icon} ", style="bold")
+        text.append(label, style="bold cyan")
+
+        if success:
+            text.append("  ✔", style="bold green")
+        else:
+            text.append("  ✖ failed", style="bold red")
+
+        # Temporarily pause live display to cleanly print badge above it
+        if self._live:
+            self._live.console.print(text)
+        else:
+            self._console.print(text)
+
+    def consume(self, event: AppServerEvent) -> None:  # noqa: PLR0912
+        match event:
+            case TurnStarted():
+                self._turn_count += 1
+                self._status_text = "Thinking..."
+                if self._live:
+                    self._live.update(self._render_view())
+
+            case HistoryEntryAdded(entry=entry) | HistoryEntryUpdated(entry=entry):
+                if isinstance(entry, PublicMessageEntry):
+                    if entry.role == "assistant":
+                        self._active_message_id = entry.id
+                        self._current_text = entry.text or ""
+                        if self._live:
+                            self._live.update(self._render_view())
+
+                elif isinstance(entry, PublicReasoningEntry):
+                    self._status_text = "Reasoning..."
+                    if self._live:
+                        self._live.update(self._render_view())
+
+                elif isinstance(entry, PublicEffectEntry):
+                    entry_id = entry.id
+                    state = entry.state
+
+                    if isinstance(state, (PendingEffectState, RunningEffectState)):
+                        self._active_tools[entry_id] = entry
+                        if self._live:
+                            self._live.update(self._render_view())
+
+                    elif isinstance(state, CompletedEffectState):
+                        self._active_tools.pop(entry_id, None)
+                        if entry_id not in self._finished_tools:
+                            self._finished_tools.add(entry_id)
+                            self._print_tool_badge(entry, success=True)
+                        if self._live:
+                            self._live.update(self._render_view())
+
+                    elif isinstance(state, FailedEffectState):
+                        self._active_tools.pop(entry_id, None)
+                        if entry_id not in self._finished_tools:
+                            self._finished_tools.add(entry_id)
+                            self._print_tool_badge(entry, success=False)
+                        if self._live:
+                            self._live.update(self._render_view())
+
+            case StatsUpdated(params=params):
+                self._stats = params
+
+            case TurnCompleted():
+                self._status_text = "Completed"
+                if self._live:
+                    self._live.update(self._render_view())
+
+            case _:
+                pass
+
+    def finalize(self, history: list[PublicHistoryEntry]) -> str | None:
+        self._is_active = False
+        if self._live:
+            # Update to final view (without spinner)
+            self._live.update(
+                Group(Markdown(self._current_text)) if self._current_text else Text("")
+            )
+            self._live.stop()
+            self._live = None
+
+        # Print summary panel with detailed stats
+        self._print_summary_panel()
+        return self._current_text
+
+    def _print_summary_panel(self) -> None:
+        if not self._stats:
+            return
+
+        s = self._stats.stats
+        total_tokens = s.session_total_llm_tokens
+        prompt_tokens = s.session_prompt_tokens
+        comp_tokens = s.session_completion_tokens
+        cached_tokens = s.session_cached_tokens
+
+        # Calculate cost
+        input_cost = (prompt_tokens / 1_000_000.0) * s.input_price_per_million
+        output_cost = (comp_tokens / 1_000_000.0) * s.output_price_per_million
+        total_cost = input_cost + output_cost
+
+        cost_str = f"${total_cost:.4f}"
+        tools_str = f"{len(self._finished_tools)}"
+
+        grid = Table.grid(padding=(0, 2))
+        grid.add_column(style="dim", justify="right")
+        grid.add_column(style="bold")
+        grid.add_column(style="dim", justify="right")
+        grid.add_column(style="bold")
+
+        # Row 1: Model & Cost
+        if self._model_name:
+            grid.add_row(
+                "Model:",
+                f"[bold yellow]{self._model_name}[/bold yellow]",
+                "Cost:",
+                f"[bold green]{cost_str}[/bold green]",
+            )
+        else:
+            grid.add_row(
+                "Cost:",
+                f"[bold green]{cost_str}[/bold green]",
+                "Tools:",
+                f"[bold magenta]{tools_str}[/bold magenta]",
+            )
+
+        # Row 2: Tokens breakdown & Tool Calls
+        tokens_breakdown = (
+            f"[bold cyan]{total_tokens:,}[/bold cyan] "
+            f"([dim]In:[/dim] [cyan]{prompt_tokens:,}[/cyan] | "
+            f"[dim]Out:[/dim] [cyan]{comp_tokens:,}[/cyan] | "
+            f"[dim]Cached:[/dim] [cyan]{cached_tokens:,}[/cyan])"
+        )
+
+        if self._model_name:
+            grid.add_row(
+                "Tokens:",
+                tokens_breakdown,
+                "Tools:",
+                f"[bold magenta]{tools_str}[/bold magenta]",
+            )
+        else:
+            grid.add_row("Tokens:", tokens_breakdown, "", "")
+
+        panel = Panel(
+            grid,
+            title="[bold green]Session Summary[/bold green]",
+            border_style="dim green",
+            expand=False,
+        )
+        self._console.print(panel)

--- a/vibe/cli/session_exit.py
+++ b/vibe/cli/session_exit.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
+from pathlib import Path
+
 from rich import print as rprint
 
 from vibe.app_server import SessionExitSummary
@@ -16,12 +20,39 @@ def format_session_usage(usage: TokenUsage) -> str:
     )
 
 
+def format_session_cost(summary: SessionExitSummary) -> str:
+    return f"Session cost: ${getattr(summary, 'session_cost', 0.0):.4f}"
+
+
+def _export_session_report(summary: SessionExitSummary) -> None:
+    report_path = os.environ.get("VIBE_REPORT_PATH")
+    if not report_path:
+        return
+    try:
+        data = {
+            "session_id": summary.session_id,
+            "session_cost": getattr(summary, "session_cost", 0.0),
+            "usage": {
+                "input_tokens": summary.usage.input_tokens,
+                "output_tokens": summary.usage.output_tokens,
+                "total_tokens": summary.usage.total_tokens,
+            },
+        }
+        Path(report_path).write_text(json.dumps(data, indent=2))
+    except Exception:
+        pass
+
+
 def print_session_resume_message(summary: SessionExitSummary | None) -> None:
     if summary is None or summary.session_id is None:
         return
 
+    _export_session_report(summary)
+
     print()
     print(format_session_usage(summary.usage))
+    if getattr(summary, "session_cost", 0.0) > 0:
+        print(format_session_cost(summary))
     print()
     rprint("To continue this session, run: [bold dark_orange]vibe --continue[/]")
     session_id = shorten_session_id(summary.session_id)

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -3104,6 +3104,8 @@ class VibeApp(App):  # noqa: PLR0904
                 return
             await self._refresh_windowing_from_history()
             self._terminal_notifier.notify(NotificationContext.COMPLETE)
+            if getattr(self, "_auto_exit", False):
+                self.exit()
 
     def _resolve_turn_error_message(self, e: Exception) -> str:
         if not isinstance(e, AppServerTurnError):

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -155,7 +155,11 @@ from vibe.cli.textual_ui.widgets.chat_input.paste_image import (
 from vibe.cli.textual_ui.widgets.chat_input.text_area import ChatTextArea
 from vibe.cli.textual_ui.widgets.collapsible import CollapsibleSection
 from vibe.cli.textual_ui.widgets.compact import CompactMessage
-from vibe.cli.textual_ui.widgets.context_progress import ContextProgress, TokenState
+from vibe.cli.textual_ui.widgets.context_progress import (
+    ContextProgress,
+    TokenState,
+    _get_total_memory,
+)
 from vibe.cli.textual_ui.widgets.debug_console import DebugConsole
 from vibe.cli.textual_ui.widgets.feedback_bar import FeedbackBar
 from vibe.cli.textual_ui.widgets.inline_notice import InlineNotice
@@ -1117,11 +1121,8 @@ class VibeApp(App):  # noqa: PLR0904
             yield NoMarkupStatic(id="spacer")
             self._context_progress = ContextProgress()
             if has_session:
-                stats = self.app_server.resources.runtime.stats
-                self._context_progress.tokens = TokenState(
-                    max_tokens=self.app_server.resources.runtime.context_window,
-                    current_tokens=stats.context_tokens,
-                )
+                self._refresh_context_progress()
+
             yield self._context_progress
 
     @property
@@ -1271,9 +1272,16 @@ class VibeApp(App):  # noqa: PLR0904
     def _update_context_progress(self, event: StatsUpdated) -> None:
         if self._context_progress is None:
             return
+        stats = event.params.stats
         self._context_progress.tokens = TokenState(
             max_tokens=event.params.context_window,
-            current_tokens=event.params.stats.context_tokens,
+            current_tokens=stats.context_tokens,
+            model_name=self.config.active_model.alias
+            if self.config.active_model
+            else "",
+            session_cost=stats.session_cost,
+            memory_bytes=_get_total_memory(),
+            total_memory_bytes=_get_total_memory(),
         )
 
     def _start_post_ready_startup(self) -> None:
@@ -5356,9 +5364,17 @@ class VibeApp(App):  # noqa: PLR0904
         if self._context_progress is None:
             return
         runtime = self.app_server.resources.runtime
+        stats = runtime.stats
+        memory_bytes = _get_total_memory()
         self._context_progress.tokens = TokenState(
             max_tokens=runtime.context_window,
-            current_tokens=runtime.stats.context_tokens,
+            current_tokens=stats.context_tokens,
+            model_name=self.config.active_model.alias
+            if self.config.active_model
+            else "",
+            session_cost=stats.session_cost,
+            memory_bytes=memory_bytes,
+            total_memory_bytes=memory_bytes,
         )
 
     def _on_profile_changed(self) -> None:

--- a/vibe/cli/textual_ui/widgets/context_progress.py
+++ b/vibe/cli/textual_ui/widgets/context_progress.py
@@ -10,11 +10,9 @@ from vibe.cli.textual_ui.widgets.no_markup_static import NoMarkupStatic
 _THOUSAND = 1_000
 _MILLION = 1_000_000
 
-
-@dataclass
-class TokenState:
-    max_tokens: int = 0
-    current_tokens: int = 0
+_KIBI = 1024
+_MEBI = 1024 * 1024
+_GIBI = 1024 * 1024 * 1024
 
 
 def _format_token_count(tokens: int) -> str:
@@ -23,6 +21,58 @@ def _format_token_count(tokens: int) -> str:
     if tokens >= _THOUSAND:
         return f"{tokens // _THOUSAND}k"
     return str(tokens)
+
+
+def _format_memory_size(size_bytes: int) -> str:
+    if size_bytes >= _GIBI:
+        return f"{size_bytes / _GIBI:.1f}G"
+    if size_bytes >= _MEBI:
+        return f"{size_bytes / _MEBI:.1f}M"
+    if size_bytes >= _KIBI:
+        return f"{size_bytes / _KIBI:.1f}K"
+    return f"{size_bytes}B"
+
+
+@dataclass
+class TokenState:
+    max_tokens: int = 0
+    current_tokens: int = 0
+    model_name: str = ""
+    session_cost: float = 0.0
+    memory_bytes: int = 0
+    total_memory_bytes: int = 0
+
+
+def _get_total_memory() -> int:
+    """Return total RSS of this process + all direct children in bytes.
+
+    Uses ``psutil`` when available; falls back to the main process only
+    (same as ``memory_bytes``) when psutil is not installed.
+    """
+    try:
+        import psutil
+    except Exception:
+        try:
+            import resource
+            import sys
+
+            rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            return rss if sys.platform == "darwin" else rss * 1024
+        except Exception:
+            return 0
+
+    try:
+        parent = psutil.Process()
+        children = parent.children(recursive=False)
+        total = parent.memory_info().rss
+        for child in children:
+            try:
+                total += child.memory_info().rss
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        return total
+    except Exception:
+        return 0
 
 
 class ContextProgress(NoMarkupStatic):
@@ -37,8 +87,19 @@ class ContextProgress(NoMarkupStatic):
             return
 
         ratio = min(1, new_state.current_tokens / new_state.max_tokens)
-        text = (
+        parts = [
             f"{_format_token_count(new_state.current_tokens)}/"
             f"{_format_token_count(new_state.max_tokens)} tokens ({ratio:.0%})"
-        )
-        self.update(text)
+        ]
+        if new_state.model_name:
+            parts.append(f"[{new_state.model_name}]")
+        if new_state.session_cost > 0:
+            parts.append(f"${new_state.session_cost:.2f}")
+        if new_state.memory_bytes > 0 or new_state.total_memory_bytes > 0:
+            mem_parts = []
+            if new_state.memory_bytes > 0:
+                mem_parts.append(_format_memory_size(new_state.memory_bytes))
+            if new_state.total_memory_bytes > 0:
+                mem_parts.append(_format_memory_size(new_state.total_memory_bytes))
+            parts.append(mem_parts[0])
+        self.update(" | ".join(parts))


### PR DESCRIPTION
### Included changes

- Add `--auto-exit` for closing the interactive TUI after prompt execution.
- Add rich streaming output for programmatic and CLI usage.
- Preserve full-length tool paths in streaming output.
- Display the total session cost on exit.
- Add optional JSON session-cost reporting.
- Show the active model, session cost, and context/memory metrics in the status bar.
- Refresh status-bar metrics correctly on the current upstream base.

### Tests

- Added coverage for `--auto-exit`.
- Added coverage for rich streaming output.
- Added coverage for session-exit cost reporting.
- Extended context-progress/status-bar tests.

### Clean up

After successful merge request old (2.24.2) pull requests needed to be removed.
- feat/cli-auto-exit
- feat/session-total-cost-on-exit
- feat/status-bar-model-and-cost
- fix/full-length-streaming-paths
- release/all-patches