### PR TITLE
Harden shell permission checks for command options

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      nix_matrix: ${{ steps.set-matrix.outputs.nix_matrix }}
       smoke_matrix: ${{ steps.set-matrix.outputs.smoke_matrix }}
     steps:
       - name: Set matrix
@@ -26,6 +27,19 @@ jobs:
               {"runner": "ubuntu-22.04", "os": "linux", "arch": "x86_64", "container": "quay.io/pypa/manylinux_2_28_x86_64@sha256:65140ef21cef92d0c13d001708afd7d304d7a154f7120d039df99dac708f3ffb"},
               {"runner": "ubuntu-22.04-arm", "os": "linux", "arch": "aarch64", "container": "quay.io/pypa/manylinux_2_28_aarch64@sha256:360bf4ec4349372e9bcfb123bf11bcc4f085072bfa4f3b946d98f5a28f9c03b0"},
               {"runner": "macos-15-intel", "os": "darwin", "arch": "x86_64"},
+              {"runner": "macos-14", "os": "darwin", "arch": "aarch64"},
+              {"runner": "windows-2022", "os": "windows", "arch": "x86_64"}
+            ]
+          }'
+          # darwin-x86_64 is absent: cryptography no longer ships a macOS x86_64
+          # wheel, so Nix would have to compile its Rust extension from the sdist,
+          # which the offline Nix build sandbox cannot do without vendoring the
+          # crate tree. The PyInstaller job above still builds and smoke-tests the
+          # Intel macOS binaries, and the Nix build gates nothing on release.
+          nix_matrix='{
+            "include": [
+              {"runner": "ubuntu-22.04", "os": "linux", "arch": "x86_64"},
+              {"runner": "ubuntu-22.04-arm", "os": "linux", "arch": "aarch64"},
               {"runner": "macos-14", "os": "darwin", "arch": "aarch64"},
               {"runner": "windows-2022", "os": "windows", "arch": "x86_64"}
             ]
@@ -45,6 +59,7 @@ jobs:
             ]
           }'
           echo "matrix=$(echo $matrix | jq -c .)" >> $GITHUB_OUTPUT
+          echo "nix_matrix=$(echo $nix_matrix | jq -c .)" >> $GITHUB_OUTPUT
           echo "smoke_matrix=$(echo $smoke_matrix | jq -c .)" >> $GITHUB_OUTPUT
 
   build-and-upload:
@@ -152,7 +167,7 @@ jobs:
     permissions:
       contents: read
     strategy:
-      matrix: ${{ fromJSON(needs.configure.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.configure.outputs.nix_matrix) }}
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,25 @@
         untokenize = prev.untokenize.overrideAttrs (old: {
           buildInputs = (old.buildInputs or []) ++ final.resolveBuildSystem {setuptools = [];};
         });
+
+        # cryptography 50.0.0 dropped macOS x86_64 wheels, so Nix must
+        # build from sdist on that platform. The sdist uses maturin as
+        # its PEP 517 backend and links against OpenSSL / Apple frameworks.
+        cryptography = prev.cryptography.overrideAttrs (old: {
+          buildInputs = (old.buildInputs or [])
+            ++ final.resolveBuildSystem {maturin = [];}
+            ++ lib.optionals pkgs.stdenv.isLinux [pkgs.openssl]
+            ++ lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.libiconv
+              pkgs.darwin.apple_sdk.frameworks.Security
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+            ];
+          nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+            pkgs.cargo
+            pkgs.rustc
+            pkgs.pkg-config
+          ];
+        });
       };
 
       pkgs = import nixpkgs {

--- a/flake.nix
+++ b/flake.nix
@@ -48,25 +48,6 @@
         untokenize = prev.untokenize.overrideAttrs (old: {
           buildInputs = (old.buildInputs or []) ++ final.resolveBuildSystem {setuptools = [];};
         });
-
-        # cryptography 50.0.0 dropped macOS x86_64 wheels, so Nix must
-        # build from sdist on that platform. The sdist uses maturin as
-        # its PEP 517 backend and links against OpenSSL / Apple frameworks.
-        cryptography = prev.cryptography.overrideAttrs (old: {
-          buildInputs = (old.buildInputs or [])
-            ++ final.resolveBuildSystem {maturin = [];}
-            ++ lib.optionals pkgs.stdenv.isLinux [pkgs.openssl]
-            ++ lib.optionals pkgs.stdenv.isDarwin [
-              pkgs.libiconv
-              pkgs.darwin.apple_sdk.frameworks.Security
-              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
-            ];
-          nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
-            pkgs.cargo
-            pkgs.rustc
-            pkgs.pkg-config
-          ];
-        });
       };
 
       pkgs = import nixpkgs {

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -1783,6 +1783,72 @@ def test_allowlisted_option_paths_outside_workspace_require_approval(
 
 
 @pytest.mark.skipif(is_windows(), reason="outside-dir permissions are POSIX-only")
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command_template",
+    [
+        "grep --file={outside} input.txt",
+        "grep --fil={outside} input.txt",
+        "grep -if{outside} input.txt",
+        "file --files-from={outside}",
+        "file --files-f={outside}",
+        "file -f{outside}",
+        "file --magic-file={outside} input.txt",
+        "file --magic-f={outside} input.txt",
+        "file -m{outside} input.txt",
+        "file -m{outside}:magic.mgc input.txt",
+        "du --files0-from={outside}",
+        "du --files0-f={outside}",
+        "wc --files0-from={outside}",
+        "wc --files0-f={outside}",
+        "date --file={outside}",
+        "date --fil={outside}",
+        "date -uf{outside}",
+        "diff --from-file={outside} input.txt",
+        "diff --to={outside} input.txt",
+    ],
+)
+def test_read_only_option_paths_outside_workspace_require_approval(
+    shell_kind, command_template, tmp_path, monkeypatch
+):
+    workdir = tmp_path / "workdir"
+    outside = tmp_path / "outside" / "data.txt"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    permission = _resolve_default_shell_permission(
+        shell_kind, command_template.format(outside=outside)
+    )
+
+    assert isinstance(permission, PermissionContext)
+    assert permission.permission is ToolPermission.ASK
+    assert any(
+        str(outside.parent) in required.label
+        for required in permission.required_permissions
+    )
+
+
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        "grep --file=patterns.txt input.txt",
+        "file -f names.txt",
+        "file --magic-file=magic.mgc input.txt",
+        "du --files0-from=names.txt",
+        "wc --files0-from=names.txt",
+        "date -f dates.txt",
+        "diff --from-file=base.txt input.txt",
+    ],
+)
+def test_read_only_option_paths_inside_workspace_remain_allowed(shell_kind, command):
+    permission = _resolve_default_shell_permission(shell_kind, command)
+
+    assert isinstance(permission, PermissionContext)
+    assert permission.permission is ToolPermission.ALWAYS
+
+
+@pytest.mark.skipif(is_windows(), reason="outside-dir permissions are POSIX-only")
 def test_legacy_bash_quoted_outside_path_requires_approval(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     outside = tmp_path.parent / "outside.txt"

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -1722,6 +1722,10 @@ def _resolve_default_shell_permission(
         "git diff --out=diff.txt",
         "git log --output=log.txt",
         "git diff --ext-diff",
+        "date -s 2020-01-01",
+        "date -us 2020-01-01",
+        "date --set=2020-01-01",
+        "date --se=2020-01-01",
     ],
 )
 def test_side_effecting_allowlisted_options_require_approval(shell_kind, command):
@@ -1742,6 +1746,9 @@ def test_side_effecting_allowlisted_options_require_approval(shell_kind, command
         "git diff --stat",
         "git log --oneline",
         "sort -- --output=ordinary-filename",
+        "date -d yesterday",
+        "date -Iseconds",
+        "date -- -s",
     ],
 )
 def test_benign_allowlisted_options_remain_allowed(shell_kind, command):

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -1689,6 +1689,99 @@ def test_find_execution_predicate_does_not_override_denylist():
     assert "matches denylist pattern 'passwd'" in (permission.reason or "")
 
 
+def _resolve_default_shell_permission(
+    shell_kind: str, command: str
+) -> PermissionContext | None:
+    if shell_kind == "legacy":
+        tool = Bash(config_getter=lambda: BashToolConfig(), state=BaseToolState())
+        return tool.resolve_permission(BashArgs(command=command))
+    tool = ExperimentalBash(
+        config_getter=lambda: ExperimentalBashToolConfig(), state=BaseToolState()
+    )
+    return tool.resolve_permission(ExperimentalBashArgs(command=command))
+
+
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sort -o sorted.txt input.txt",
+        "sort -rosorted.txt input.txt",
+        "sort --out=sorted.txt input.txt",
+        "sort --temporary-directory=. input.txt",
+        "sort --compress-program=gzip input.txt",
+        "find . -delete",
+        "find . -fprint matches.txt",
+        r"find . -exec echo {} \;",
+        "less -o less.log input.txt",
+        "less -Noless.log input.txt",
+        "less --LOG-FILE=less.log input.txt",
+        "tree -o tree.txt .",
+        "tree -aotree.txt .",
+        "git diff --output=diff.txt",
+        "git diff --out=diff.txt",
+        "git log --output=log.txt",
+        "git diff --ext-diff",
+    ],
+)
+def test_side_effecting_allowlisted_options_require_approval(shell_kind, command):
+    permission = _resolve_default_shell_permission(shell_kind, command)
+
+    assert isinstance(permission, PermissionContext)
+    assert permission.permission is ToolPermission.ASK
+
+
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sort -r input.txt",
+        "find . -name '*.py'",
+        "less -N input.txt",
+        "tree -L 2 .",
+        "git diff --stat",
+        "git log --oneline",
+        "sort -- --output=ordinary-filename",
+    ],
+)
+def test_benign_allowlisted_options_remain_allowed(shell_kind, command):
+    permission = _resolve_default_shell_permission(shell_kind, command)
+
+    assert isinstance(permission, PermissionContext)
+    assert permission.permission is ToolPermission.ALWAYS
+
+
+@pytest.mark.skipif(is_windows(), reason="outside-dir permissions are POSIX-only")
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command_template",
+    [
+        "tree {outside}",
+        "git diff --no-index {outside} other.txt",
+        "sort --random-source={outside} input.txt",
+        "sort --random={outside} input.txt",
+    ],
+)
+def test_allowlisted_option_paths_outside_workspace_require_approval(
+    shell_kind, command_template, tmp_path, monkeypatch
+):
+    workdir = tmp_path / "workdir"
+    outside = tmp_path / "outside" / "data.txt"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    permission = _resolve_default_shell_permission(
+        shell_kind, command_template.format(outside=outside)
+    )
+
+    assert isinstance(permission, PermissionContext)
+    assert permission.permission is ToolPermission.ASK
+    assert any(
+        str(outside.parent) in required.label
+        for required in permission.required_permissions
+    )
+
+
 @pytest.mark.skipif(is_windows(), reason="outside-dir permissions are POSIX-only")
 def test_legacy_bash_quoted_outside_path_requires_approval(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)

--- a/vibe/core/tools/builtins/_shell_command_policy.py
+++ b/vibe/core/tools/builtins/_shell_command_policy.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ShellCommandPolicy:
+    requires_approval: bool = False
+    inspect_positional_paths: bool = False
+    embedded_path_values: tuple[str, ...] = ()
+
+
+def _matches_long_option(token: str, option: str) -> bool:
+    option_token = token.partition("=")[0]
+    return option_token == option or (
+        option_token.startswith("--")
+        and option_token != "--"
+        and option.startswith(option_token)
+    )
+
+
+def _contains_short_option(
+    token: str, options: frozenset[str], *, preceding_value_options: frozenset[str]
+) -> bool:
+    if not token.startswith("-") or token.startswith("--"):
+        return False
+    for option in token[1:]:
+        if option in options:
+            return True
+        if option in preceding_value_options:
+            return False
+    return False
+
+
+def _embedded_long_option_values(
+    args: list[str], options: frozenset[str]
+) -> tuple[str, ...]:
+    values: list[str] = []
+    for token in _option_tokens(args):
+        _, separator, value = token.partition("=")
+        if (
+            separator
+            and value
+            and any(_matches_long_option(token, option) for option in options)
+        ):
+            values.append(value)
+    return tuple(values)
+
+
+def _option_tokens(args: list[str]) -> tuple[str, ...]:
+    try:
+        end = args.index("--")
+    except ValueError:
+        return tuple(args)
+    return tuple(args[:end])
+
+
+def _sort_policy(args: list[str]) -> ShellCommandPolicy:
+    options = _option_tokens(args)
+    side_effecting_long = {"--compress-program", "--output", "--temporary-directory"}
+    requires_approval = any(
+        any(_matches_long_option(token, option) for option in side_effecting_long)
+        or _contains_short_option(
+            token,
+            frozenset({"o", "T"}),
+            preceding_value_options=frozenset({"k", "S", "t"}),
+        )
+        for token in options
+    )
+    return ShellCommandPolicy(
+        requires_approval=requires_approval,
+        embedded_path_values=_embedded_long_option_values(
+            args, frozenset({"--random-source"})
+        ),
+    )
+
+
+def _find_policy(args: list[str]) -> ShellCommandPolicy:
+    side_effecting_predicates = {
+        "-delete",
+        "-exec",
+        "-execdir",
+        "-fls",
+        "-fprint",
+        "-fprintf",
+        "-fprint0",
+        "-ok",
+        "-okdir",
+    }
+    return ShellCommandPolicy(
+        requires_approval=any(
+            token in side_effecting_predicates for token in _option_tokens(args)
+        )
+    )
+
+
+def _less_policy(args: list[str]) -> ShellCommandPolicy:
+    requires_approval = any(
+        _matches_long_option(token, "--log-file")
+        or _matches_long_option(token, "--LOG-FILE")
+        or _contains_short_option(
+            token,
+            frozenset({"o", "O"}),
+            preceding_value_options=frozenset("DbhjkpPtTxyz"),
+        )
+        for token in _option_tokens(args)
+    )
+    return ShellCommandPolicy(requires_approval=requires_approval)
+
+
+def _tree_policy(args: list[str]) -> ShellCommandPolicy:
+    requires_approval = any(
+        _matches_long_option(token, "--output")
+        or _contains_short_option(
+            token,
+            frozenset({"o"}),
+            preceding_value_options=frozenset({"H", "I", "L", "P", "T", "X"}),
+        )
+        for token in _option_tokens(args)
+    )
+    return ShellCommandPolicy(
+        requires_approval=requires_approval, inspect_positional_paths=True
+    )
+
+
+def _git_policy(args: list[str]) -> ShellCommandPolicy:
+    if not args or args[0] not in {"diff", "log"}:
+        return ShellCommandPolicy()
+    subcommand = args[0]
+    subcommand_args = args[1:]
+    options = _option_tokens(subcommand_args)
+    requires_approval = any(
+        _matches_long_option(token, "--output") or token in {"--ext-diff", "--textconv"}
+        for token in options
+    )
+    return ShellCommandPolicy(
+        requires_approval=requires_approval,
+        inspect_positional_paths=(subcommand == "diff" and "--no-index" in options),
+    )
+
+
+_COMMAND_POLICIES = {
+    "find": _find_policy,
+    "git": _git_policy,
+    "less": _less_policy,
+    "sort": _sort_policy,
+    "tree": _tree_policy,
+}
+
+
+def analyze_shell_command_policy(tokens: list[str]) -> ShellCommandPolicy:
+    """Describe option semantics that are unsafe to infer from token shape alone."""
+    if not tokens:
+        return ShellCommandPolicy()
+    command = tokens[0].rsplit("/", 1)[-1]
+    policy = _COMMAND_POLICIES.get(command)
+    return policy(tokens[1:]) if policy else ShellCommandPolicy()
+
+
+def path_candidates(
+    tokens: list[str], *, inspect_positional_paths: bool
+) -> tuple[str, ...]:
+    """Return operands and known option values that may name filesystem paths."""
+    if not tokens:
+        return ()
+
+    policy = analyze_shell_command_policy(tokens)
+    candidates = list(policy.embedded_path_values)
+    if not (inspect_positional_paths or policy.inspect_positional_paths):
+        return tuple(candidates)
+
+    command = tokens[0].rsplit("/", 1)[-1]
+    options_ended = False
+    for token in tokens[1:]:
+        if token == "--":
+            options_ended = True
+            continue
+        if not options_ended and token.startswith("-"):
+            continue
+        if command == "chmod" and token.startswith("+"):
+            continue
+        candidates.append(token)
+    return tuple(candidates)

--- a/vibe/core/tools/builtins/_shell_command_policy.py
+++ b/vibe/core/tools/builtins/_shell_command_policy.py
@@ -132,13 +132,25 @@ def _files0_from_policy(args: list[str]) -> ShellCommandPolicy:
 
 
 def _date_policy(args: list[str]) -> ShellCommandPolicy:
+    # --set/-s writes the system clock. -I takes an optional attached value, so it
+    # terminates a short cluster and keeps `date -Iseconds` out of the -s match.
+    requires_approval = any(
+        _matches_long_option(token, "--set")
+        or _contains_short_option(
+            token,
+            frozenset({"s"}),
+            preceding_value_options=frozenset({"d", "f", "I", "r"}),
+        )
+        for token in _option_tokens(args)
+    )
     return ShellCommandPolicy(
+        requires_approval=requires_approval,
         option_path_values=(
             *_long_option_values(args, frozenset({"--file"})),
             *_short_option_values(
                 args, frozenset({"f"}), preceding_value_options=frozenset({"d", "s"})
             ),
-        )
+        ),
     )
 
 

--- a/vibe/core/tools/builtins/_shell_command_policy.py
+++ b/vibe/core/tools/builtins/_shell_command_policy.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 class ShellCommandPolicy:
     requires_approval: bool = False
     inspect_positional_paths: bool = False
-    embedded_path_values: tuple[str, ...] = ()
+    option_path_values: tuple[str, ...] = ()
 
 
 def _matches_long_option(token: str, option: str) -> bool:
@@ -32,18 +32,38 @@ def _contains_short_option(
     return False
 
 
-def _embedded_long_option_values(
-    args: list[str], options: frozenset[str]
-) -> tuple[str, ...]:
+def _long_option_values(args: list[str], options: frozenset[str]) -> tuple[str, ...]:
+    option_tokens = _option_tokens(args)
     values: list[str] = []
-    for token in _option_tokens(args):
-        _, separator, value = token.partition("=")
-        if (
-            separator
-            and value
-            and any(_matches_long_option(token, option) for option in options)
-        ):
-            values.append(value)
+    for index, token in enumerate(option_tokens):
+        _, separator, attached_value = token.partition("=")
+        if not any(_matches_long_option(token, option) for option in options):
+            continue
+        if separator and attached_value:
+            values.append(attached_value)
+        elif not separator and index + 1 < len(option_tokens):
+            values.append(option_tokens[index + 1])
+    return tuple(values)
+
+
+def _short_option_values(
+    args: list[str], options: frozenset[str], *, preceding_value_options: frozenset[str]
+) -> tuple[str, ...]:
+    option_tokens = _option_tokens(args)
+    values: list[str] = []
+    for token_index, token in enumerate(option_tokens):
+        if not token.startswith("-") or token.startswith("--"):
+            continue
+        for option_index, option in enumerate(token[1:]):
+            if option in options:
+                attached_value = token[option_index + 2 :]
+                if attached_value:
+                    values.append(attached_value)
+                elif token_index + 1 < len(option_tokens):
+                    values.append(option_tokens[token_index + 1])
+                break
+            if option in preceding_value_options:
+                break
     return tuple(values)
 
 
@@ -69,9 +89,64 @@ def _sort_policy(args: list[str]) -> ShellCommandPolicy:
     )
     return ShellCommandPolicy(
         requires_approval=requires_approval,
-        embedded_path_values=_embedded_long_option_values(
-            args, frozenset({"--random-source"})
+        option_path_values=_long_option_values(args, frozenset({"--random-source"})),
+    )
+
+
+def _grep_policy(args: list[str]) -> ShellCommandPolicy:
+    return ShellCommandPolicy(
+        option_path_values=(
+            *_long_option_values(args, frozenset({"--file"})),
+            *_short_option_values(
+                args,
+                frozenset({"f"}),
+                preceding_value_options=frozenset({"A", "B", "C", "D", "d", "e", "m"}),
+            ),
+        )
+    )
+
+
+def _file_policy(args: list[str]) -> ShellCommandPolicy:
+    files_from = (
+        *_long_option_values(args, frozenset({"--files-from"})),
+        *_short_option_values(
+            args, frozenset({"f"}), preceding_value_options=frozenset({"e", "F", "P"})
         ),
+    )
+    magic_files = (
+        *_long_option_values(args, frozenset({"--magic-file"})),
+        *_short_option_values(
+            args, frozenset({"m"}), preceding_value_options=frozenset({"e", "F", "P"})
+        ),
+    )
+    return ShellCommandPolicy(
+        option_path_values=files_from
+        + tuple(path for value in magic_files for path in value.split(":"))
+    )
+
+
+def _files0_from_policy(args: list[str]) -> ShellCommandPolicy:
+    return ShellCommandPolicy(
+        option_path_values=_long_option_values(args, frozenset({"--files0-from"}))
+    )
+
+
+def _date_policy(args: list[str]) -> ShellCommandPolicy:
+    return ShellCommandPolicy(
+        option_path_values=(
+            *_long_option_values(args, frozenset({"--file"})),
+            *_short_option_values(
+                args, frozenset({"f"}), preceding_value_options=frozenset({"d", "s"})
+            ),
+        )
+    )
+
+
+def _diff_policy(args: list[str]) -> ShellCommandPolicy:
+    return ShellCommandPolicy(
+        option_path_values=_long_option_values(
+            args, frozenset({"--from-file", "--to-file"})
+        )
     )
 
 
@@ -140,11 +215,17 @@ def _git_policy(args: list[str]) -> ShellCommandPolicy:
 
 
 _COMMAND_POLICIES = {
+    "date": _date_policy,
+    "diff": _diff_policy,
+    "du": _files0_from_policy,
+    "file": _file_policy,
     "find": _find_policy,
     "git": _git_policy,
+    "grep": _grep_policy,
     "less": _less_policy,
     "sort": _sort_policy,
     "tree": _tree_policy,
+    "wc": _files0_from_policy,
 }
 
 
@@ -165,7 +246,7 @@ def path_candidates(
         return ()
 
     policy = analyze_shell_command_policy(tokens)
-    candidates = list(policy.embedded_path_values)
+    candidates = list(policy.option_path_values)
     if not (inspect_positional_paths or policy.inspect_positional_paths):
         return tuple(candidates)
 

--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -21,6 +21,10 @@ from vibe.core.tools.base import (
     ToolError,
     ToolPermission,
 )
+from vibe.core.tools.builtins._shell_command_policy import (
+    analyze_shell_command_policy,
+    path_candidates,
+)
 from vibe.core.tools.io_port import ShellCommandRequest
 from vibe.core.tools.permissions import (
     PermissionContext,
@@ -173,8 +177,6 @@ _MUTATING_PATH_COMMANDS = {"cd", "chmod", "chown", "cp", "mkdir", "mv", "rm", "t
 # OUTSIDE_DIRECTORY permission.
 _PATH_COMMANDS = _MUTATING_PATH_COMMANDS | set(_READ_ONLY_COMMANDS_POSIX)
 
-_FIND_EXECUTION_PREDICATES = {"-exec", "-execdir", "-ok", "-okdir"}
-
 
 def _split_command_tokens(command: str) -> list[str]:
     try:
@@ -222,15 +224,11 @@ def _collect_outside_dirs(
     for part in command_parts:
         tokens = _split_command_tokens(part)
         command = tokens[0] if tokens else None
-        if not command or command not in _PATH_COMMANDS:
+        if not command:
             continue
-        for token in tokens[1:]:
-            # Skip CLI flags like -r, --recursive
-            if token.startswith("-"):
-                continue
-            # Skip chmod mode strings like +x, +rwx — they are not file paths
-            if command == "chmod" and token.startswith("+"):
-                continue
+        for token in path_candidates(
+            tokens, inspect_positional_paths=command in _PATH_COMMANDS
+        ):
             # Only consider tokens that look like paths
             if not (
                 token.startswith("/")
@@ -352,13 +350,6 @@ class Bash(
         return "Running command"
 
     @staticmethod
-    def _has_find_execution_predicate(command: str) -> bool:
-        """Defensive check for find -exec, -execdir, -ok, -okdir predicates."""
-        if not _matches_pattern(command, "find"):
-            return False
-        return any(predicate in command for predicate in _FIND_EXECUTION_PREDICATES)
-
-    @staticmethod
     def _build_command_required_permission(
         invocation_pattern: str, session_pattern: str, label: str
     ) -> RequiredPermission:
@@ -410,8 +401,8 @@ class Bash(
     def _resolve_guardrail_permission(
         self, command_parts: list[str]
     ) -> PermissionContext | None:
-        find_execution_required: list[RequiredPermission] = []
-        seen_find_execution: set[str] = set()
+        option_required: list[RequiredPermission] = []
+        seen_option_required: set[str] = set()
 
         for part in command_parts:
             if matched := self._find_denylist_match(part):
@@ -424,21 +415,23 @@ class Bash(
                     permission=ToolPermission.NEVER,
                     reason=f"Command denied: '{part}' is not allowed as a standalone command. Do not attempt to run this command.",
                 )
-            if not self._has_find_execution_predicate(part):
+            if not analyze_shell_command_policy(
+                _split_command_tokens(part)
+            ).requires_approval:
                 continue
-            if part in seen_find_execution:
+            if part in seen_option_required:
                 continue
-            seen_find_execution.add(part)
-            find_execution_required.append(
+            seen_option_required.add(part)
+            option_required.append(
                 self._build_command_required_permission(
                     invocation_pattern=part, session_pattern=part, label=part
                 )
             )
 
-        if not find_execution_required:
+        if not option_required:
             return None
         return PermissionContext(
-            permission=ToolPermission.ASK, required_permissions=find_execution_required
+            permission=ToolPermission.ASK, required_permissions=option_required
         )
 
     def _is_unconditionally_allowed(

--- a/vibe/core/tools/builtins/experimental_bash.py
+++ b/vibe/core/tools/builtins/experimental_bash.py
@@ -40,6 +40,10 @@ from vibe.core.tools.base import (
     ToolError,
     ToolPermission,
 )
+from vibe.core.tools.builtins._shell_command_policy import (
+    analyze_shell_command_policy,
+    path_candidates,
+)
 from vibe.core.tools.builtins.bash import BashToolConfig
 from vibe.core.tools.builtins.managed_shell import backend as managed_shell_backend
 from vibe.core.tools.builtins.managed_shell.backend import (
@@ -337,8 +341,6 @@ def _get_default_denylist_standalone() -> list[str]:
 _MUTATING_PATH_COMMANDS = {"cd", "chmod", "chown", "cp", "mkdir", "mv", "rm", "touch"}
 _PATH_COMMANDS = _MUTATING_PATH_COMMANDS | set(_READ_ONLY_COMMANDS_POSIX)
 
-_FIND_EXECUTION_PREDICATES = {"-exec", "-execdir", "-ok", "-okdir"}
-
 
 def _split_command_tokens(
     command: str, *, preserve_backslashes: bool = False
@@ -386,13 +388,9 @@ def _collect_outside_dirs(
         if not command:
             continue
         command_name = command if case_sensitive_commands else command.lower()
-        if command_name not in path_commands:
-            continue
-        for token in tokens[1:]:
-            if token.startswith("-"):
-                continue
-            if command_name == "chmod" and token.startswith("+"):
-                continue
+        for token in path_candidates(
+            tokens, inspect_positional_paths=command_name in path_commands
+        ):
             if not _looks_like_path(token):
                 continue
 
@@ -1454,12 +1452,6 @@ class _BashPermissionMixin[ConfigT: BashToolConfig]:
         scratchpad_dir: Path | None
 
     @staticmethod
-    def _has_find_execution_predicate(command: str) -> bool:
-        if not _matches_pattern(command, "find"):
-            return False
-        return any(predicate in command for predicate in _FIND_EXECUTION_PREDICATES)
-
-    @staticmethod
     def _build_command_required_permission(
         invocation_pattern: str, session_pattern: str, label: str
     ) -> RequiredPermission:
@@ -1516,8 +1508,8 @@ class _BashPermissionMixin[ConfigT: BashToolConfig]:
     def _resolve_guardrail_permission(
         self, command_parts: list[str]
     ) -> PermissionContext | None:
-        find_execution_required: list[RequiredPermission] = []
-        seen_find_execution: set[str] = set()
+        option_required: list[RequiredPermission] = []
+        seen_option_required: set[str] = set()
 
         for part in command_parts:
             if matched := self._find_denylist_match(part):
@@ -1530,21 +1522,23 @@ class _BashPermissionMixin[ConfigT: BashToolConfig]:
                     permission=ToolPermission.NEVER,
                     reason=f"Command denied: '{part}' is not allowed as a standalone command. Do not attempt to run this command.",
                 )
-            if not self._has_find_execution_predicate(part):
+            if not analyze_shell_command_policy(
+                _split_command_tokens(part)
+            ).requires_approval:
                 continue
-            if part in seen_find_execution:
+            if part in seen_option_required:
                 continue
-            seen_find_execution.add(part)
-            find_execution_required.append(
+            seen_option_required.add(part)
+            option_required.append(
                 self._build_command_required_permission(
                     invocation_pattern=part, session_pattern=part, label=part
                 )
             )
 
-        if not find_execution_required:
+        if not option_required:
             return None
         return PermissionContext(
-            permission=ToolPermission.ASK, required_permissions=find_execution_required
+            permission=ToolPermission.ASK, required_permissions=option_required
         )
 
     def _is_unconditionally_allowed(


### PR DESCRIPTION
Default-allowlisted shell commands could hide filesystem paths or side effects inside option arguments. The permission checker skipped every token beginning with `-`, so commands such as `sort --output=...`, `find -delete`, `tree /outside`, and `grep --file=/outside/patterns` could bypass the approval that equivalent positional paths or operations receive.

This change adds one shared, command-aware option policy used by both Bash backends.

- Side-effecting or execution-capable options now require approval for `sort`, `find`, `less`, `tree`, and `git diff/log`.
- Path-bearing read options for `grep`, `file`, `du`, `wc`, `date`, `diff`, and `sort` now participate in the existing workspace-boundary check.
- `tree` operands and `git diff --no-index` operands now receive the same boundary check.
- Attached short values, clustered short flags, supported long-option abbreviations, and the `--` option terminator are handled explicitly.
- Benign options and in-workspace input files remain auto-allowed.

This is the command-option hardening follow-up identified in #1081.

Validation:

- `uv run --frozen pytest -q`: 8,955 passed, 18 skipped
- `uv run --frozen pytest tests/tools/test_bash.py`: 236 passed
- `uv run pyright`: 0 errors
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`

No README, settings schema, or managed-config changes are needed because this tightens the existing Bash permission policy without adding configuration.
