### PR TITLE
v2.25.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.25.4] - 2026-09-12
+
+### Fixed
+
+- Connector discovery excludes raw HTTP connectors that do not support MCP tools.
+- A single invalid connector no longer prevents the rest of your connectors from loading; an individual tool with an oversized schema is dropped on its own, and accounts over the connector cap keep a bounded catalog instead of loading none.
+- Automatic session titles use the active model on custom Mistral endpoints.
+- Smart-approve now appears in the Vibe Desktop mode picker when enabled via its rollout, and a background refresh no longer drops it.
+- ACP clients (Zed/JetBrains) always list the active mode, so a session can never get stuck on a mode missing from its own list.
+- Smart-approve now escalates to a confirmation prompt when a risky action is requested again, instead of only blocking it, and shows the reason it is asking.
+- Auto-approved calls no longer read as warnings: the reason smart-approve let a call run is shown as a note rather than a warning.
+- `@` file mentions now resolve against every workspace root, including `--add-dir` ones.
+- A `@` mention outside the workspace no longer rejects the whole message; it stays plain text and the read tool can still ask for it.
+- `--add-dir` no longer drops the working directory from the file tools' workspace roots.
+- Shell permission checks now require approval for risky syntax and command options that could bypass workspace and denylist controls (CVE-2026-87984, CVE-2026-87985, CVE-2026-87986, CVE-2026-87987, and residual CVE-2026-87988 variants).
+
 ## [2.25.3] - 2026-09-11
 
 ### Added

--- a/distribution/zed/extension.toml
+++ b/distribution/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "mistral-vibe"
 name = "Mistral Vibe"
 description = "Mistral's open-source coding assistant"
-version = "2.25.3"
+version = "2.25.4"
 schema_version = 1
 authors = ["Mistral AI"]
 repository = "https://github.com/mistralai/mistral-vibe"
@@ -11,21 +11,21 @@ name = "Mistral Vibe"
 icon = "./icons/mistral_vibe.svg"
 
 [agent_servers.mistral-vibe.targets.darwin-aarch64]
-archive = "https://github.com/mistralai/mistral-vibe/releases/download/v2.25.3/vibe-acp-darwin-aarch64-2.25.3.tar.gz"
+archive = "https://github.com/mistralai/mistral-vibe/releases/download/v2.25.4/vibe-acp-darwin-aarch64-2.25.4.tar.gz"
 cmd = "./vibe-acp"
 
 [agent_servers.mistral-vibe.targets.darwin-x86_64]
-archive = "https://github.com/mistralai/mistral-vibe/releases/download/v2.25.3/vibe-acp-darwin-x86_64-2.25.3.tar.gz"
+archive = "https://github.com/mistralai/mistral-vibe/releases/download/v2.25.4/vibe-acp-darwin-x86_64-2.25.4.tar.gz"
 cmd = "./vibe-acp"
 
 [agent_servers.mistral-vibe.targets.linux-aarch64]
-archive = "https://github.com/mistralai/mistral-vibe/releases/download/v2.25.3/vibe-acp-linux-aarch64-2.25.3.tar.gz"
+archive = "https://github.com/mistralai/mistral-vibe/releases/download/v2.25.4/vibe-acp-linux-aarch64-2.25.4.tar.gz"
 cmd = "./vibe-acp"
 
 [agent_servers.mistral-vibe.targets.linux-x86_64]
-archive = "https://github.com/mistralai/mistral-vibe/releases/download/v2.25.3/vibe-acp-linux-x86_64-2.25.3.tar.gz"
+archive = "https://github.com/mistralai/mistral-vibe/releases/download/v2.25.4/vibe-acp-linux-x86_64-2.25.4.tar.gz"
 cmd = "./vibe-acp"
 
 [agent_servers.mistral-vibe.targets.windows-x86_64]
-archive = "https://github.com/mistralai/mistral-vibe/releases/download/v2.25.3/vibe-acp-windows-x86_64-2.25.3.zip"
+archive = "https://github.com/mistralai/mistral-vibe/releases/download/v2.25.4/vibe-acp-windows-x86_64-2.25.4.zip"
 cmd = "./vibe-acp.exe"

--- a/flake.nix
+++ b/flake.nix
@@ -49,24 +49,31 @@
           buildInputs = (old.buildInputs or []) ++ final.resolveBuildSystem {setuptools = [];};
         });
 
-        # cryptography 50.0.0 dropped macOS x86_64 wheels, so Nix must
-        # build from sdist on that platform. The sdist uses maturin as
-        # its PEP 517 backend and links against OpenSSL / Apple frameworks.
-        cryptography = prev.cryptography.overrideAttrs (old: {
-          buildInputs = (old.buildInputs or [])
-            ++ final.resolveBuildSystem {maturin = [];}
-            ++ lib.optionals pkgs.stdenv.isLinux [pkgs.openssl]
-            ++ lib.optionals pkgs.stdenv.isDarwin [
-              pkgs.libiconv
-              pkgs.darwin.apple_sdk.frameworks.Security
-              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
-            ];
-          nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
-            pkgs.cargo
-            pkgs.rustc
-            pkgs.pkg-config
-          ];
-        });
+        # cryptography 50.0.0 has no macOS x86_64 wheel. Source builds need
+        # the Python backend and vendored Rust crates inside the Nix sandbox.
+        cryptography = prev.cryptography.overrideAttrs (old:
+          lib.optionalAttrs (old.passthru.format == "pyproject") {
+            cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+              inherit (old) pname version src;
+              # Matches cryptography 50.0.0 in nixpkgs (a7e1a760ab81).
+              hash = "sha256-heJGLh0MgDPpksWyPLaIkZ5gVEWx8UnaJKv4GvclpmI=";
+            };
+            buildInputs = (old.buildInputs or [])
+              ++ [pkgs.openssl]
+              ++ lib.optionals pkgs.stdenv.isDarwin [pkgs.libiconv];
+            nativeBuildInputs = (old.nativeBuildInputs or [])
+              ++ final.resolveBuildSystem {
+                maturin = [];
+                cffi = [];
+                setuptools = [];
+              }
+              ++ [
+                pkgs.rustPlatform.cargoSetupHook
+                pkgs.cargo
+                pkgs.rustc
+                pkgs.pkg-config
+              ];
+          });
       };
 
       pkgs = import nixpkgs {

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,25 @@
         untokenize = prev.untokenize.overrideAttrs (old: {
           buildInputs = (old.buildInputs or []) ++ final.resolveBuildSystem {setuptools = [];};
         });
+
+        # cryptography 50.0.0 dropped macOS x86_64 wheels, so Nix must
+        # build from sdist on that platform. The sdist uses maturin as
+        # its PEP 517 backend and links against OpenSSL / Apple frameworks.
+        cryptography = prev.cryptography.overrideAttrs (old: {
+          buildInputs = (old.buildInputs or [])
+            ++ final.resolveBuildSystem {maturin = [];}
+            ++ lib.optionals pkgs.stdenv.isLinux [pkgs.openssl]
+            ++ lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.libiconv
+              pkgs.darwin.apple_sdk.frameworks.Security
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+            ];
+          nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
+            pkgs.cargo
+            pkgs.rustc
+            pkgs.pkg-config
+          ];
+        });
       };
 
       pkgs = import nixpkgs {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mistral-vibe"
-version = "2.25.3"
+version = "2.25.4"
 description = "Minimal CLI coding agent by Mistral"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/acp/conftest.py
+++ b/tests/acp/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -17,6 +18,15 @@ from vibe.core.config import ModelConfig, SessionLoggingConfig
 from vibe.core.types import LLMChunk, LLMMessage, LLMUsage, Role, StopInfo
 
 
+@pytest.fixture(params=[False, True], ids=["legacy", "unified"])
+def experimental_harness(request: Any) -> bool:
+    """Override the root conftest fixture to parametrize every ACP test: run
+    once with the legacy harness and once with the Unified Harness flag, so
+    both code paths stay green.
+    """
+    return request.param
+
+
 @pytest.fixture
 def backend() -> FakeBackend:
     backend = FakeBackend(
@@ -29,11 +39,15 @@ def backend() -> FakeBackend:
     return backend
 
 
-def _create_acp_agent(session_starter: SessionStarter | None = None) -> VibeAcpAgent:
+def _create_acp_agent(
+    session_starter: SessionStarter | None = None, *, experimental_harness: bool = False
+) -> VibeAcpAgent:
     vibe_acp_agent = (
-        VibeAcpAgent(session_starter=session_starter)
+        VibeAcpAgent(
+            session_starter=session_starter, experimental_harness=experimental_harness
+        )
         if session_starter is not None
-        else VibeAcpAgent()
+        else VibeAcpAgent(experimental_harness=experimental_harness)
     )
     client = FakeClient()
 
@@ -44,8 +58,9 @@ def _create_acp_agent(session_starter: SessionStarter | None = None) -> VibeAcpA
 
 
 @pytest.fixture
-def acp_agent_loop(backend: FakeBackend) -> VibeAcpAgent:
+def acp_agent_loop(backend: FakeBackend, experimental_harness: bool) -> VibeAcpAgent:
     async def start_session(options: LocalHarnessOptions) -> AppServerSession:
+        assert options.experimental_harness is experimental_harness
         loop = build_test_agent_loop(backend=backend, enable_streaming=True)
         return await AppServerSession.start(
             start_test_app_server(loop),
@@ -54,12 +69,15 @@ def acp_agent_loop(backend: FakeBackend) -> VibeAcpAgent:
             session_options=options.session_options,
         )
 
-    return _create_acp_agent(start_session)
+    return _create_acp_agent(start_session, experimental_harness=experimental_harness)
 
 
 @pytest.fixture
 def acp_agent_with_session_config(
-    backend: FakeBackend, temp_session_dir: Path, monkeypatch: pytest.MonkeyPatch
+    backend: FakeBackend,
+    temp_session_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    experimental_harness: bool,
 ) -> tuple[VibeAcpAgent, FakeClient]:
     session_config = SessionLoggingConfig(
         save_dir=str(temp_session_dir), session_prefix="session", enabled=True
@@ -75,6 +93,7 @@ def acp_agent_with_session_config(
     )
 
     async def start_session(options: LocalHarnessOptions) -> AppServerSession:
+        assert options.experimental_harness is experimental_harness
         loop = build_test_agent_loop(
             config=config, backend=backend, enable_streaming=True
         )
@@ -90,7 +109,9 @@ def acp_agent_with_session_config(
             ),
         )
 
-    vibe_acp_agent = VibeAcpAgent(session_starter=start_session)
+    vibe_acp_agent = VibeAcpAgent(
+        session_starter=start_session, experimental_harness=experimental_harness
+    )
     client = FakeClient()
     vibe_acp_agent.on_connect(client)
     client.on_connect(vibe_acp_agent)

--- a/tests/acp/test_agent_app_server.py
+++ b/tests/acp/test_agent_app_server.py
@@ -48,8 +48,11 @@ from vibe.core.config import SessionLoggingConfig
 from vibe.core.types import FunctionCall, ScheduledLoop, ToolCall
 
 
-def _agent(backend: FakeBackend) -> tuple[VibeAcpAgent, FakeClient]:
+def _agent(
+    backend: FakeBackend, *, experimental_harness: bool = False
+) -> tuple[VibeAcpAgent, FakeClient]:
     async def start_session(options: LocalHarnessOptions) -> AppServerSession:
+        assert options.experimental_harness is experimental_harness
         loop = build_test_agent_loop(backend=backend, enable_streaming=True)
         return await AppServerSession.start(
             start_test_app_server(loop),
@@ -59,7 +62,9 @@ def _agent(backend: FakeBackend) -> tuple[VibeAcpAgent, FakeClient]:
             client_tool_handler=options.client_tool_handler,
         )
 
-    agent = VibeAcpAgent(session_starter=start_session)
+    agent = VibeAcpAgent(
+        session_starter=start_session, experimental_harness=experimental_harness
+    )
     client = FakeClient()
     agent.on_connect(client)
     client.on_connect(agent)
@@ -67,8 +72,13 @@ def _agent(backend: FakeBackend) -> tuple[VibeAcpAgent, FakeClient]:
 
 
 @pytest.mark.asyncio
-async def test_prompt_is_a_thin_translation_of_public_app_server_events() -> None:
-    agent, client = _agent(FakeBackend([mock_llm_chunk(content="Public response")]))
+async def test_prompt_is_a_thin_translation_of_public_app_server_events(
+    experimental_harness: bool,
+) -> None:
+    agent, client = _agent(
+        FakeBackend([mock_llm_chunk(content="Public response")]),
+        experimental_harness=experimental_harness,
+    )
     try:
         created = await agent.new_session(cwd=str(Path.cwd()), mcp_servers=[])
         response = await agent.prompt(
@@ -93,7 +103,9 @@ async def test_prompt_is_a_thin_translation_of_public_app_server_events() -> Non
 
 
 @pytest.mark.asyncio
-async def test_cancelled_prompt_uses_interrupted_app_server_turn_status() -> None:
+async def test_cancelled_prompt_uses_interrupted_app_server_turn_status(
+    experimental_harness: bool,
+) -> None:
     backend_started = asyncio.Event()
     release_backend = asyncio.Event()
 
@@ -104,7 +116,10 @@ async def test_cancelled_prompt_uses_interrupted_app_server_turn_status() -> Non
             async for chunk in super().complete_streaming(**kwargs):
                 yield chunk
 
-    agent, _ = _agent(GatedBackend([mock_llm_chunk(content="unused")]))
+    agent, _ = _agent(
+        GatedBackend([mock_llm_chunk(content="unused")]),
+        experimental_harness=experimental_harness,
+    )
     try:
         created = await agent.new_session(cwd=str(Path.cwd()), mcp_servers=[])
         prompt_task = asyncio.create_task(
@@ -173,9 +188,12 @@ async def test_new_session_without_a_key_is_unauthenticated(
 
 
 @pytest.mark.asyncio
-async def test_reasoning_is_projected_from_public_app_server_events() -> None:
+async def test_reasoning_is_projected_from_public_app_server_events(
+    experimental_harness: bool,
+) -> None:
     agent, client = _agent(
-        FakeBackend([mock_llm_chunk(content="Answer", reasoning_content="Thinking")])
+        FakeBackend([mock_llm_chunk(content="Answer", reasoning_content="Thinking")]),
+        experimental_harness=experimental_harness,
     )
     try:
         created = await agent.new_session(cwd=str(Path.cwd()), mcp_servers=[])
@@ -198,11 +216,12 @@ async def test_reasoning_is_projected_from_public_app_server_events() -> None:
 
 @pytest.mark.asyncio
 async def test_acp_session_workspace_and_mcp_inputs_cross_the_app_server_boundary(
-    tmp_path: Path,
+    tmp_path: Path, experimental_harness: bool
 ) -> None:
     captured: list[LocalHarnessOptions] = []
 
     async def start_session(options: LocalHarnessOptions) -> AppServerSession:
+        assert options.experimental_harness is experimental_harness
         captured.append(options)
         loop = build_test_agent_loop(enable_streaming=True)
         return await AppServerSession.start(
@@ -213,7 +232,9 @@ async def test_acp_session_workspace_and_mcp_inputs_cross_the_app_server_boundar
             client_tool_handler=options.client_tool_handler,
         )
 
-    agent = VibeAcpAgent(session_starter=start_session)
+    agent = VibeAcpAgent(
+        session_starter=start_session, experimental_harness=experimental_harness
+    )
     client = FakeClient()
     agent.on_connect(client)
     client.on_connect(agent)
@@ -249,12 +270,15 @@ async def test_acp_session_workspace_and_mcp_inputs_cross_the_app_server_boundar
 
 
 @pytest.mark.asyncio
-async def test_unsolicited_scheduled_turn_is_forwarded_to_acp(tmp_path: Path) -> None:
+async def test_unsolicited_scheduled_turn_is_forwarded_to_acp(
+    tmp_path: Path, experimental_harness: bool
+) -> None:
     config = build_test_vibe_config(
         session_logging=SessionLoggingConfig(enabled=True, save_dir=str(tmp_path))
     )
 
     async def start_session(options: LocalHarnessOptions) -> AppServerSession:
+        assert options.experimental_harness is experimental_harness
         loop = build_test_agent_loop(
             config=config,
             backend=FakeBackend([mock_llm_chunk(content="Scheduled response")]),
@@ -280,7 +304,9 @@ async def test_unsolicited_scheduled_turn_is_forwarded_to_acp(tmp_path: Path) ->
             client_tool_handler=options.client_tool_handler,
         )
 
-    agent = VibeAcpAgent(session_starter=start_session)
+    agent = VibeAcpAgent(
+        session_starter=start_session, experimental_harness=experimental_harness
+    )
     client = FakeClient()
     agent.on_connect(client)
     client.on_connect(agent)
@@ -304,9 +330,9 @@ async def test_unsolicited_scheduled_turn_is_forwarded_to_acp(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_retries_are_forwarded_as_an_ext_notification_not_a_session_update() -> (
-    None
-):
+async def test_retries_are_forwarded_as_an_ext_notification_not_a_session_update(
+    experimental_harness: bool,
+) -> None:
     """Retrying is transient, so it must not enter the session update stream.
 
     Every SessionUpdate variant renders as chat content and lands in history; a
@@ -317,6 +343,7 @@ async def test_retries_are_forwarded_as_an_ext_notification_not_a_session_update
     )
 
     async def start_session(options: LocalHarnessOptions) -> AppServerSession:
+        assert options.experimental_harness is experimental_harness
         loop = build_test_agent_loop(backend=backend, enable_streaming=True)
         backend.on_retry = loop.notice_retry
         return await AppServerSession.start(
@@ -327,7 +354,9 @@ async def test_retries_are_forwarded_as_an_ext_notification_not_a_session_update
             client_tool_handler=options.client_tool_handler,
         )
 
-    agent = VibeAcpAgent(session_starter=start_session)
+    agent = VibeAcpAgent(
+        session_starter=start_session, experimental_harness=experimental_harness
+    )
     client = FakeClient()
     agent.on_connect(client)
     client.on_connect(agent)
@@ -392,7 +421,9 @@ async def test_retry_notification_reaches_the_wire_underscore_prefixed() -> None
 
 
 @pytest.mark.asyncio
-async def test_autonomous_profile_change_re_pushes_config_options() -> None:
+async def test_autonomous_profile_change_re_pushes_config_options(
+    experimental_harness: bool,
+) -> None:
     """An autonomous profile switch (e.g. exit_plan_mode) patches the
     session's `agent` and arrives as a SessionUpdated AppServerEvent. The mode
     is otherwise only carried on the load/new session response, so external
@@ -404,7 +435,10 @@ async def test_autonomous_profile_change_re_pushes_config_options() -> None:
     forwarded (see AppServerSession._handle_notification), so the re-pushed
     config must read the *new* mode, not the stale one.
     """
-    agent, client = _agent(FakeBackend([mock_llm_chunk(content="ok")]))
+    agent, client = _agent(
+        FakeBackend([mock_llm_chunk(content="ok")]),
+        experimental_harness=experimental_harness,
+    )
     try:
         created = await agent.new_session(cwd=str(Path.cwd()), mcp_servers=[])
         session = agent.sessions[created.session_id]
@@ -449,12 +483,17 @@ async def test_autonomous_profile_change_re_pushes_config_options() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unchanged_agent_does_not_re_push_config_options() -> None:
+async def test_unchanged_agent_does_not_re_push_config_options(
+    experimental_harness: bool,
+) -> None:
     """A SessionUpdated that did not change the agent (e.g. a title patch) must
     not re-push config options — that would spam the client on every session
     mutation.
     """
-    agent, client = _agent(FakeBackend([mock_llm_chunk(content="ok")]))
+    agent, client = _agent(
+        FakeBackend([mock_llm_chunk(content="ok")]),
+        experimental_harness=experimental_harness,
+    )
     try:
         created = await agent.new_session(cwd=str(Path.cwd()), mcp_servers=[])
         session = agent.sessions[created.session_id]
@@ -491,9 +530,9 @@ def test_acp_runtime_adapter_has_no_direct_core_dependency() -> None:
 
 @pytest.mark.asyncio
 async def test_response_too_long_returns_max_tokens_stop_reason(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, experimental_harness: bool
 ) -> None:
-    agent, _ = _agent(FakeBackend())
+    agent, _ = _agent(FakeBackend(), experimental_harness=experimental_harness)
     try:
         created = await agent.new_session(cwd=str(Path.cwd()), mcp_servers=[])
         session = agent.sessions[created.session_id]
@@ -522,8 +561,10 @@ async def test_response_too_long_returns_max_tokens_stop_reason(
 
 
 @pytest.mark.asyncio
-async def test_conversation_limit_returns_max_turn_requests_stop_reason() -> None:
-    agent, _ = _agent(FakeBackend())
+async def test_conversation_limit_returns_max_turn_requests_stop_reason(
+    experimental_harness: bool,
+) -> None:
+    agent, _ = _agent(FakeBackend(), experimental_harness=experimental_harness)
     try:
         created = await agent.new_session(cwd=str(Path.cwd()), mcp_servers=[])
         await agent.set_config_option("max_turns", created.session_id, "0")
@@ -540,7 +581,7 @@ async def test_conversation_limit_returns_max_turn_requests_stop_reason() -> Non
 
 @pytest.mark.asyncio
 async def test_acp_host_filesystem_flows_through_the_app_server(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, experimental_harness: bool
 ) -> None:
     file_path = Path.cwd() / "host.txt"
     file_path.touch()
@@ -555,7 +596,8 @@ async def test_acp_host_filesystem_flows_through_the_app_server(
         FakeBackend([
             [mock_llm_chunk(content="", tool_calls=[tool_call])],
             [mock_llm_chunk(content="done")],
-        ])
+        ]),
+        experimental_harness=experimental_harness,
     )
     read_text_file = AsyncMock(
         return_value=ReadTextFileResponse(content="from the ACP host")
@@ -586,7 +628,7 @@ async def test_acp_host_filesystem_flows_through_the_app_server(
 
 @pytest.mark.asyncio
 async def test_acp_host_write_only_filesystem_flows_through_the_app_server(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, experimental_harness: bool
 ) -> None:
     file_path = Path.cwd() / "host-write.txt"
     tool_call = ToolCall(
@@ -601,7 +643,8 @@ async def test_acp_host_write_only_filesystem_flows_through_the_app_server(
         FakeBackend([
             [mock_llm_chunk(content="", tool_calls=[tool_call])],
             [mock_llm_chunk(content="done")],
-        ])
+        ]),
+        experimental_harness=experimental_harness,
     )
     write_text_file = AsyncMock()
     monkeypatch.setattr(client, "write_text_file", write_text_file)
@@ -638,7 +681,7 @@ async def test_acp_host_write_only_filesystem_flows_through_the_app_server(
 
 @pytest.mark.asyncio
 async def test_acp_terminal_timeout_can_kill_while_wait_request_is_open(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, experimental_harness: bool
 ) -> None:
     tool_call = ToolCall(
         id="shell-1",
@@ -651,7 +694,8 @@ async def test_acp_terminal_timeout_can_kill_while_wait_request_is_open(
         FakeBackend([
             [mock_llm_chunk(content="", tool_calls=[tool_call])],
             [mock_llm_chunk(content="done")],
-        ])
+        ]),
+        experimental_harness=experimental_harness,
     )
     wait_started = asyncio.Event()
 

--- a/tests/acp/test_agent_methods.py
+++ b/tests/acp/test_agent_methods.py
@@ -168,7 +168,7 @@ async def test_config_options_delegate_to_typed_app_server_resources(
         await acp_agent_loop.set_config_option("unknown", session_id, "x")
 
 
-def _acp_agent_with_allowed_models() -> VibeAcpAgent:
+def _acp_agent_with_allowed_models(experimental_harness: bool = False) -> VibeAcpAgent:
     config = build_test_vibe_config(
         active_model="allowed",
         allowed_models=["allowed"],
@@ -179,6 +179,7 @@ def _acp_agent_with_allowed_models() -> VibeAcpAgent:
     )
 
     async def start_session(options: LocalHarnessOptions) -> AppServerSession:
+        assert options.experimental_harness is experimental_harness
         loop = build_test_agent_loop(
             config=config, backend=FakeBackend(), enable_streaming=True
         )
@@ -190,7 +191,9 @@ def _acp_agent_with_allowed_models() -> VibeAcpAgent:
         )
 
     starter: SessionStarter = start_session
-    agent = VibeAcpAgent(session_starter=starter)
+    agent = VibeAcpAgent(
+        session_starter=starter, experimental_harness=experimental_harness
+    )
     client = FakeClient()
     agent.on_connect(client)
     client.on_connect(agent)
@@ -198,8 +201,10 @@ def _acp_agent_with_allowed_models() -> VibeAcpAgent:
 
 
 @pytest.mark.asyncio
-async def test_set_config_option_rejects_model_excluded_by_allowed_models() -> None:
-    agent = _acp_agent_with_allowed_models()
+async def test_set_config_option_rejects_model_excluded_by_allowed_models(
+    experimental_harness: bool,
+) -> None:
+    agent = _acp_agent_with_allowed_models(experimental_harness=experimental_harness)
     session_id = await _new_session(agent)
 
     with pytest.raises(InvalidRequestError):

--- a/tests/acp/test_connectors.py
+++ b/tests/acp/test_connectors.py
@@ -108,9 +108,9 @@ MUTATED_PAYLOAD = {
 
 @pytest_asyncio.fixture
 async def connectors_agent(
-    tmp_path: Path,
+    tmp_path: Path, experimental_harness: bool
 ) -> AsyncIterator[tuple[VibeAcpAgent, str, FakeMCPResource]]:
-    agent = VibeAcpAgent()
+    agent = VibeAcpAgent(experimental_harness=experimental_harness)
     client = FakeClient()
     agent.on_connect(client)
     client.on_connect(agent)

--- a/tests/acp/test_elicitation.py
+++ b/tests/acp/test_elicitation.py
@@ -53,9 +53,13 @@ def _elicitation_capable_client() -> ClientCapabilities:
 
 
 def _agent(
-    backend: FakeBackend, *, captured_options: dict[str, object] | None = None
+    backend: FakeBackend,
+    *,
+    captured_options: dict[str, object] | None = None,
+    experimental_harness: bool = False,
 ) -> tuple[VibeAcpAgent, FakeClient]:
     async def start_session(options: LocalHarnessOptions) -> AppServerSession:
+        assert options.experimental_harness is experimental_harness
         if captured_options is not None:
             captured_options["disabled_tools"] = list(
                 options.session_options.disabled_tools
@@ -72,7 +76,9 @@ def _agent(
             client_tool_handler=options.client_tool_handler,
         )
 
-    agent = VibeAcpAgent(session_starter=start_session)
+    agent = VibeAcpAgent(
+        session_starter=start_session, experimental_harness=experimental_harness
+    )
     client = FakeClient()
     agent.on_connect(client)
     client.on_connect(agent)
@@ -81,7 +87,7 @@ def _agent(
 
 @pytest.mark.asyncio
 async def test_ask_user_question_round_trips_through_acp_elicitation(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, experimental_harness: bool
 ) -> None:
     """With elicitation support, ask_user_question is returned to the model and
     its answers round-trip through ACP elicitation back into the turn.
@@ -93,6 +99,7 @@ async def test_ask_user_question_round_trips_through_acp_elicitation(
             [mock_llm_chunk(content="Shipped.")],
         ]),
         captured_options=captured_options,
+        experimental_harness=experimental_harness,
     )
     captured: dict[str, object] = {}
 
@@ -145,7 +152,7 @@ async def test_ask_user_question_round_trips_through_acp_elicitation(
 
 @pytest.mark.asyncio
 async def test_declined_elicitation_cancels_the_question_without_failing_the_turn(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, experimental_harness: bool
 ) -> None:
     """A declined elicitation cancels the question; the turn still completes."""
     captured_options: dict[str, object] = {}
@@ -155,6 +162,7 @@ async def test_declined_elicitation_cancels_the_question_without_failing_the_tur
             [mock_llm_chunk(content="Never mind.")],
         ]),
         captured_options=captured_options,
+        experimental_harness=experimental_harness,
     )
     monkeypatch.setattr(
         client,
@@ -181,7 +189,7 @@ async def test_declined_elicitation_cancels_the_question_without_failing_the_tur
 
 @pytest.mark.asyncio
 async def test_malformed_elicitation_response_fails_the_turn(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, experimental_harness: bool
 ) -> None:
     """An accept whose content violates the schema is a client error: the turn
     fails and the error reaches the client, rather than silently cancelling.
@@ -190,7 +198,8 @@ async def test_malformed_elicitation_response_fails_the_turn(
         FakeBackend([
             [mock_llm_chunk(content="", tool_calls=[_ask_user_question_tool_call()])],
             [mock_llm_chunk(content="Shipped.")],
-        ])
+        ]),
+        experimental_harness=experimental_harness,
     )
     monkeypatch.setattr(
         client,
@@ -216,7 +225,9 @@ async def test_malformed_elicitation_response_fails_the_turn(
 
 
 @pytest.mark.asyncio
-async def test_tools_are_gated_by_elicitation_capability() -> None:
+async def test_tools_are_gated_by_elicitation_capability(
+    experimental_harness: bool,
+) -> None:
     """Without elicitation support the interactive tools are disabled and the
     client advertises only approval callbacks; with it, neither holds.
     """
@@ -224,6 +235,7 @@ async def test_tools_are_gated_by_elicitation_capability() -> None:
     agent_without, _client = _agent(
         FakeBackend([[mock_llm_chunk(content="ok")]]),
         captured_options=captured_disabled,
+        experimental_harness=experimental_harness,
     )
     try:
         await agent_without.initialize(
@@ -241,7 +253,9 @@ async def test_tools_are_gated_by_elicitation_capability() -> None:
 
     captured_enabled: dict[str, object] = {}
     agent_with, _client = _agent(
-        FakeBackend([[mock_llm_chunk(content="ok")]]), captured_options=captured_enabled
+        FakeBackend([[mock_llm_chunk(content="ok")]]),
+        captured_options=captured_enabled,
+        experimental_harness=experimental_harness,
     )
     try:
         await agent_with.initialize(

--- a/tests/acp/test_project_links.py
+++ b/tests/acp/test_project_links.py
@@ -30,8 +30,8 @@ ROOT = "/tmp/widgets"
 
 
 @pytest.fixture
-def acp_agent() -> VibeAcpAgent:
-    return _create_acp_agent()
+def acp_agent(experimental_harness: bool) -> VibeAcpAgent:
+    return _create_acp_agent(experimental_harness=experimental_harness)
 
 
 class _FakeController:

--- a/tests/acp/test_review.py
+++ b/tests/acp/test_review.py
@@ -16,10 +16,13 @@ from vibe.core.checkpoints import FileSnapshot, FileState
 
 
 @pytest.mark.asyncio
-async def test_review_extensions_delegate_to_app_server(tmp_path: Path) -> None:
+async def test_review_extensions_delegate_to_app_server(
+    tmp_path: Path, experimental_harness: bool
+) -> None:
     loops: list[AgentLoop] = []
 
     async def start_session(options: LocalHarnessOptions) -> AppServerSession:
+        assert options.experimental_harness is experimental_harness
         loop = build_test_agent_loop()
         loops.append(loop)
         return await AppServerSession.start(
@@ -29,7 +32,9 @@ async def test_review_extensions_delegate_to_app_server(tmp_path: Path) -> None:
             session_options=options.session_options,
         )
 
-    agent = VibeAcpAgent(session_starter=start_session)
+    agent = VibeAcpAgent(
+        session_starter=start_session, experimental_harness=experimental_harness
+    )
     client = FakeClient()
     agent.on_connect(client)
     client.on_connect(agent)
@@ -92,11 +97,12 @@ async def test_review_extensions_delegate_to_app_server(tmp_path: Path) -> None:
 )
 @pytest.mark.asyncio
 async def test_review_mutation_extensions_delegate_to_app_server(
-    tmp_path: Path, method: str, expected_content: str
+    tmp_path: Path, method: str, expected_content: str, experimental_harness: bool
 ) -> None:
     loops: list[AgentLoop] = []
 
     async def start_session(options: LocalHarnessOptions) -> AppServerSession:
+        assert options.experimental_harness is experimental_harness
         loop = build_test_agent_loop()
         loops.append(loop)
         return await AppServerSession.start(
@@ -106,7 +112,9 @@ async def test_review_mutation_extensions_delegate_to_app_server(
             session_options=options.session_options,
         )
 
-    agent = VibeAcpAgent(session_starter=start_session)
+    agent = VibeAcpAgent(
+        session_starter=start_session, experimental_harness=experimental_harness
+    )
     client = FakeClient()
     agent.on_connect(client)
     client.on_connect(agent)
@@ -133,8 +141,10 @@ async def test_review_mutation_extensions_delegate_to_app_server(
 
 
 @pytest.mark.asyncio
-async def test_review_mutation_rejects_invalid_target(tmp_path: Path) -> None:
-    agent = VibeAcpAgent()
+async def test_review_mutation_rejects_invalid_target(
+    tmp_path: Path, experimental_harness: bool
+) -> None:
+    agent = VibeAcpAgent(experimental_harness=experimental_harness)
     client = FakeClient()
     agent.on_connect(client)
     client.on_connect(agent)

--- a/tests/acp/test_utils.py
+++ b/tests/acp/test_utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from vibe.acp.utils import build_permission_options
+from vibe.acp.utils import build_mode_state, build_permission_options
+from vibe.agents import AgentSafety, AgentType
+from vibe.app_server.models import AgentSummary
 from vibe.permissions import PermissionScope, RequiredPermission
 
 
@@ -29,3 +31,62 @@ def test_build_permission_options_serializes_scopes_with_snake_case_keys() -> No
     for option in session_options:
         assert option.field_meta is not None
         assert option.field_meta["required_permissions"] == expected_meta
+
+
+def _agent(
+    name: str,
+    *,
+    safety: AgentSafety = AgentSafety.NEUTRAL,
+    agent_type: AgentType = AgentType.AGENT,
+) -> AgentSummary:
+    return AgentSummary(
+        name=name,
+        display_name=name.replace("-", " ").title(),
+        description=f"{name} mode",
+        safety=safety,
+        agent_type=agent_type,
+    )
+
+
+def test_build_mode_state_includes_active_mode_hidden_from_picker() -> None:
+    # A session can run a mode the rollout gate hides from the offered list
+    # (e.g. smart-approve after its experiment flag lapses). The advertised list
+    # must still contain the active mode so the client can label it and switch
+    # away from it.
+    offered = [_agent("ask"), _agent("auto-approve", safety=AgentSafety.YOLO)]
+    active = _agent("smart-approve", safety=AgentSafety.SMART)
+
+    state, option = build_mode_state(offered, active)
+
+    mode_ids = [mode.id for mode in state.available_modes]
+    assert state.current_mode_id == "smart-approve"
+    assert state.current_mode_id in mode_ids
+    option_values = [choice.value for choice in option.options]
+    assert option.current_value == "smart-approve"
+    assert option.current_value in option_values
+
+
+def test_build_mode_state_does_not_duplicate_active_mode() -> None:
+    auto = _agent("auto-approve", safety=AgentSafety.YOLO)
+    offered = [_agent("ask"), auto]
+
+    state, option = build_mode_state(offered, auto)
+
+    mode_ids = [mode.id for mode in state.available_modes]
+    assert mode_ids.count("auto-approve") == 1
+    option_values = [choice.value for choice in option.options]
+    assert option_values.count("auto-approve") == 1
+
+
+def test_build_mode_state_excludes_subagents_but_keeps_active() -> None:
+    offered = [
+        _agent("ask"),
+        _agent("explore", safety=AgentSafety.SAFE, agent_type=AgentType.SUBAGENT),
+    ]
+    active = _agent("smart-approve", safety=AgentSafety.SMART)
+
+    state, _ = build_mode_state(offered, active)
+
+    mode_ids = [mode.id for mode in state.available_modes]
+    assert "explore" not in mode_ids
+    assert "smart-approve" in mode_ids

--- a/tests/app_server/backend_contract/test_connector_catalog.py
+++ b/tests/app_server/backend_contract/test_connector_catalog.py
@@ -212,15 +212,16 @@ async def test_connector_catalog_default_selection_matches_production_compositio
 
 
 @pytest.mark.asyncio
-async def test_invalid_initial_connector_bootstrap_keeps_session_usable(
+async def test_faulty_connector_is_dropped_without_hiding_healthy_siblings(
     backend_contract_connection: BackendContractConnection,
     backend_contract_mistral_api,
     respx_mock: respx.MockRouter,
 ) -> None:
-    """An invalid initial catalog is unavailable instead of aborting session startup."""
-    duplicate_tools = _connector("github/raw", "github", tools=("search", " search "))
+    """One invalid connector is dropped so the rest of the catalog still loads."""
+    faulty = _connector("github/raw", "github", tools=("search", " search "))
+    healthy = _connector("wiki/raw", "wiki")
     session, _ = await _open_connector_session(
-        backend_contract_connection, respx_mock, _payload(duplicate_tools)
+        backend_contract_connection, respx_mock, _payload(faulty, healthy)
     )
     try:
         response = ConnectorCatalogReadResponse.model_validate(
@@ -230,11 +231,11 @@ async def test_invalid_initial_connector_bootstrap_keeps_session_usable(
             )
         )
 
-        assert response.catalog.disposition == "not_loaded"
-        assert response.catalog.catalog_revision is None
+        assert response.catalog.disposition == "memory"
+        assert response.catalog.catalog_revision is not None
+        assert [entry.alias for entry in response.catalog.connectors] == ["wiki"]
         assert response.session is not None
-        assert response.session.sources == []
-        assert session.resources.runtime.connectors.total == 0
+        assert [source.alias for source in response.session.sources] == ["wiki"]
     finally:
         await session.close()
 

--- a/tests/app_server/test_connector_catalog.py
+++ b/tests/app_server/test_connector_catalog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 import json
+import logging
 from pathlib import Path
 import threading
 from threading import Event
@@ -518,22 +519,8 @@ def test_concurrent_connector_cache_writers_preserve_account_entries(
         _v2_entry({"connectors": []}, stored_at=1_101),
         _v2_entry({"connectors": "not-a-list"}),
         _v2_entry({"connectors": [_connector()]}, stored_at=500),
-        _v2_entry({"connectors": [_connector() for _ in range(257)]}),
-        _v2_entry({
-            "connectors": [
-                {
-                    **_connector(),
-                    "tools": [
-                        {
-                            "name": "oversized",
-                            "inputSchema": {"description": "x" * (64 * 1_024)},
-                        }
-                    ],
-                }
-            ]
-        }),
     ],
-    ids=["future", "malformed", "expired", "connector-limit", "schema-limit"],
+    ids=["future", "malformed", "expired"],
 )
 def test_connector_cache_rejects_unsafe_records(
     tmp_path: Path, entry: dict[str, object]
@@ -552,6 +539,33 @@ def test_connector_cache_rejects_unsafe_records(
 
     # Assert
     assert result is None
+
+
+def test_connector_cache_drops_faulty_connector_but_keeps_siblings(
+    tmp_path: Path,
+) -> None:
+    # A cached record with one invalid connector must not poison the whole cache
+    # read: the faulty row is dropped and its healthy sibling survives.
+    entry = _v2_entry({
+        "connectors": [
+            _connector(name="wiki"),
+            {
+                **_connector(connector_id="c-dup", name="dup"),
+                "tools": [
+                    {"name": "same", "inputSchema": {}},
+                    {"name": "same", "inputSchema": {}},
+                ],
+            },
+        ]
+    })
+    fingerprint = "f" * 64
+    cache_path = tmp_path / "connectors.json"
+    cache_path.write_text(json.dumps({fingerprint: entry}), encoding="utf-8")
+
+    result = ConnectorCatalogCache(cache_path).read(fingerprint, now=1_100)
+
+    assert result is not None
+    assert [connector.alias for connector in result.catalog.connectors] == ["wiki"]
 
 
 @pytest.mark.asyncio
@@ -762,28 +776,223 @@ async def test_connector_collision_suffix_stays_within_public_name_limit(
     assert len(aliases[1]) == 256
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("names", [("search", "search"), ("search", " search ")])
-async def test_connector_catalog_rejects_duplicate_trimmed_tool_names(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, names: tuple[str, str]
+def test_resolve_drops_connector_with_duplicate_trimmed_tool_names(
+    names: tuple[str, str],
 ) -> None:
-    monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
-    connector = _connector()
-    connector["tools"] = [
+    faulty = _connector(connector_id="c-dup", name="dup")
+    faulty["tools"] = [
         {"name": name, "description": name, "inputSchema": {}} for name in names
     ]
 
-    async def fetch(_base_url: str, _api_key: str) -> object:
-        return {"connectors": [connector]}
-
-    service = ConnectorCatalogService(
-        implicit_source_enabled=False,
-        cache_path=tmp_path / "connectors.json",
-        fetch_bootstrap=fetch,
+    catalog = connector_catalog._resolve_catalog(
+        {"connectors": [_connector(name="wiki"), faulty]}, "fingerprint"
     )
 
-    with pytest.raises(ConnectorCatalogValidationError, match="duplicate tool names"):
-        await service.resolve_catalog(_orchestrator())
+    # The faulty connector is dropped; its healthy sibling still loads.
+    assert [connector.alias for connector in catalog.connectors] == ["wiki"]
+
+
+def test_resolve_drops_connector_exceeding_tool_limit() -> None:
+    over_limit = _connector(connector_id="c-many", name="many")
+    over_limit["tools"] = [
+        {"name": f"tool_{index}", "description": "x", "inputSchema": {}}
+        for index in range(connector_catalog._MAX_TOOLS_PER_CONNECTOR + 1)
+    ]
+
+    catalog = connector_catalog._resolve_catalog(
+        {"connectors": [over_limit, _connector(name="wiki")]}, "fingerprint"
+    )
+
+    assert [connector.alias for connector in catalog.connectors] == ["wiki"]
+
+
+def test_resolve_drops_oversized_tool_but_keeps_connector() -> None:
+    connector = _connector(connector_id="c-big", name="big")
+    connector["tools"] = [
+        {"name": "ok", "description": "x", "inputSchema": {}},
+        {
+            "name": "huge",
+            "description": "x",
+            # Padding beyond the 64 KiB cap; only this tool is dropped.
+            "inputSchema": {"type": "object", "pad": "x" * (65 * 1024)},
+        },
+    ]
+
+    catalog = connector_catalog._resolve_catalog(
+        {"connectors": [connector]}, "fingerprint"
+    )
+
+    # The connector survives with its healthy tool; the oversized one is gone.
+    assert len(catalog.connectors) == 1
+    assert [tool.raw_name for tool in catalog.connectors[0].tools] == ["ok"]
+
+
+def test_resolve_drops_unnamed_tool_but_keeps_connector() -> None:
+    connector = _connector(connector_id="c-x", name="x")
+    connector["tools"] = [
+        {"name": "ok", "description": "x", "inputSchema": {}},
+        {"name": "   ", "description": "blank", "inputSchema": {}},
+    ]
+
+    catalog = connector_catalog._resolve_catalog(
+        {"connectors": [connector]}, "fingerprint"
+    )
+
+    assert len(catalog.connectors) == 1
+    assert [tool.raw_name for tool in catalog.connectors[0].tools] == ["ok"]
+
+
+def test_resolve_drops_all_faulty_connectors_yielding_empty_catalog() -> None:
+    faulty = _connector(connector_id="c-bad", name="bad")
+    faulty["tools"] = [{"name": "n", "description": "n", "inputSchema": {}}] * 2
+
+    catalog = connector_catalog._resolve_catalog(
+        {"connectors": [faulty]}, "fingerprint"
+    )
+
+    assert catalog.connectors == ()
+
+
+def test_resolve_tail_truncates_over_cap_catalog() -> None:
+    over_cap = connector_catalog._MAX_CONNECTORS + 5
+    payload = {
+        "connectors": [
+            _connector(connector_id=f"c-{index:04d}", name=f"conn{index:04d}")
+            for index in range(over_cap)
+        ]
+    }
+
+    catalog = connector_catalog._resolve_catalog(payload, "fingerprint")
+
+    # The tail beyond the cap is dropped after the deterministic id sort, so the
+    # catalog keeps the first _MAX_CONNECTORS instead of being rejected wholesale.
+    assert len(catalog.connectors) == connector_catalog._MAX_CONNECTORS
+    assert catalog.connectors[0].raw_id == "c-0000"
+    assert (
+        catalog.connectors[-1].raw_id
+        == f"c-{connector_catalog._MAX_CONNECTORS - 1:04d}"
+    )
+
+
+def test_resolve_drops_duplicate_id_connectors_but_keeps_unique_siblings() -> None:
+    # A duplicated id has an ambiguous identity, so every copy is dropped while
+    # uniquely identified siblings still load.
+    payload = {
+        "connectors": [
+            _connector(connector_id="same", name="a"),
+            _connector(connector_id="same", name="b"),
+            _connector(connector_id="unique", name="c"),
+        ]
+    }
+
+    catalog = connector_catalog._resolve_catalog(payload, "fingerprint")
+
+    assert [connector.raw_id for connector in catalog.connectors] == ["unique"]
+
+
+def test_resolve_still_aborts_on_broken_envelope() -> None:
+    # A connectors field that is not a list is whole-payload corruption, so
+    # resolution stays fatal rather than guessing at partial recovery.
+    with pytest.raises(ConnectorCatalogValidationError, match="malformed"):
+        connector_catalog._resolve_catalog({"connectors": "nope"}, "fingerprint")
+
+
+def test_resolve_drops_malformed_connector_but_keeps_siblings() -> None:
+    # A connector whose wire shape is invalid (tools is not a list) is dropped
+    # without taking its healthy sibling down.
+    malformed = {"id": "c-bad", "name": "bad", "tools": "not-a-list"}
+
+    catalog = connector_catalog._resolve_catalog(
+        {"connectors": [malformed, _connector(name="wiki")]}, "fingerprint"
+    )
+
+    assert [connector.alias for connector in catalog.connectors] == ["wiki"]
+
+
+def test_resolve_drops_malformed_tool_but_keeps_connector() -> None:
+    # A tool missing its required name key is dropped on its own; the connector
+    # keeps its healthy tool instead of the whole payload failing to parse.
+    connector = _connector(connector_id="c-x", name="x")
+    connector["tools"] = [
+        {"name": "ok", "description": "x", "inputSchema": {}},
+        {"description": "no name key", "inputSchema": {}},
+    ]
+
+    catalog = connector_catalog._resolve_catalog(
+        {"connectors": [connector]}, "fingerprint"
+    )
+
+    assert len(catalog.connectors) == 1
+    assert [tool.raw_name for tool in catalog.connectors[0].tools] == ["ok"]
+
+
+def test_resolve_keeps_alias_stable_when_colliding_sibling_dropped() -> None:
+    # `a-id` sorts before `b-id` and shares the normalized alias; dropping it for
+    # bad tools must not promote the survivor from `dup_2` to `dup`, which would
+    # break any selection persisted against `dup_2`.
+    dropped = _connector(connector_id="a-id", name="dup")
+    dropped["tools"] = [
+        {"name": "same", "description": "x", "inputSchema": {}},
+        {"name": "same", "description": "x", "inputSchema": {}},
+    ]
+    survivor = _connector(connector_id="b-id", name="dup")
+
+    catalog = connector_catalog._resolve_catalog(
+        {"connectors": [dropped, survivor]}, "fingerprint"
+    )
+
+    assert [(c.raw_id, c.alias) for c in catalog.connectors] == [("b-id", "dup_2")]
+
+
+def test_resolve_truncation_keeps_healthy_tail_over_invalid_head() -> None:
+    # Fill every cap slot with invalid connectors that sort first, then a single
+    # healthy connector in the tail. Filtering before truncating keeps the
+    # healthy one instead of yielding an empty catalog.
+    max_connectors = connector_catalog._MAX_CONNECTORS
+
+    def faulty(index: int) -> dict[str, object]:
+        connector = _connector(connector_id=f"c-{index:04d}", name=f"bad{index}")
+        connector["tools"] = [
+            {"name": "same", "description": "x", "inputSchema": {}},
+            {"name": "same", "description": "x", "inputSchema": {}},
+        ]
+        return connector
+
+    payload = {
+        "connectors": [faulty(index) for index in range(max_connectors)]
+        + [_connector(connector_id=f"c-{max_connectors:04d}", name="healthy")]
+    }
+
+    catalog = connector_catalog._resolve_catalog(payload, "fingerprint")
+
+    assert [connector.raw_id for connector in catalog.connectors] == [
+        f"c-{max_connectors:04d}"
+    ]
+
+
+def test_resolve_aggregates_dropped_tool_warnings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Many unusable tools on one connector emit a single summary warning, not one
+    # line per tool, to bound the log volume on a bad refresh.
+    connector = _connector(connector_id="c", name="c")
+    connector["tools"] = [
+        {"name": "   ", "description": "blank", "inputSchema": {}} for _ in range(5)
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="vibe"):
+        connector_catalog._resolve_catalog({"connectors": [connector]}, "fingerprint")
+
+    tool_drop_logs = [
+        record
+        for record in caplog.records
+        if getattr(record, "connector_drop_reason", None) == "tools_dropped"
+    ]
+    assert len(tool_drop_logs) == 1
+    assert getattr(tool_drop_logs[0], "connector_tool_drop_counts", None) == {
+        "unnamed_tool": 5
+    }
 
 
 def test_connector_selection_preserves_explicit_policy_precedence() -> None:

--- a/tests/app_server/test_host_agents_experiments.py
+++ b/tests/app_server/test_host_agents_experiments.py
@@ -1,0 +1,51 @@
+"""The passive Host's ``agents/list`` must reflect GrowthBook experiment
+variants, exactly like a session build does.
+
+Regression: ``_load_orchestrator`` built a plain orchestrator without applying
+the cached experiment variants, so rollout flags such as
+``smart_approve_available`` were absent and smart-approve was hidden from the
+desktop mode picker even though the session path offered it.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from vibe.app_server._host import HostRequestHandler
+import vibe.app_server._runtime as runtime_module
+from vibe.app_server.protocol import AgentsListParams, AgentsListResponse
+from vibe.core.config.harness_files import HarnessFilesManager
+from vibe.core.experiments.active import ExperimentName
+from vibe.core.experiments.models import EvalResponse
+
+
+def _smart_approve_available_response() -> EvalResponse:
+    # A rollout served purely via defaultValue (no force rules), as GrowthBook
+    # returns it for smart approve.
+    return EvalResponse.model_validate({
+        "features": {
+            ExperimentName.SMART_APPROVE.value: {"defaultValue": True, "rules": []}
+        }
+    })
+
+
+@pytest.mark.asyncio
+async def test_agents_list_offers_smart_approve_from_cached_experiment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        runtime_module,
+        "load_cached_eval_response",
+        lambda _config: _smart_approve_available_response(),
+    )
+    handler = HostRequestHandler(HarnessFilesManager(sources=("user",)))
+
+    result = await handler.dispatch(
+        "agents/list", AgentsListParams().model_dump(mode="json", by_alias=True)
+    )
+
+    response = cast(AgentsListResponse, result.response)
+    names = [agent.name for agent in response.agents]
+    assert "smart-approve" in names

--- a/tests/app_server/test_mode_state_experiment_boundary.py
+++ b/tests/app_server/test_mode_state_experiment_boundary.py
@@ -1,0 +1,71 @@
+"""End-to-end boundary: a GrowthBook rollout served purely via a feature's
+``defaultValue`` (no force rules) must surface smart-approve all the way from the
+resolved config through AgentManager into the ACP mode list.
+
+This locks the seam past ``resolve``/``GrowthbookLayer`` (already unit-tested):
+config field -> AgentManager.available_agents -> project_agent_summaries ->
+build_mode_state, which is what the desktop client renders.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vibe.acp.utils import build_mode_state
+from vibe.app_server._projection import project_agent_summaries
+from vibe.core.agents.manager import AgentManager
+from vibe.core.config import build_default_orchestrator
+from vibe.core.config.layers.growthbook import GrowthbookLayer
+from vibe.core.experiments.active import ExperimentName
+from vibe.core.experiments.manager import config_variants_from_response
+from vibe.core.experiments.models import EvalResponse
+
+
+def _default_value_only_smart_approve() -> EvalResponse:
+    # Mirrors the desktop eval cache: smart-approve served as a boolean
+    # defaultValue with no force rules / tracks.
+    return EvalResponse.model_validate({
+        "features": {
+            ExperimentName.SMART_APPROVE.value: {"defaultValue": True, "rules": []},
+            ExperimentName.SMART_APPROVE_DEFAULT.value: {
+                "defaultValue": True,
+                "rules": [],
+            },
+        }
+    })
+
+
+async def _orchestrator_with_smart_approve():
+    orchestrator = await build_default_orchestrator()
+    layer = orchestrator.get_layer(GrowthbookLayer.NAME)
+    assert isinstance(layer, GrowthbookLayer)
+    layer.set_variants(
+        config_variants_from_response(_default_value_only_smart_approve())
+    )
+    await orchestrator.reload()
+    return orchestrator
+
+
+@pytest.mark.asyncio
+async def test_default_value_rollout_enables_smart_approve_config() -> None:
+    config = (await _orchestrator_with_smart_approve()).config
+    assert config.smart_approve_available is True
+    assert config.smart_approve_default is True
+    assert config.smart_approve_offered() is True
+    assert config.resolve_default_agent() == "smart-approve"
+
+
+@pytest.mark.asyncio
+async def test_default_value_rollout_surfaces_smart_approve_in_mode_list() -> None:
+    orchestrator = await _orchestrator_with_smart_approve()
+    agents = AgentManager(orchestrator, orchestrator.config.resolve_default_agent())
+
+    active, summaries = project_agent_summaries(
+        agents.active_profile, agents.available_agents.values()
+    )
+    state, option = build_mode_state(summaries, active)
+
+    mode_ids = [mode.id for mode in state.available_modes]
+    assert "smart-approve" in mode_ids
+    assert state.current_mode_id == "smart-approve"
+    assert "smart-approve" in [choice.value for choice in option.options]

--- a/tests/app_server/test_unified_harness_backend_adapter.py
+++ b/tests/app_server/test_unified_harness_backend_adapter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable, Sequence
 import contextlib
 from dataclasses import replace
 from datetime import UTC, datetime
@@ -584,6 +584,53 @@ async def test_unified_title_generation_gated_on_entrypoint(
 
     has_title_model = derivation.adapter_config.title_model is not None
     assert has_title_model is expect_title_model
+
+
+@pytest.mark.parametrize(
+    ("api_base", "expected"),
+    [
+        ("https://api.mistral.ai/v1", True),
+        ("HTTPS://API.MISTRAL.AI:443/v1", True),
+        ("https://customer.mistral.ai/v1", False),
+        ("https://api.mistral.ai.example.com/v1", False),
+        ("http://api.mistral.ai/v1", False),
+        ("https://api.mistral.ai:8443/v1", False),
+        ("https://api.mistral.ai:not-a-port/v1", False),
+    ],
+)
+def test_unified_fast_title_model_requires_public_mistral_origin(
+    api_base: str, expected: bool
+) -> None:
+    assert runtime_module._is_public_mistral_api(api_base) is expected
+
+
+@pytest.mark.asyncio
+async def test_unified_title_model_uses_active_model_on_custom_mistral_endpoint(
+    tmp_path: Path, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pytest.importorskip("mistralai_vibe_local_harness.vibe")
+    from vibe.app_server._unified_harness_backend_adapter import UnifiedSessionSettings
+
+    config_file = config_dir / "config.toml"
+    config = tomllib.loads(config_file.read_text(encoding="utf-8"))
+    config["providers"][0]["api_base"] = "https://customer.mistral.ai/v1"
+    config["session_logging"] = {"generate_titles": True}
+    config_file.write_text(tomli_w.dumps(config), encoding="utf-8")
+
+    monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+    process = runtime_module.HarnessProcess(experimental_harness=True)
+    try:
+        context = await process.build_unified_session_context(
+            SessionOptions(cwd=str(tmp_path)), entrypoint="desktop"
+        )
+        derivation = context.derive(UnifiedSessionSettings())
+    finally:
+        await process.close()
+
+    assert derivation.adapter_config.title_model is not None
+    assert derivation.adapter_config.title_model.model == "mistral-vibe-cli-latest"
+    assert derivation.adapter_config.title_model_is_fast is False
+    assert derivation.adapter_config.title_provider is None
 
 
 @pytest.mark.asyncio
@@ -2442,7 +2489,9 @@ async def test_unified_connector_projection_keeps_server_error_on_name_collision
     assert adapter._runtime.mcp.discovery_errors == {}
 
 
-async def _skill_adapter(tmp_path: Path, session: _RecordingSession) -> Any:
+async def _skill_adapter(
+    tmp_path: Path, session: _RecordingSession, *, workspace_roots: Sequence[Path] = ()
+) -> Any:
     """An adapter over a workspace holding one user-invocable skill."""
     from vibe.app_server._runtime import HarnessProcess
     from vibe.app_server._unified_harness_backend_adapter import (
@@ -2453,7 +2502,11 @@ async def _skill_adapter(tmp_path: Path, session: _RecordingSession) -> Any:
     _write_workspace_skill(tmp_path, "code-review", "Read the diff twice.")
     process = HarnessProcess(experimental_harness=True)
     context = await process.build_unified_session_context(
-        SessionOptions(cwd=str(tmp_path), trust_workspace=True)
+        SessionOptions(
+            cwd=str(tmp_path),
+            trust_workspace=True,
+            workspace_roots=[str(root) for root in workspace_roots],
+        )
     )
     session.cwd = str(tmp_path)
     return UnifiedHarnessBackendAdapter(
@@ -2811,6 +2864,121 @@ async def test_unified_inject_context_does_not_expand_mentions_inside_a_skill_bo
     ]
     assert [Path(uri).name for uri in resources] == ["notes.md"]
     assert "Write @secret.md to name a file." in blocks[-1].text
+
+
+@pytest.mark.asyncio
+async def test_unified_session_keeps_the_cwd_among_its_workspace_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prepare session options carrying one ``--add-dir`` root beside the cwd.
+
+    Do build the session context and derive its adapter config.
+
+    Assert the cwd leads the root set. The harness reads a non-empty set as the
+    complete one, so an added directory that replaced the cwd would leave the
+    file tools unable to read the project the session was started in.
+    """
+    pytest.importorskip("mistralai_vibe_local_harness.vibe")
+    monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+    from vibe.app_server._runtime import HarnessProcess
+    from vibe.app_server._unified_harness_backend_adapter import UnifiedSessionSettings
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    downloads = tmp_path / "downloads"
+    downloads.mkdir()
+    process = HarnessProcess(experimental_harness=True)
+
+    context = await process.build_unified_session_context(
+        SessionOptions(
+            cwd=str(workspace), trust_workspace=True, workspace_roots=[str(downloads)]
+        )
+    )
+
+    derivation = context.derive(UnifiedSessionSettings())
+    assert derivation.adapter_config.workspace_roots == (workspace, downloads)
+
+
+@pytest.mark.asyncio
+async def test_unified_start_turn_inlines_a_mention_from_an_added_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prepare a session whose workspace roots add a directory beside the cwd.
+
+    Do start a turn mentioning a file in the cwd and one in the added root.
+
+    Assert both are inlined. The file tools resolve against the same root set,
+    so a session that refuses to attach a path ``read_file`` would happily read
+    holds two contradictory definitions of its own workspace.
+    """
+    pytest.importorskip("mistralai_vibe_local_harness.vibe")
+    monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    downloads = tmp_path / "downloads"
+    downloads.mkdir()
+    (workspace / "notes.md").write_text("user file", encoding="utf-8")
+    (downloads / "build.log").write_text("vitest failed", encoding="utf-8")
+    session = _RecordingSession()
+    adapter = await _skill_adapter(workspace, session, workspace_roots=[downloads])
+
+    await adapter.start_turn(
+        TurnStartParams(
+            session_id=session.session_id,
+            message=[
+                TextContentBlock(
+                    text=f"compare @notes.md with @{downloads / 'build.log'}"
+                )
+            ],
+        )
+    )
+
+    blocks = session.sent[-1].message
+    resources = [
+        block.resource.uri
+        for block in blocks
+        if isinstance(block, ResourceContentBlock)
+    ]
+    assert sorted(Path(uri).name for uri in resources) == ["build.log", "notes.md"]
+
+
+@pytest.mark.asyncio
+async def test_unified_start_turn_keeps_an_unreachable_mention_as_plain_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prepare a file outside every workspace root of the session.
+
+    Do start a turn mentioning it alongside a file inside the workspace.
+
+    Assert the turn is sent with only the reachable file inlined. Rejecting the
+    request instead would discard a prompt the user had already composed over
+    one path they typed themselves.
+    """
+    pytest.importorskip("mistralai_vibe_local_harness.vibe")
+    monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "notes.md").write_text("user file", encoding="utf-8")
+    outside = tmp_path / "build.log"
+    outside.write_text("vitest failed", encoding="utf-8")
+    session = _RecordingSession()
+    adapter = await _skill_adapter(workspace, session)
+
+    await adapter.start_turn(
+        TurnStartParams(
+            session_id=session.session_id,
+            message=[TextContentBlock(text=f"compare @notes.md with @{outside}")],
+        )
+    )
+
+    blocks = session.sent[-1].message
+    resources = [
+        block.resource.uri
+        for block in blocks
+        if isinstance(block, ResourceContentBlock)
+    ]
+    assert [Path(uri).name for uri in resources] == ["notes.md"]
+    assert str(outside) in blocks[0].text
 
 
 @pytest.mark.asyncio
@@ -3666,7 +3834,7 @@ async def test_unified_turn_start_injects_mentioned_file_context(
     calls: list[tuple[str, Path]] = []
 
     async def fake_mentioned_file_blocks(
-        text: str, *, base_dir: Path
+        text: str, *, base_dir: Path, workspace_roots: Sequence[Path] = ()
     ) -> list[ResourceContentBlock]:
         calls.append((text, base_dir))
         return [mentioned_block]

--- a/tests/app_server/test_unified_permissions.py
+++ b/tests/app_server/test_unified_permissions.py
@@ -252,14 +252,13 @@ async def test_a_command_no_shell_can_read_is_scoped_to_itself(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_a_permanent_grant_for_an_unreadable_command_outlives_the_session(
+async def test_a_permanent_grant_cannot_auto_allow_unreadable_shell_syntax(
     tmp_path: Path,
 ) -> None:
-    """*Prepare*: A resolver, and the same unreadable command approved for good.
+    """*Prepare*: Persist an unreadable command in the shell allowlist.
     *Do*: Resolve it again against a fresh store, as the next session would.
-    *Assert*: It runs. The shells match their allowlists against a *parsed*
-    command, and this one parses to nothing, so only the resolver can read back
-    the entry it wrote -- without that, "always" would prompt every session.
+    *Assert*: It still asks. Invalid syntax must fail closed before allowlist
+    matching because a real shell may execute behavior the parser omitted.
     """
     # Prepare
     resolver, orchestrator = _resolver(tmp_path)
@@ -272,7 +271,7 @@ async def test_a_permanent_grant_for_an_unreadable_command_outlives_the_session(
     again = await next_session.resolve("file_system.bash", {"command": "&&"})
 
     # Assert
-    assert again.decision == "allow"
+    assert again.decision == "ask"
 
 
 @pytest.mark.parametrize("command", ["", "   "])

--- a/tests/app_server/test_unified_tool_projection.py
+++ b/tests/app_server/test_unified_tool_projection.py
@@ -225,11 +225,43 @@ def test_projects_unified_shell_result_from_structured_transcript() -> None:
     assert projected.state.output_text == "outerr"
 
 
-def test_shell_projection_preserves_auto_approved_note_warning() -> None:
+def test_shell_projection_preserves_the_auto_approved_note() -> None:
     """*Prepare*: A completed bash effect whose incoming display carries a
-    smart-approve auto-approved note as a warning.
+    smart-approve auto-approved note.
     *Do*: Project it through the Vibe-owned semantic adapter.
     *Assert*: The rebuilt shell display keeps the note so the TUI can render it.
+    """
+    note = "Auto-approved: read-only command (ls)"
+    entry = _effect(
+        "bash",
+        {"command": "ls"},
+        result={
+            "structured_content": {
+                "command": "ls",
+                "stdout": "file.txt\n",
+                "stderr": "",
+                "output": "file.txt\n",
+                "returncode": 0,
+                "was_truncated": False,
+            }
+        },
+        approval_note=note,
+    )
+
+    projected = project_unified_history_entry(entry)
+
+    assert isinstance(projected, PublicEffectEntry)
+    assert isinstance(projected.state, CompletedEffectState)
+    assert projected.state.display.approval_note == note
+    # It is not a warning: the call was authorised and succeeded.
+    assert projected.state.display.warnings == []
+
+
+def test_shell_projection_keeps_a_pre_split_note_stored_as_a_warning() -> None:
+    """*Prepare*: A completed bash effect from a session written before the
+    approval note had its own field, so the note sits in ``warnings``.
+    *Do*: Project it through the Vibe-owned semantic adapter.
+    *Assert*: The note survives replay instead of being dropped.
     """
     note = "Auto-approved: read-only command (ls)"
     entry = _effect(
@@ -837,6 +869,7 @@ def _effect(
     error: str | None = None,
     output_text: str = "",
     warnings: list[str] | None = None,
+    approval_note: str | None = None,
 ) -> PublicEffectEntry:
     completed_display: dict[str, object] = {
         "success": True,
@@ -844,6 +877,8 @@ def _effect(
     }
     if warnings is not None:
         completed_display["warnings"] = warnings
+    if approval_note is not None:
+        completed_display["approvalNote"] = approval_note
     raw = {
         "type": "effect",
         "id": "effect-action-1",

--- a/tests/app_server/test_workspace.py
+++ b/tests/app_server/test_workspace.py
@@ -105,14 +105,84 @@ def test_mentioned_file_content_blocks_cap_text_resources(tmp_path: Path) -> Non
     assert "truncated" in block.resource.text
 
 
-def test_mentioned_file_content_blocks_reject_outside_workspace(tmp_path: Path) -> None:
+def test_mentioned_file_content_blocks_skip_outside_workspace(tmp_path: Path) -> None:
+    """Prepare a workspace and a file that sits outside it.
+
+    Do mention both in one message.
+
+    Assert the outside file is dropped instead of failing the turn. Inlining
+    skips the read tool's permission prompt, so it stays inside the roots --
+    but the mention is user-authored, and rejecting the whole prompt over it
+    threw away everything else the user had written.
+    """
     workspace = tmp_path / "workspace"
     workspace.mkdir()
+    (workspace / "notes.md").write_text("inside", encoding="utf-8")
     secret = tmp_path / "secret.txt"
     secret.write_text("nope", encoding="utf-8")
 
-    with pytest.raises(PromptPreparationError, match="outside the workspace"):
-        mentioned_file_content_blocks(f"read @{secret}", base_dir=workspace)
+    blocks = mentioned_file_content_blocks(
+        f"read @notes.md and @{secret}", base_dir=workspace
+    )
+
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert isinstance(block, ResourceContentBlock)
+    assert isinstance(block.resource, UserTextResource)
+    assert block.resource.text == "inside"
+
+
+def test_mentioned_file_content_blocks_attach_from_additional_roots(
+    tmp_path: Path,
+) -> None:
+    """Prepare a file outside cwd but inside an ``--add-dir`` root.
+
+    Do mention it by absolute path.
+
+    Assert it is inlined. The file tools resolve against the same root set, so
+    refusing the mention while allowing ``read_file`` would be incoherent.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    downloads = tmp_path / "downloads"
+    downloads.mkdir()
+    log = downloads / "build.log"
+    log.write_text("vitest failed", encoding="utf-8")
+
+    blocks = mentioned_file_content_blocks(
+        f"read @{log}", base_dir=workspace, workspace_roots=[downloads]
+    )
+
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert isinstance(block, ResourceContentBlock)
+    assert isinstance(block.resource, UserTextResource)
+    assert block.resource.uri == log.as_uri()
+    assert block.resource.text == "vitest failed"
+
+
+def test_mentioned_file_content_blocks_count_only_attachable_files(
+    tmp_path: Path,
+) -> None:
+    """Prepare more out-of-root mentions than the per-message cap allows.
+
+    Do mention them alongside one file inside the workspace.
+
+    Assert the cap counts only what is actually inlined. Dropped mentions cost
+    no context, so they must not consume the budget.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "notes.md").write_text("inside", encoding="utf-8")
+    mentions = [f"@{workspace / 'notes.md'}"]
+    for index in range(9):
+        outside = tmp_path / f"outside-{index}.md"
+        outside.write_text(str(index), encoding="utf-8")
+        mentions.append(f"@{outside}")
+
+    blocks = mentioned_file_content_blocks(" ".join(mentions), base_dir=workspace)
+
+    assert len(blocks) == 1
 
 
 def test_mentioned_file_content_blocks_reject_too_many_files(tmp_path: Path) -> None:

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -1689,6 +1689,200 @@ def test_find_execution_predicate_does_not_override_denylist():
     assert "matches denylist pattern 'passwd'" in (permission.reason or "")
 
 
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize("wrapper", ["eval", "exec"])
+def test_shell_wrappers_preserve_nested_denylist(shell_kind, wrapper):
+    """A shell builtin must not downgrade its statically visible command to ASK."""
+    if shell_kind == "legacy":
+        tool = Bash(
+            config_getter=lambda: BashToolConfig(denylist=["denied-marker"]),
+            state=BaseToolState(),
+        )
+        result = tool.resolve_permission(
+            BashArgs(command=f"{wrapper} denied-marker harmless")
+        )
+    else:
+        tool = ExperimentalBash(
+            config_getter=lambda: ExperimentalBashToolConfig(
+                denylist=["denied-marker"]
+            ),
+            state=BaseToolState(),
+        )
+        result = tool.resolve_permission(
+            ExperimentalBashArgs(command=f"{wrapper} denied-marker harmless")
+        )
+
+    assert isinstance(result, PermissionContext)
+    assert result.permission is ToolPermission.NEVER
+    assert "matches denylist pattern 'denied-marker'" in (result.reason or "")
+
+
+def _resolve_default_shell_permission(
+    shell_kind: str, command: str
+) -> PermissionContext | None:
+    if shell_kind == "legacy":
+        tool = Bash(config_getter=lambda: BashToolConfig(), state=BaseToolState())
+        return tool.resolve_permission(BashArgs(command=command))
+    tool = ExperimentalBash(
+        config_getter=lambda: ExperimentalBashToolConfig(), state=BaseToolState()
+    )
+    return tool.resolve_permission(ExperimentalBashArgs(command=command))
+
+
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sort -o sorted.txt input.txt",
+        "sort -rosorted.txt input.txt",
+        "sort --out=sorted.txt input.txt",
+        "sort --temporary-directory=. input.txt",
+        "sort --compress-program=gzip input.txt",
+        "find . -delete",
+        "find . -fprint matches.txt",
+        r"find . -exec echo {} \;",
+        "less -o less.log input.txt",
+        "less -Noless.log input.txt",
+        "less --LOG-FILE=less.log input.txt",
+        "tree -o tree.txt .",
+        "tree -aotree.txt .",
+        "git diff --output=diff.txt",
+        "git diff --out=diff.txt",
+        "git log --output=log.txt",
+        "git diff --ext-diff",
+        "date -s 2020-01-01",
+        "date -us 2020-01-01",
+        "date --set=2020-01-01",
+        "date --se=2020-01-01",
+    ],
+)
+def test_side_effecting_allowlisted_options_require_approval(shell_kind, command):
+    permission = _resolve_default_shell_permission(shell_kind, command)
+
+    assert isinstance(permission, PermissionContext)
+    assert permission.permission is ToolPermission.ASK
+
+
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sort -r input.txt",
+        "find . -name '*.py'",
+        "less -N input.txt",
+        "tree -L 2 .",
+        "git diff --stat",
+        "git log --oneline",
+        "sort -- --output=ordinary-filename",
+        "date -d yesterday",
+        "date -Iseconds",
+        "date -- -s",
+    ],
+)
+def test_benign_allowlisted_options_remain_allowed(shell_kind, command):
+    permission = _resolve_default_shell_permission(shell_kind, command)
+
+    assert isinstance(permission, PermissionContext)
+    assert permission.permission is ToolPermission.ALWAYS
+
+
+@pytest.mark.skipif(is_windows(), reason="outside-dir permissions are POSIX-only")
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command_template",
+    [
+        "tree {outside}",
+        "git diff --no-index {outside} other.txt",
+        "sort --random-source={outside} input.txt",
+        "sort --random={outside} input.txt",
+    ],
+)
+def test_allowlisted_option_paths_outside_workspace_require_approval(
+    shell_kind, command_template, tmp_path, monkeypatch
+):
+    workdir = tmp_path / "workdir"
+    outside = tmp_path / "outside" / "data.txt"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    permission = _resolve_default_shell_permission(
+        shell_kind, command_template.format(outside=outside)
+    )
+
+    assert isinstance(permission, PermissionContext)
+    assert permission.permission is ToolPermission.ASK
+    assert any(
+        str(outside.parent) in required.label
+        for required in permission.required_permissions
+    )
+
+
+@pytest.mark.skipif(is_windows(), reason="outside-dir permissions are POSIX-only")
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command_template",
+    [
+        "grep --file={outside} input.txt",
+        "grep --fil={outside} input.txt",
+        "grep -if{outside} input.txt",
+        "file --files-from={outside}",
+        "file --files-f={outside}",
+        "file -f{outside}",
+        "file --magic-file={outside} input.txt",
+        "file --magic-f={outside} input.txt",
+        "file -m{outside} input.txt",
+        "file -m{outside}:magic.mgc input.txt",
+        "du --files0-from={outside}",
+        "du --files0-f={outside}",
+        "wc --files0-from={outside}",
+        "wc --files0-f={outside}",
+        "date --file={outside}",
+        "date --fil={outside}",
+        "date -uf{outside}",
+        "diff --from-file={outside} input.txt",
+        "diff --to={outside} input.txt",
+    ],
+)
+def test_read_only_option_paths_outside_workspace_require_approval(
+    shell_kind, command_template, tmp_path, monkeypatch
+):
+    workdir = tmp_path / "workdir"
+    outside = tmp_path / "outside" / "data.txt"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    permission = _resolve_default_shell_permission(
+        shell_kind, command_template.format(outside=outside)
+    )
+
+    assert isinstance(permission, PermissionContext)
+    assert permission.permission is ToolPermission.ASK
+    assert any(
+        str(outside.parent) in required.label
+        for required in permission.required_permissions
+    )
+
+
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        "grep --file=patterns.txt input.txt",
+        "file -f names.txt",
+        "file --magic-file=magic.mgc input.txt",
+        "du --files0-from=names.txt",
+        "wc --files0-from=names.txt",
+        "date -f dates.txt",
+        "diff --from-file=base.txt input.txt",
+    ],
+)
+def test_read_only_option_paths_inside_workspace_remain_allowed(shell_kind, command):
+    permission = _resolve_default_shell_permission(shell_kind, command)
+
+    assert isinstance(permission, PermissionContext)
+    assert permission.permission is ToolPermission.ALWAYS
+
+
 @pytest.mark.skipif(is_windows(), reason="outside-dir permissions are POSIX-only")
 def test_legacy_bash_quoted_outside_path_requires_approval(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -1996,7 +2190,7 @@ def test_new_read_only_commands_are_allowlisted():
         "grep pattern file.txt",
         "cut -d',' -f1 file.csv",
         "sort file.txt",
-        "tr 'a' 'b' < file.txt",
+        "tr 'a' 'b'",
         "uniq file.txt",
         "basename file.txt",
         "comm file1.txt file2.txt",
@@ -2031,6 +2225,217 @@ def test_new_read_only_commands_are_allowlisted():
         assert permission.permission is ToolPermission.ALWAYS, (
             f"Command '{cmd}' should be always allowed"
         )
+
+
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        r"find . $'-exec' echo harmless {} \;",
+        r"find . $'-ex'c echo harmless {} \;",
+        r'find . "$(basename ./-exe)c" echo harmless {} \;',
+        "echo $( {/bin/bash,-c,id} ) $( (){ /bin/bash -c id } )",
+        "GIT_PAGER=cat git diff",
+        "PATH=/tmp; git status",
+        "PATH=/tmp && git status",
+        "(PATH=/tmp; git status)",
+        "{ PATH=/tmp; git status; }",
+        "for value in 1; do PATH=/tmp; git status; done",
+        "FOO=bar",
+        'cat "$HOME/.ssh/id_rsa"',
+        "echo ${VALUE:-harmless}",
+        "echo {harmless,safe}",
+        "echo {1..3}",
+        "echo $((1 + 2))",
+        "cat =sh",
+        "grep --file==sh pattern README.md",
+        "cat ~-/secret",
+        "cat ~+2/secret",
+        "cat ~vault/secret",
+        "cat ***/*",
+        "cat =(printf harmless)",
+        "echo ${(e)payload}",
+        "echo *(e:'true':)",
+        "[[ -r /etc/passwd ]] && echo readable",
+        "[ -r /etc/passwd ] && echo readable",
+        "for value in harmless; do echo harmless; done",
+        "for ((i = 0; i < 1; i++)); do echo harmless; done",
+        "while echo harmless; do echo harmless; done",
+        "if echo harmless; then echo harmless; fi",
+        "case harmless in harmless) echo harmless;; esac",
+        "(echo harmless)",
+        "{ echo harmless; }",
+        "harmless() { echo harmless; }",
+        "echo harmless &",
+    ],
+    ids=[
+        "ansi-c-string",
+        "nested-ansi-c-string",
+        "command-substitution",
+        "parse-error",
+        "environment-assignment",
+        "standalone-assignment",
+        "and-list-assignment",
+        "subshell-assignment",
+        "group-assignment",
+        "loop-assignment",
+        "assignment-only",
+        "variable-expansion",
+        "parameter-default-expansion",
+        "brace-expansion",
+        "brace-range-expansion",
+        "arithmetic-expansion",
+        "zsh-equals-expansion",
+        "zsh-magic-equals-expansion",
+        "zsh-directory-stack-expansion",
+        "zsh-directory-stack-index-expansion",
+        "zsh-named-directory-expansion",
+        "zsh-symlink-following-glob",
+        "zsh-temp-file-substitution",
+        "zsh-parameter-evaluation",
+        "zsh-executable-glob-qualifier",
+        "double-bracket-test-command",
+        "single-bracket-test-command",
+        "for-loop",
+        "c-style-for-loop",
+        "while-loop",
+        "conditional",
+        "case-conditional",
+        "subshell",
+        "group",
+        "function-definition",
+        "background",
+    ],
+)
+def test_shell_permission_analysis_fails_closed(shell_kind, command):
+    """Permission resolution must reject syntax not modeled for auto-approval."""
+    if shell_kind == "legacy":
+        tool = Bash(config_getter=lambda: BashToolConfig(), state=BaseToolState())
+        result = tool.resolve_permission(BashArgs(command=command))
+    else:
+        tool = ExperimentalBash(
+            config_getter=lambda: ExperimentalBashToolConfig(), state=BaseToolState()
+        )
+        result = tool.resolve_permission(ExperimentalBashArgs(command=command))
+
+    assert isinstance(result, PermissionContext)
+    assert result.permission is ToolPermission.ASK
+
+
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo harmless > output.txt",
+        "echo harmless >> output.txt",
+        "cat < input.txt",
+        "echo harmless 2>&1",
+        "echo harmless &> output.txt",
+        "cat <<'EOF'\nharmless\nEOF",
+        "cat <<< harmless",
+        "> output.txt",
+        "{ echo harmless; } > output.txt",
+        'echo "$(echo harmless > output.txt)"',
+        "cat <(echo harmless)",
+        "echo harmless > >(cat)",
+    ],
+    ids=[
+        "output",
+        "append",
+        "input",
+        "fd-duplication",
+        "combined-output",
+        "heredoc",
+        "here-string",
+        "redirect-only",
+        "compound",
+        "nested",
+        "process-substitution-input",
+        "process-substitution-output",
+    ],
+)
+def test_shell_redirections_require_approval(shell_kind, command):
+    """Redirection and process substitution must never be auto-approved."""
+    if shell_kind == "legacy":
+        tool = Bash(config_getter=lambda: BashToolConfig(), state=BaseToolState())
+        result = tool.resolve_permission(BashArgs(command=command))
+    else:
+        tool = ExperimentalBash(
+            config_getter=lambda: ExperimentalBashToolConfig(), state=BaseToolState()
+        )
+        result = tool.resolve_permission(ExperimentalBashArgs(command=command))
+
+    assert isinstance(result, PermissionContext)
+    assert result.permission is ToolPermission.ASK
+
+
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    "command",
+    ["cat <(printf harmless > marker.txt)", "cat <<EOF\n$(printf harmless)\nEOF"],
+    ids=["process-substitution-with-nested-redirect", "unquoted-heredoc-substitution"],
+)
+def test_nested_dynamic_redirections_require_approval(shell_kind, command):
+    """Nested redirects and substitutions must remain visible to permission policy."""
+    if shell_kind == "legacy":
+        tool = Bash(config_getter=lambda: BashToolConfig(), state=BaseToolState())
+        result = tool.resolve_permission(BashArgs(command=command))
+    else:
+        tool = ExperimentalBash(
+            config_getter=lambda: ExperimentalBashToolConfig(), state=BaseToolState()
+        )
+        result = tool.resolve_permission(ExperimentalBashArgs(command=command))
+
+    assert isinstance(result, PermissionContext)
+    assert result.permission is ToolPermission.ASK
+
+
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+def test_shell_permission_analysis_preserves_simple_allowlisted_commands(shell_kind):
+    if shell_kind == "legacy":
+        tool = Bash(config_getter=lambda: BashToolConfig(), state=BaseToolState())
+        result = tool.resolve_permission(BashArgs(command="git status"))
+    else:
+        tool = ExperimentalBash(
+            config_getter=lambda: ExperimentalBashToolConfig(), state=BaseToolState()
+        )
+        result = tool.resolve_permission(ExperimentalBashArgs(command="git status"))
+
+    assert isinstance(result, PermissionContext)
+    assert result.permission is ToolPermission.ALWAYS
+
+
+@pytest.mark.parametrize("shell_kind", ["legacy", "managed"])
+@pytest.mark.parametrize(
+    ("command", "expected_reason"),
+    [
+        ("echo $(id)", "command substitution"),
+        ("echo $HOME", "variable expansion"),
+        ("cat < input.txt", "redirection"),
+        ("(PATH=/tmp; git status)", "environment assignments, subshell"),
+        ("&&", "a syntax error"),
+    ],
+    ids=["substitution", "expansion", "redirection", "multiple", "parse-error"],
+)
+def test_shell_approval_prompt_names_the_offending_syntax(
+    shell_kind, command, expected_reason
+):
+    """The prompt must say which construct blocked auto-approval, not just that one did."""
+    if shell_kind == "legacy":
+        tool = Bash(config_getter=lambda: BashToolConfig(), state=BaseToolState())
+        result = tool.resolve_permission(BashArgs(command=command))
+    else:
+        tool = ExperimentalBash(
+            config_getter=lambda: ExperimentalBashToolConfig(), state=BaseToolState()
+        )
+        result = tool.resolve_permission(ExperimentalBashArgs(command=command))
+
+    assert isinstance(result, PermissionContext)
+    assert result.permission is ToolPermission.ASK
+    assert any(
+        required.label == f"shell syntax requiring approval: {expected_reason}"
+        for required in result.required_permissions
+    )
 
 
 def _force_windows_bash(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -813,7 +813,7 @@ wheels = [
 
 [[package]]
 name = "mistral-vibe"
-version = "2.25.3"
+version = "2.25.4"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },

--- a/vibe/__init__.py
+++ b/vibe/__init__.py
@@ -9,4 +9,4 @@ from pathlib import Path
 os.environ.setdefault("PYDANTIC_ERRORS_INCLUDE_URL", "0")
 
 VIBE_ROOT = Path(__file__).parent
-__version__ = "2.25.3"
+__version__ = "2.25.4"

--- a/vibe/acp/agent.py
+++ b/vibe/acp/agent.py
@@ -391,10 +391,14 @@ class VibeAcpAgent(AcpAgent):
         credentials_persister: CredentialsPersister | None = None,
         tenant_domain_resolver: TenantDomainResolver | None = None,
         environ_before_dotenv_load: Mapping[str, str] | None = None,
+        experimental_harness: bool = False,
+        legacy_harness: bool = False,
     ) -> None:
         self.sessions: dict[str, AcpSession] = {}
         self.client_capabilities: ClientCapabilities | None = None
         self.client_info: Implementation | None = None
+        self._experimental_harness = experimental_harness
+        self._legacy_harness = legacy_harness
         self._harness_host = LocalHarnessHost()
         self._start_session = session_starter or self._harness_host.start
         self._passive_host: AppServerHost | None = None
@@ -578,6 +582,8 @@ class VibeAcpAgent(AcpAgent):
                     ),
                     session=intent,
                     client_tool_handler=client_tool_handler,
+                    experimental_harness=self._experimental_harness,
+                    legacy_harness=self._legacy_harness,
                 )
             )
         except AppServerResponseError as exc:
@@ -1352,6 +1358,8 @@ class VibeAcpAgent(AcpAgent):
                     LocalHarnessOptions(
                         client=self._client_descriptor(),
                         session_options=SessionOptions(cwd=str(Path.cwd())),
+                        experimental_harness=self._experimental_harness,
+                        legacy_harness=self._legacy_harness,
                     )
                 )
         return self._passive_host
@@ -1659,9 +1667,16 @@ async def _serve_acp_agent(agent: VibeAcpAgent) -> None:
 
 
 def run_acp_server(
-    *, environ_before_dotenv_load: Mapping[str, str] | None = None
+    *,
+    environ_before_dotenv_load: Mapping[str, str] | None = None,
+    experimental_harness: bool = False,
+    legacy_harness: bool = False,
 ) -> None:
-    agent = VibeAcpAgent(environ_before_dotenv_load=environ_before_dotenv_load)
+    agent = VibeAcpAgent(
+        environ_before_dotenv_load=environ_before_dotenv_load,
+        experimental_harness=experimental_harness,
+        legacy_harness=legacy_harness,
+    )
     previous_sigterm_handler = signal.getsignal(signal.SIGTERM)
 
     def handle_sigterm(_signum: int, _frame: Any) -> None:

--- a/vibe/acp/entrypoint.py
+++ b/vibe/acp/entrypoint.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from vibe import __version__
+from vibe._experimental_harness import add_experimental_harness_argument
 from vibe.core.config.default_orchestrator import build_default_orchestrator
 from vibe.core.config.harness_files import init_harness_files_manager
 from vibe.core.paths import HISTORY_FILE, LOG_FILE
@@ -23,6 +24,8 @@ sys.stdin.reconfigure(line_buffering=True)  # pyright: ignore[reportAttributeAcc
 @dataclass
 class Arguments:
     setup: bool
+    experimental_harness: bool
+    legacy_harness: bool
 
 
 def parse_arguments() -> Arguments:
@@ -31,8 +34,20 @@ def parse_arguments() -> Arguments:
         "-v", "--version", action="version", version=f"%(prog)s {__version__}"
     )
     parser.add_argument("--setup", action="store_true", help="Setup API key and exit")
+    harness_group = parser.add_mutually_exclusive_group()
+    add_experimental_harness_argument(parser, group=harness_group)
+    harness_group.add_argument(
+        "--legacy-harness",
+        action="store_true",
+        default=False,
+        help="Force the legacy Python harness, overriding the GrowthBook rollout.",
+    )
     args = parser.parse_args()
-    return Arguments(setup=args.setup)
+    return Arguments(
+        setup=args.setup,
+        experimental_harness=args.experimental_harness,
+        legacy_harness=args.legacy_harness,
+    )
 
 
 def bootstrap_config_files() -> None:
@@ -94,7 +109,11 @@ def main() -> None:
         except Exception:
             pass  # error reporting disabled
 
-    run_acp_server(environ_before_dotenv_load=environ_before_dotenv_load)
+    run_acp_server(
+        environ_before_dotenv_load=environ_before_dotenv_load,
+        experimental_harness=args.experimental_harness,
+        legacy_harness=args.legacy_harness,
+    )
 
 
 if __name__ == "__main__":

--- a/vibe/acp/utils.py
+++ b/vibe/acp/utils.py
@@ -74,6 +74,10 @@ def build_mode_state(
     agents: list[AgentSummary], active: AgentSummary
 ) -> tuple[SessionModeState, SessionConfigOptionSelect]:
     primary = [agent for agent in agents if agent.agent_type is AgentType.AGENT]
+    # The current mode must stay in the advertised list even when the rollout
+    # gate hides it, so the client can label it and switch away.
+    if all(agent.name != active.name for agent in primary):
+        primary = [*primary, active]
     modes = [
         SessionMode(
             id=agent.name, name=agent.display_name, description=agent.description

--- a/vibe/app_server/_host.py
+++ b/vibe/app_server/_host.py
@@ -304,7 +304,7 @@ class HostRequestHandler:
         orchestrator = await self._load_orchestrator(None)
         agents = AgentManager(
             orchestrator,
-            orchestrator.config.default_agent,
+            orchestrator.config.resolve_default_agent(),
             harness_files=self._harness_files.for_session(self._cwd(None)),
         )
         active, available = project_unified_agent_summaries(
@@ -598,7 +598,13 @@ class HostRequestHandler:
         self, cwd: str | None
     ) -> ConfigOrchestrator[VibeConfigSchema]:
         session_files = self._harness_files.for_session(self._cwd(cwd))
-        return await build_default_orchestrator(harness_files=session_files)
+        orchestrator = await build_default_orchestrator(harness_files=session_files)
+        # Match the session path so host reads (agents/list) see rollout flags
+        # like smart_approve_available. Lazy import: _runtime imports _host.
+        from vibe.app_server._runtime import _apply_cached_experiment_variants
+
+        await _apply_cached_experiment_variants(orchestrator)
+        return orchestrator
 
     @staticmethod
     def _cwd(value: str | None) -> Path:

--- a/vibe/app_server/_runtime.py
+++ b/vibe/app_server/_runtime.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 import threading
 from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import urlsplit
 
 from pydantic import JsonValue, ValidationError
 
@@ -86,7 +87,7 @@ from vibe.core.experiments.manager import (
 from vibe.core.experiments.models import EvalResponse
 from vibe.core.hooks.config import load_hooks_file, load_hooks_from_fs
 from vibe.core.hooks.models import HookConfigResult
-from vibe.core.paths import VIBE_HOME, WORKTREES_DIR
+from vibe.core.paths import VIBE_HOME, WORKTREES_DIR, dedup_paths
 from vibe.core.session import last_session_pointer
 from vibe.core.session.session_id import extract_suffix, generate_session_id
 from vibe.core.session.session_index import warm_session_index
@@ -116,6 +117,7 @@ from vibe.utils.cache_store import FileSystemCacheStore
 from vibe.utils.http import get_server_url_from_api_base
 
 _SHORT_SESSION_ID_LENGTH = 8
+_PUBLIC_MISTRAL_API_ORIGIN = ("https", "api.mistral.ai", 443)
 type _CommandEnvironmentMode = Literal["unix", "git_bash", "powershell"]
 
 
@@ -125,6 +127,17 @@ def _command_environment_mode() -> _CommandEnvironmentMode:
     if get_windows_bash_path() is not None:
         return "git_bash"
     return "powershell"
+
+
+def _is_public_mistral_api(api_base: str) -> bool:
+    parsed = urlsplit(api_base)
+    try:
+        port = parsed.port
+    except ValueError:
+        return False
+    effective_port = 443 if port is None and parsed.scheme.lower() == "https" else port
+    origin = (parsed.scheme.lower(), (parsed.hostname or "").lower(), effective_port)
+    return origin == _PUBLIC_MISTRAL_API_ORIGIN
 
 
 def _build_unified_system_instructions(
@@ -168,7 +181,7 @@ def _build_launch_context_from_services(
 def _utility_credential_provider(config: VibeConfigSchema) -> ProviderConfig:
     """The provider a background title's credential resolves against.
 
-    Bound to the Mistral provider (the destination the title route targets)
+    Bound to the Mistral provider (the destination the fast title route targets)
     rather than re-running utility selection, so a vanished Mistral key surfaces
     as auth-required instead of resolving the active provider's key — which the
     route would then send to the Mistral endpoint. Raising here is turned into an
@@ -189,12 +202,10 @@ def _utility_provider_route(
 ) -> LocalProviderRoute | None:
     """A utility completion's provider destination, or None to reuse the session's.
 
-    Used by background title generation and the smart-approve classifier: both run
-    the fast Mistral model regardless of the session's active provider. The route
-    is set only when the caller enables it and the utility provider differs from
-    the session's active provider — so the utility call runs on the fast Mistral
-    model while the session runs elsewhere. Same-provider callers reuse the session
-    adapter and its credentials, so the route stays None.
+    Used by background title generation and the smart-approve classifier. The route
+    is set only when the caller enables it and the selected provider differs from
+    the session's active provider. Same-provider callers reuse the session adapter
+    and its credentials, so the route stays None.
     """
     if not enabled or provider_cfg.name == session_provider_name:
         return None
@@ -1162,9 +1173,14 @@ class HarnessProcess:
         harness_files = session_config.harness_files
         config = config_orchestrator.config
         cwd = Path(options.cwd or Path.cwd()).expanduser().resolve()
+        # The harness reads a non-empty root set as the complete one, so the cwd
+        # has to stay in it: ``--add-dir`` widens the workspace, never replaces it.
         workspace_roots = tuple(
-            Path(root).expanduser().resolve() for root in options.workspace_roots
-        ) or (cwd,)
+            dedup_paths([
+                cwd,
+                *(Path(root).expanduser() for root in options.workspace_roots),
+            ])
+        )
         plugins, plugin_provider, plugin_mcp = await self._build_plugins(
             session_config, cwd
         )
@@ -1184,12 +1200,12 @@ class HarnessProcess:
 
         # A second credential port for background title generation that may run on
         # the fast Mistral model even when the session's active provider differs.
-        # Bound to the Mistral provider — the one the title route targets — rather
-        # than re-running utility selection: if the Mistral key later disappears,
-        # this must surface as auth-required, not fall back to the active provider
-        # and send its key to the Mistral endpoint the route still points at. Same
-        # per-session lifetime as ``credentials`` so rejection memory survives
-        # derivations.
+        # Bound to the Mistral provider — the one the fast title route targets —
+        # rather than re-running utility selection: if the Mistral key later
+        # disappears, this must surface as auth-required, not fall back to the active
+        # provider and send its key to the Mistral endpoint the route still points
+        # at. Same per-session lifetime as ``credentials`` so rejection memory
+        # survives derivations.
         title_credentials = ProviderCredentialService(
             config_orchestrator, select_provider=_utility_credential_provider
         )
@@ -1295,12 +1311,20 @@ class HarnessProcess:
             config: VibeConfigSchema, settings: UnifiedSessionSettings
         ) -> UnifiedRuntimeDerivation:
             active_model = config.get_active_model()
+            provider = config.get_provider_for_model(active_model)
             compaction_model = config.get_compaction_model()
-            title_model_config, title_provider_cfg = select_utility_model(config)
+            title_model_config, utility_provider_cfg = select_utility_model(config)
+            title_provider_cfg = utility_provider_cfg
+            title_model_is_fast = is_fast_utility_model(config)
+            if title_model_is_fast and not _is_public_mistral_api(
+                utility_provider_cfg.api_base
+            ):
+                title_model_config = active_model
+                title_provider_cfg = provider
+                title_model_is_fast = False
             title_model = LocalModelRoute(
                 model=title_model_config.name, temperature=0.0, thinking="off"
             )
-            title_model_is_fast = is_fast_utility_model(config)
             # Match the legacy policy: only interactive terminal/desktop clients
             # get background titles; other clients keep the message preview.
             auto_title_enabled = (
@@ -1314,7 +1338,6 @@ class HarnessProcess:
                 if active_model.auto_compact_threshold > 0
                 else RustDisabledCompactionPolicy()
             )
-            provider = config.get_provider_for_model(active_model)
             derived_tools = ToolManager(
                 lambda: config, defer_mcp=True, cwd=cwd, harness_files=harness_files
             )
@@ -1433,7 +1456,7 @@ class HarnessProcess:
                     # route + credentials rather than the active model's. Set only
                     # under smart approve, when the classify gate actually runs.
                     classifier_provider=_utility_provider_route(
-                        title_provider_cfg,
+                        utility_provider_cfg,
                         session_provider_name=provider.name,
                         credentials=title_credentials,
                         enabled=smart_approve,

--- a/vibe/app_server/_unified_harness_backend_adapter.py
+++ b/vibe/app_server/_unified_harness_backend_adapter.py
@@ -4158,6 +4158,10 @@ class UnifiedHarnessBackendAdapter(  # noqa: PLR0904 - implements app-server ses
     def _cwd_path(self) -> Path:
         return Path(self.cwd or Path.cwd()).expanduser().resolve()
 
+    def _mention_roots(self) -> tuple[Path, ...]:
+        """The roots a mention may be inlined from, as the file tools see them."""
+        return tuple(self._adapter_config.workspace_roots)
+
     def _session_dir(self) -> Path:
         return Path(self._storage_root) / "unified" / self.session_id
 
@@ -4314,7 +4318,7 @@ class UnifiedHarnessBackendAdapter(  # noqa: PLR0904 - implements app-server ses
     ) -> ParamsT:
         text = _text_from_blocks(params.message)
         blocks = await mentioned_file_content_blocks_async(
-            text, base_dir=self._cwd_path()
+            text, base_dir=self._cwd_path(), workspace_roots=self._mention_roots()
         )
         if not blocks:
             return params
@@ -4336,7 +4340,7 @@ class UnifiedHarnessBackendAdapter(  # noqa: PLR0904 - implements app-server ses
         user_entry = params.entries[user_index]
         text = _text_from_session_blocks(user_entry.content)
         blocks = await mentioned_file_content_blocks_async(
-            text, base_dir=self._cwd_path()
+            text, base_dir=self._cwd_path(), workspace_roots=self._mention_roots()
         )
         if not blocks:
             return params
@@ -4356,7 +4360,7 @@ class UnifiedHarnessBackendAdapter(  # noqa: PLR0904 - implements app-server ses
     ) -> ContextInjectParams:
         text = _text_from_blocks(params.input)
         blocks = await mentioned_file_content_blocks_async(
-            text, base_dir=self._cwd_path()
+            text, base_dir=self._cwd_path(), workspace_roots=self._mention_roots()
         )
         if not blocks:
             return params

--- a/vibe/app_server/_unified_tool_projection.py
+++ b/vibe/app_server/_unified_tool_projection.py
@@ -919,12 +919,18 @@ def _completed_state(
     *,
     output_text: str | None = None,
 ) -> CompletedEffectState:
-    # Semantic projection rebuilds display from scratch, but cross-cutting
-    # advisories (smart approve's "Auto-approved: <reason>" note) ride in on the
-    # incoming effect's display.warnings. Carry them across so they still render.
+    # Semantic projection rebuilds display from scratch, so whatever rode in on
+    # the incoming effect has to be carried over. Sessions written before the
+    # note had its own field still keep it in `warnings`; carry those too rather
+    # than dropping the explanation when an old session is replayed.
     carried = [w for w in state.display.warnings if w not in display.warnings]
+    carry: dict[str, object] = {}
+    if state.display.approval_note is not None:
+        carry["approval_note"] = state.display.approval_note
     if carried:
-        display = display.model_copy(update={"warnings": [*display.warnings, *carried]})
+        carry["warnings"] = [*display.warnings, *carried]
+    if carry:
+        display = display.model_copy(update=carry)
     update: dict[str, object] = {
         "output": cast(
             JsonValue, output.model_dump(mode="json", by_alias=True, exclude_none=False)

--- a/vibe/app_server/_workspace.py
+++ b/vibe/app_server/_workspace.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import cast
 
@@ -161,10 +162,12 @@ def prepare_prompt_from_context(
 
 
 def mentioned_file_content_blocks(
-    message: str, *, base_dir: Path
+    message: str, *, base_dir: Path, workspace_roots: Sequence[Path] = ()
 ) -> list[ContentBlock]:
     blocks: list[ContentBlock] = []
-    for resource in _mentioned_file_resources(message, base_dir=base_dir):
+    for resource in _mentioned_file_resources(
+        message, base_dir=base_dir, workspace_roots=workspace_roots
+    ):
         try:
             result = read_lines_safe(
                 resource.path,
@@ -180,10 +183,12 @@ def mentioned_file_content_blocks(
 
 
 async def mentioned_file_content_blocks_async(
-    message: str, *, base_dir: Path
+    message: str, *, base_dir: Path, workspace_roots: Sequence[Path] = ()
 ) -> list[ContentBlock]:
     blocks: list[ContentBlock] = []
-    for resource in _mentioned_file_resources(message, base_dir=base_dir):
+    for resource in _mentioned_file_resources(
+        message, base_dir=base_dir, workspace_roots=workspace_roots
+    ):
         try:
             result = await read_lines_safe_async(
                 resource.path,
@@ -198,20 +203,40 @@ async def mentioned_file_content_blocks_async(
     return blocks
 
 
-def _mentioned_file_resources(message: str, *, base_dir: Path) -> list[PathResource]:
+def _mentioned_file_resources(
+    message: str, *, base_dir: Path, workspace_roots: Sequence[Path] = ()
+) -> list[PathResource]:
+    """The mentioned files inside the workspace roots, in mention order.
+
+    Inlining skips the read tool's prompt, so it keeps to those roots. A
+    mention outside them stays plain text for the read tool to ask about,
+    rather than failing the whole message.
+    """
     root = base_dir.expanduser().resolve()
+    roots = _attachable_roots(root, workspace_roots)
     payload = build_path_prompt_payload(message, base_dir=root)
-    resources = [resource for resource in payload.resources if resource.kind == "file"]
+    resources = [
+        resource
+        for resource in payload.resources
+        if resource.kind == "file" and _is_within_roots(resource.path, roots)
+    ]
     if len(resources) > _MENTIONED_FILE_MAX_FILES:
         raise PromptPreparationError(
             f"Too many file mentions: {_MENTIONED_FILE_MAX_FILES} maximum"
         )
-    for resource in resources:
-        if not resource.path.resolve().is_relative_to(root):
-            raise PromptPreparationError(
-                f"Cannot attach file outside the workspace: {resource.alias}"
-            )
     return resources
+
+
+def _attachable_roots(cwd: Path, workspace_roots: Sequence[Path]) -> tuple[Path, ...]:
+    roots = [root.expanduser().resolve() for root in workspace_roots]
+    if cwd not in roots:
+        roots.insert(0, cwd)
+    return tuple(roots)
+
+
+def _is_within_roots(path: Path, roots: Sequence[Path]) -> bool:
+    resolved = path.expanduser().resolve()
+    return any(resolved.is_relative_to(root) for root in roots)
 
 
 def _mentioned_file_content_block(

--- a/vibe/app_server/connector_catalog.py
+++ b/vibe/app_server/connector_catalog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import Counter
 from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
@@ -117,6 +118,11 @@ class ConnectorCatalogUnavailableError(ConnectorCatalogError):
 class ConnectorCatalogValidationError(ConnectorCatalogError):
     """The connector bootstrap payload violates the bounded catalog contract."""
 
+    def __init__(self, message: str, *, reason: str | None = None) -> None:
+        # Low-cardinality drop code; keeps ids/tool names (the message) out of logs.
+        super().__init__(message)
+        self.reason = reason
+
 
 @runtime_checkable
 class SessionConnectorCatalogBinding(Protocol):
@@ -155,15 +161,11 @@ class _BootstrapConnector(BaseModel):
     name: str | None = None
     protocol: str | None = None
     status: _BootstrapStatus = Field(default_factory=_BootstrapStatus)
-    tools: list[_BootstrapTool] = Field(default_factory=list)
+    # Tools stay raw so a single malformed tool never fails the whole connector;
+    # each one is parsed (and isolated) individually in _resolve_connector_tools.
+    tools: list[JsonValue] = Field(default_factory=list)
     auth_action: _BootstrapAuthAction | None = None
     bootstrap_errors: JsonValue = None
-
-
-class _BootstrapPayload(BaseModel):
-    model_config = ConfigDict(extra="ignore", frozen=True)
-
-    connectors: list[_BootstrapConnector] = Field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1497,50 +1499,35 @@ def _resolve_provider(config: VibeConfigSchema) -> _ConnectorProvider | None:
 def _resolve_catalog(
     payload: object, provider_fingerprint: str
 ) -> ResolvedConnectorCatalog:
-    try:
-        parsed = _BootstrapPayload.model_validate(payload)
-    except ValidationError as exc:
-        raise ConnectorCatalogValidationError(
-            "Connector bootstrap payload is malformed"
-        ) from exc
-    if len(parsed.connectors) > _MAX_CONNECTORS:
-        raise ConnectorCatalogValidationError(
-            f"Connector bootstrap exceeds {_MAX_CONNECTORS} connectors"
-        )
-
-    raw_ids: set[str] = set()
-    prepared_connectors: list[tuple[str, str, _BootstrapConnector]] = []
-    for raw_connector in parsed.connectors:
-        raw_id = (raw_connector.id or "").strip()
-        if not raw_id:
-            continue
-        if raw_id in raw_ids:
-            raise ConnectorCatalogValidationError(
-                "Connector bootstrap contains a duplicate connector ID"
-            )
-        raw_ids.add(raw_id)
-        if len(raw_connector.tools) > _MAX_TOOLS_PER_CONNECTOR:
-            raise ConnectorCatalogValidationError(
-                f"Connector {raw_id!r} exceeds {_MAX_TOOLS_PER_CONNECTOR} tools"
-            )
-        display_name = (raw_connector.name or raw_id).strip() or raw_id
-        prepared_connectors.append((raw_id, display_name, raw_connector))
+    # Structurally valid, id-sorted connectors. Only a broken envelope is fatal;
+    # malformed items and duplicate ids are isolated so healthy siblings survive.
+    ordered_connectors = _prepare_bootstrap_connectors(payload)
 
     aliases: set[str] = set()
     connectors: list[ResolvedConnector] = []
-    for raw_id, display_name, raw_connector in sorted(
-        prepared_connectors, key=lambda item: item[0]
-    ):
+    truncated = False
+    for raw_id, display_name, raw_connector in ordered_connectors:
+        # Reserve the alias for every structurally valid connector in id order so
+        # dropping one below (bad tools, over cap) never shifts a sibling's alias.
         alias = _unique_alias(normalize_connector_alias(display_name), aliases)
-        tools = tuple(
-            _resolve_tool(tool, raw_id=raw_id) for tool in raw_connector.tools
-        )
-        tool_names = [tool.raw_name for tool in tools]
-        if len(tool_names) != len(set(tool_names)):
-            raise ConnectorCatalogValidationError(
-                f"Connector {raw_id!r} contains duplicate tool names"
+        # Count only kept connectors against the cap so invalid rows never crowd
+        # out a healthy tail; excess healthy connectors are truncated, not the
+        # ones that happen to sort first.
+        if len(connectors) >= _MAX_CONNECTORS:
+            truncated = True
+            continue
+        try:
+            tools = _resolve_connector_tools(raw_connector, raw_id=raw_id)
+        except ConnectorCatalogValidationError as exc:
+            logger.warning(
+                "Dropping connector that violates the bounded catalog contract",
+                extra={
+                    "connector_operation": "bootstrap",
+                    "connector_outcome": "invalid",
+                    "connector_drop_reason": exc.reason or "invalid",
+                },
             )
-        tools = tuple(sorted(tools, key=lambda tool: tool.raw_name))
+            continue
         connectors.append(
             ResolvedConnector(
                 raw_id=raw_id,
@@ -1551,6 +1538,17 @@ def _resolve_catalog(
                 tools=tools,
                 diagnostics=_bounded_diagnostics(raw_connector.bootstrap_errors),
             )
+        )
+
+    if truncated:
+        logger.warning(
+            "Truncating connector catalog to the bounded maximum",
+            extra={
+                "connector_operation": "bootstrap",
+                "connector_drop_reason": "catalog_truncated",
+                "connector_total": len(ordered_connectors),
+                "connector_limit": _MAX_CONNECTORS,
+            },
         )
 
     revision_payload = [_connector_revision_payload(item) for item in connectors]
@@ -1567,15 +1565,121 @@ def _resolve_catalog(
     return catalog
 
 
+def _prepare_bootstrap_connectors(
+    payload: object,
+) -> list[tuple[str, str, _BootstrapConnector]]:
+    """Parse each connector individually and drop the ones we cannot trust.
+
+    Only a structurally broken envelope (not a mapping, or ``connectors`` not a
+    list) is fatal. Malformed connector items are dropped, and every copy of a
+    duplicated id is dropped since its identity is ambiguous. Returns id-sorted
+    ``(raw_id, display_name, connector)`` triples for the structurally valid rows.
+    """
+    if not isinstance(payload, Mapping):
+        raise ConnectorCatalogValidationError(
+            "Connector bootstrap payload is malformed"
+        )
+    raw_items = payload.get("connectors")
+    if raw_items is None:
+        return []
+    if not isinstance(raw_items, list):
+        raise ConnectorCatalogValidationError(
+            "Connector bootstrap payload is malformed"
+        )
+
+    parsed: list[_BootstrapConnector] = []
+    malformed = 0
+    for raw_item in raw_items:
+        try:
+            parsed.append(_BootstrapConnector.model_validate(raw_item))
+        except ValidationError:
+            malformed += 1
+    if malformed:
+        logger.warning(
+            "Dropping connectors with a malformed bootstrap payload",
+            extra={
+                "connector_operation": "bootstrap",
+                "connector_drop_reason": "malformed_connector",
+                "connector_dropped": malformed,
+            },
+        )
+
+    id_counts = Counter(raw_id for c in parsed if (raw_id := (c.id or "").strip()))
+    duplicate_ids = {raw_id for raw_id, count in id_counts.items() if count > 1}
+    if duplicate_ids:
+        logger.warning(
+            "Dropping connectors that share a duplicate id",
+            extra={
+                "connector_operation": "bootstrap",
+                "connector_drop_reason": "duplicate_connector_id",
+                "connector_dropped": len(duplicate_ids),
+            },
+        )
+
+    prepared: list[tuple[str, str, _BootstrapConnector]] = []
+    for connector in parsed:
+        raw_id = (connector.id or "").strip()
+        if not raw_id or raw_id in duplicate_ids:
+            continue
+        display_name = (connector.name or raw_id).strip() or raw_id
+        prepared.append((raw_id, display_name, connector))
+    prepared.sort(key=lambda item: item[0])
+    return prepared
+
+
+def _resolve_connector_tools(
+    raw_connector: _BootstrapConnector, *, raw_id: str
+) -> tuple[ResolvedConnectorTool, ...]:
+    """Resolve one connector's tools, raising on per-connector contract breaches."""
+    if len(raw_connector.tools) > _MAX_TOOLS_PER_CONNECTOR:
+        raise ConnectorCatalogValidationError(
+            f"Connector {raw_id!r} exceeds {_MAX_TOOLS_PER_CONNECTOR} tools",
+            reason="too_many_tools",
+        )
+    # Drop a single unusable tool (malformed wire, oversized schema, missing name)
+    # on its own so the connector keeps its remaining tools.
+    resolved: list[ResolvedConnectorTool] = []
+    drop_counts: Counter[str] = Counter()
+    for raw_tool in raw_connector.tools:
+        try:
+            resolved.append(
+                _resolve_tool(_BootstrapTool.model_validate(raw_tool), raw_id=raw_id)
+            )
+        except ValidationError:
+            drop_counts["malformed_tool"] += 1
+        except ConnectorCatalogValidationError as exc:
+            drop_counts[exc.reason or "invalid"] += 1
+    if drop_counts:
+        # One summary per connector instead of one line per tool, so a connector
+        # shipping many unusable tools cannot flood the logs.
+        logger.warning(
+            "Dropping connector tools that violate the bounded contract",
+            extra={
+                "connector_operation": "bootstrap",
+                "connector_drop_reason": "tools_dropped",
+                "connector_tool_drop_counts": dict(drop_counts),
+            },
+        )
+    tool_names = [tool.raw_name for tool in resolved]
+    if len(tool_names) != len(set(tool_names)):
+        raise ConnectorCatalogValidationError(
+            f"Connector {raw_id!r} contains duplicate tool names",
+            reason="duplicate_tool_names",
+        )
+    return tuple(sorted(resolved, key=lambda tool: tool.raw_name))
+
+
 def _resolve_tool(tool: _BootstrapTool, *, raw_id: str) -> ResolvedConnectorTool:
     name = tool.name.strip()
     if not name:
         raise ConnectorCatalogValidationError(
-            f"Connector {raw_id!r} contains a tool without a name"
+            f"Connector {raw_id!r} contains a tool without a name",
+            reason="unnamed_tool",
         )
     if _json_size(tool.input_schema) > _MAX_INPUT_SCHEMA_BYTES:
         raise ConnectorCatalogValidationError(
-            f"Connector tool {name!r} input schema exceeds 64 KiB"
+            f"Connector tool {name!r} input schema exceeds 64 KiB",
+            reason="oversized_tool_schema",
         )
     return ResolvedConnectorTool(
         raw_name=name,

--- a/vibe/cli/textual_ui/app.tcss
+++ b/vibe/cli/textual_ui/app.tcss
@@ -1067,6 +1067,10 @@ StatusMessage {
     color: $warning;
 }
 
+.tool-result-approval-note {
+    color: $text-muted;
+}
+
 .diff-scroll {
     width: 1fr;
     height: auto;

--- a/vibe/cli/textual_ui/widgets/tool_widgets.py
+++ b/vibe/cli/textual_ui/widgets/tool_widgets.py
@@ -152,12 +152,14 @@ class ToolResultWidget[TResult: BaseModel](Static):
         success: bool,
         message: str,
         warnings: list[str] | None = None,
+        approval_note: str | None = None,
     ) -> None:
         super().__init__()
         self.result = result
         self.success = success
         self.message = message
         self.warnings = warnings or []
+        self.approval_note = approval_note
         self.border_row_colors: dict[int, str] = {}
         self.add_class("tool-result-widget")
 
@@ -165,11 +167,21 @@ class ToolResultWidget[TResult: BaseModel](Static):
         if extra:
             yield NoMarkupStatic(extra, classes="tool-result-hint")
 
-    def _yield_warnings(self) -> Iterable[Widget]:
-        # Approval notes (e.g. smart approve's "Auto-approved: <reason>") and other
-        # per-result advisories, shown at the top of the unfolded body.
-        for warning in self.warnings:
-            yield NoMarkupStatic(f"⚠ {warning}", classes="tool-result-warning")
+    def _advisories(self) -> list[tuple[str, str]]:
+        # Shown at the top of the unfolded body, as (text, css class). The
+        # approval note says the call was allowed to run, so it must not carry
+        # the warning glyph.
+        advisories: list[tuple[str, str]] = []
+        if self.approval_note:
+            advisories.append((self.approval_note, "tool-result-approval-note"))
+        advisories.extend(
+            (f"⚠ {warning}", "tool-result-warning") for warning in self.warnings
+        )
+        return advisories
+
+    def _yield_advisories(self) -> Iterable[Widget]:
+        for text, classes in self._advisories():
+            yield NoMarkupStatic(text, classes=classes)
 
     def _yield_text(
         self, content: str, *, classes: str = "tool-result-detail"
@@ -185,7 +197,7 @@ class ToolResultWidget[TResult: BaseModel](Static):
             yield Markdown(_fenced_code_block(content.strip("\n"), ext))
 
     def compose(self) -> ComposeResult:
-        yield from self._yield_warnings()
+        yield from self._yield_advisories()
         if self.result:
             lines = [
                 f"{field_name}: {value}"
@@ -200,7 +212,7 @@ class ToolResultWidget[TResult: BaseModel](Static):
 
 class GenericToolResultWidget(ToolResultWidget[GenericToolData]):
     def compose(self) -> ComposeResult:
-        yield from self._yield_warnings()
+        yield from self._yield_advisories()
         if self.result and (text := _format_generic_result(self.result.data)):
             yield from self._yield_text(text)
         yield from self._footer()
@@ -327,7 +339,7 @@ class BashResultWidget(ToolResultWidget[ShellOutput]):
         return self.result.transcript.strip("\n") if self.result else ""
 
     def compose(self) -> ComposeResult:
-        yield from self._yield_warnings()
+        yield from self._yield_advisories()
         if not self.result:
             yield from self._footer()
             return
@@ -358,7 +370,7 @@ class WriteFileResultWidget(ToolResultWidget[FileWriteOutput]):
     COLLAPSIBLE = False
 
     def compose(self) -> ComposeResult:
-        yield from self._yield_warnings()
+        yield from self._yield_advisories()
         if not self.result:
             yield from self._footer()
             return
@@ -457,8 +469,9 @@ class EditResultWidget(ToolResultWidget[FileEditOutput]):
         success: bool,
         message: str,
         warnings: list[str] | None = None,
+        approval_note: str | None = None,
     ) -> None:
-        super().__init__(result, success, message, warnings)
+        super().__init__(result, success, message, warnings, approval_note)
         self._diff_view = DiffView([], ansi=False, dark=True)
         self._requested_render_theme: tuple[bool, bool] | None = None
         self._render_worker: Worker[None] | None = None
@@ -480,16 +493,14 @@ class EditResultWidget(ToolResultWidget[FileEditOutput]):
         if not self.result:
             yield from self._footer()
             return
-        warnings = [
-            NoMarkupStatic(f"⚠ {w}", classes="tool-result-warning")
-            for w in self.warnings
-        ]
         # Wrap the diff in a horizontal-scroll container so wide lines can be
         # scrolled instead of clipped (overflow-x is `auto`, so the scrollbar
         # only shows when a line overruns the width). For a diff taller than the
         # viewport the bar sits at the bottom -- the same trade-off write_file's
         # code fence makes -- but that beats silently truncating long lines.
-        yield Vertical(*warnings, self._diff_view, classes="diff-scroll")
+        yield Vertical(
+            *self._yield_advisories(), self._diff_view, classes="diff-scroll"
+        )
         yield from self._footer()
 
     def on_mount(self) -> None:
@@ -524,10 +535,11 @@ class EditResultWidget(ToolResultWidget[FileEditOutput]):
             if rendered_theme != self._requested_render_theme:
                 continue
             self._diff_view.set_render_data(lines, ansi=ansi, dark=dark)
-            # Border rows sit below the warning lines, so shift the diff's own row
-            # colors down by the number of warnings.
+            # Border rows sit below the advisory lines, so shift the diff's own
+            # row colors down by however many were rendered.
+            advisory_count = len(self._advisories())
             self.border_row_colors = {
-                len(self.warnings) + row: color
+                advisory_count + row: color
                 for row, color in self._diff_view.border_row_colors.items()
             }
             self.post_message(self.BorderColorsChanged(self))
@@ -595,8 +607,7 @@ class ReadResultWidget(ToolResultWidget[FileReadOutput]):
         if not self.result:
             yield from self._footer()
             return
-        for warning in self.warnings:
-            yield NoMarkupStatic(f"⚠ {warning}", classes="tool-result-warning")
+        yield from self._yield_advisories()
         if self.result.content:
             ext = Path(self.result.file_path).suffix.lstrip(".") or "text"
             yield from self._yield_markdown(
@@ -619,8 +630,7 @@ class GrepApprovalWidget(ToolApprovalWidget[FileSearchInput]):
 
 class GrepResultWidget(ToolResultWidget[FileSearchOutput]):
     def compose(self) -> ComposeResult:
-        for warning in self.warnings:
-            yield NoMarkupStatic(f"⚠ {warning}", classes="tool-result-warning")
+        yield from self._yield_advisories()
         if not self.result or not self.result.matches:
             yield from self._footer()
             return
@@ -735,6 +745,7 @@ def get_result_widget(
     success: bool,
     message: str,
     warnings: list[str] | None = None,
+    approval_note: str | None = None,
 ) -> ToolResultWidget:
     widgets = EFFECT_WIDGETS.get(detail.kind, EffectWidgets())
     if result is None:
@@ -743,7 +754,7 @@ def get_result_widget(
         parsed = widgets.output_model.model_validate(result)
     else:
         parsed = GenericToolData(data=result)
-    return widgets.result(parsed, success, message, warnings)
+    return widgets.result(parsed, success, message, warnings, approval_note)
 
 
 def linkify_effect_result(detail: EffectDetail) -> bool:

--- a/vibe/cli/textual_ui/widgets/tools.py
+++ b/vibe/cli/textual_ui/widgets/tools.py
@@ -711,6 +711,7 @@ class ToolResultMessage(ClickWithoutDragMixin, Static):
                     success=display.success,
                     message=display.message,
                     warnings=display.warnings,
+                    approval_note=display.approval_note,
                 )
                 self._result_widget = widget
             return Horizontal(
@@ -720,8 +721,13 @@ class ToolResultMessage(ClickWithoutDragMixin, Static):
             )
 
         # The header is inert only when there is genuinely nothing to unfold: no
-        # structured output, no fallback text, and no warnings.
-        has_body = not (output is None and not fallback_text and not display.warnings)
+        # structured output, no fallback text, and no advisories.
+        has_body = not (
+            output is None
+            and not fallback_text
+            and not display.warnings
+            and display.approval_note is None
+        )
         is_failure = not display.success
         section = HeaderCollapsibleSection(
             build_result_body,
@@ -805,6 +811,7 @@ class ToolResultMessage(ClickWithoutDragMixin, Static):
             success=display.success,
             message=display.message,
             warnings=display.warnings,
+            approval_note=display.approval_note,
         )
         await self._content_container.mount(widget)
         self._result_widget = widget

--- a/vibe/core/tools/builtins/_shell_command_policy.py
+++ b/vibe/core/tools/builtins/_shell_command_policy.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ShellCommandPolicy:
+    requires_approval: bool = False
+    inspect_positional_paths: bool = False
+    option_path_values: tuple[str, ...] = ()
+
+
+def _matches_long_option(token: str, option: str) -> bool:
+    option_token = token.partition("=")[0]
+    return option_token == option or (
+        option_token.startswith("--")
+        and option_token != "--"
+        and option.startswith(option_token)
+    )
+
+
+def _contains_short_option(
+    token: str, options: frozenset[str], *, preceding_value_options: frozenset[str]
+) -> bool:
+    if not token.startswith("-") or token.startswith("--"):
+        return False
+    for option in token[1:]:
+        if option in options:
+            return True
+        if option in preceding_value_options:
+            return False
+    return False
+
+
+def _long_option_values(args: list[str], options: frozenset[str]) -> tuple[str, ...]:
+    option_tokens = _option_tokens(args)
+    values: list[str] = []
+    for index, token in enumerate(option_tokens):
+        _, separator, attached_value = token.partition("=")
+        if not any(_matches_long_option(token, option) for option in options):
+            continue
+        if separator and attached_value:
+            values.append(attached_value)
+        elif not separator and index + 1 < len(option_tokens):
+            values.append(option_tokens[index + 1])
+    return tuple(values)
+
+
+def _short_option_values(
+    args: list[str], options: frozenset[str], *, preceding_value_options: frozenset[str]
+) -> tuple[str, ...]:
+    option_tokens = _option_tokens(args)
+    values: list[str] = []
+    for token_index, token in enumerate(option_tokens):
+        if not token.startswith("-") or token.startswith("--"):
+            continue
+        for option_index, option in enumerate(token[1:]):
+            if option in options:
+                attached_value = token[option_index + 2 :]
+                if attached_value:
+                    values.append(attached_value)
+                elif token_index + 1 < len(option_tokens):
+                    values.append(option_tokens[token_index + 1])
+                break
+            if option in preceding_value_options:
+                break
+    return tuple(values)
+
+
+def _option_tokens(args: list[str]) -> tuple[str, ...]:
+    try:
+        end = args.index("--")
+    except ValueError:
+        return tuple(args)
+    return tuple(args[:end])
+
+
+def _sort_policy(args: list[str]) -> ShellCommandPolicy:
+    options = _option_tokens(args)
+    side_effecting_long = {"--compress-program", "--output", "--temporary-directory"}
+    requires_approval = any(
+        any(_matches_long_option(token, option) for option in side_effecting_long)
+        or _contains_short_option(
+            token,
+            frozenset({"o", "T"}),
+            preceding_value_options=frozenset({"k", "S", "t"}),
+        )
+        for token in options
+    )
+    return ShellCommandPolicy(
+        requires_approval=requires_approval,
+        option_path_values=_long_option_values(args, frozenset({"--random-source"})),
+    )
+
+
+def _grep_policy(args: list[str]) -> ShellCommandPolicy:
+    return ShellCommandPolicy(
+        option_path_values=(
+            *_long_option_values(args, frozenset({"--file"})),
+            *_short_option_values(
+                args,
+                frozenset({"f"}),
+                preceding_value_options=frozenset({"A", "B", "C", "D", "d", "e", "m"}),
+            ),
+        )
+    )
+
+
+def _file_policy(args: list[str]) -> ShellCommandPolicy:
+    files_from = (
+        *_long_option_values(args, frozenset({"--files-from"})),
+        *_short_option_values(
+            args, frozenset({"f"}), preceding_value_options=frozenset({"e", "F", "P"})
+        ),
+    )
+    magic_files = (
+        *_long_option_values(args, frozenset({"--magic-file"})),
+        *_short_option_values(
+            args, frozenset({"m"}), preceding_value_options=frozenset({"e", "F", "P"})
+        ),
+    )
+    return ShellCommandPolicy(
+        option_path_values=files_from
+        + tuple(path for value in magic_files for path in value.split(":"))
+    )
+
+
+def _files0_from_policy(args: list[str]) -> ShellCommandPolicy:
+    return ShellCommandPolicy(
+        option_path_values=_long_option_values(args, frozenset({"--files0-from"}))
+    )
+
+
+def _date_policy(args: list[str]) -> ShellCommandPolicy:
+    # --set/-s writes the system clock. -I takes an optional attached value, so it
+    # terminates a short cluster and keeps `date -Iseconds` out of the -s match.
+    requires_approval = any(
+        _matches_long_option(token, "--set")
+        or _contains_short_option(
+            token,
+            frozenset({"s"}),
+            preceding_value_options=frozenset({"d", "f", "I", "r"}),
+        )
+        for token in _option_tokens(args)
+    )
+    return ShellCommandPolicy(
+        requires_approval=requires_approval,
+        option_path_values=(
+            *_long_option_values(args, frozenset({"--file"})),
+            *_short_option_values(
+                args, frozenset({"f"}), preceding_value_options=frozenset({"d", "s"})
+            ),
+        ),
+    )
+
+
+def _diff_policy(args: list[str]) -> ShellCommandPolicy:
+    return ShellCommandPolicy(
+        option_path_values=_long_option_values(
+            args, frozenset({"--from-file", "--to-file"})
+        )
+    )
+
+
+def _find_policy(args: list[str]) -> ShellCommandPolicy:
+    side_effecting_predicates = {
+        "-delete",
+        "-exec",
+        "-execdir",
+        "-fls",
+        "-fprint",
+        "-fprintf",
+        "-fprint0",
+        "-ok",
+        "-okdir",
+    }
+    return ShellCommandPolicy(
+        requires_approval=any(
+            token in side_effecting_predicates for token in _option_tokens(args)
+        )
+    )
+
+
+def _less_policy(args: list[str]) -> ShellCommandPolicy:
+    requires_approval = any(
+        _matches_long_option(token, "--log-file")
+        or _matches_long_option(token, "--LOG-FILE")
+        or _contains_short_option(
+            token,
+            frozenset({"o", "O"}),
+            preceding_value_options=frozenset("DbhjkpPtTxyz"),
+        )
+        for token in _option_tokens(args)
+    )
+    return ShellCommandPolicy(requires_approval=requires_approval)
+
+
+def _tree_policy(args: list[str]) -> ShellCommandPolicy:
+    requires_approval = any(
+        _matches_long_option(token, "--output")
+        or _contains_short_option(
+            token,
+            frozenset({"o"}),
+            preceding_value_options=frozenset({"H", "I", "L", "P", "T", "X"}),
+        )
+        for token in _option_tokens(args)
+    )
+    return ShellCommandPolicy(
+        requires_approval=requires_approval, inspect_positional_paths=True
+    )
+
+
+def _git_policy(args: list[str]) -> ShellCommandPolicy:
+    if not args or args[0] not in {"diff", "log"}:
+        return ShellCommandPolicy()
+    subcommand = args[0]
+    subcommand_args = args[1:]
+    options = _option_tokens(subcommand_args)
+    requires_approval = any(
+        _matches_long_option(token, "--output") or token in {"--ext-diff", "--textconv"}
+        for token in options
+    )
+    return ShellCommandPolicy(
+        requires_approval=requires_approval,
+        inspect_positional_paths=(subcommand == "diff" and "--no-index" in options),
+    )
+
+
+_COMMAND_POLICIES = {
+    "date": _date_policy,
+    "diff": _diff_policy,
+    "du": _files0_from_policy,
+    "file": _file_policy,
+    "find": _find_policy,
+    "git": _git_policy,
+    "grep": _grep_policy,
+    "less": _less_policy,
+    "sort": _sort_policy,
+    "tree": _tree_policy,
+    "wc": _files0_from_policy,
+}
+
+
+def analyze_shell_command_policy(tokens: list[str]) -> ShellCommandPolicy:
+    """Describe option semantics that are unsafe to infer from token shape alone."""
+    if not tokens:
+        return ShellCommandPolicy()
+    command = tokens[0].rsplit("/", 1)[-1]
+    policy = _COMMAND_POLICIES.get(command)
+    return policy(tokens[1:]) if policy else ShellCommandPolicy()
+
+
+def path_candidates(
+    tokens: list[str], *, inspect_positional_paths: bool
+) -> tuple[str, ...]:
+    """Return operands and known option values that may name filesystem paths."""
+    if not tokens:
+        return ()
+
+    policy = analyze_shell_command_policy(tokens)
+    candidates = list(policy.option_path_values)
+    if not (inspect_positional_paths or policy.inspect_positional_paths):
+        return tuple(candidates)
+
+    command = tokens[0].rsplit("/", 1)[-1]
+    options_ended = False
+    for token in tokens[1:]:
+        if token == "--":
+            options_ended = True
+            continue
+        if not options_ended and token.startswith("-"):
+            continue
+        if command == "chmod" and token.startswith("+"):
+            continue
+        candidates.append(token)
+    return tuple(candidates)

--- a/vibe/core/tools/builtins/_shell_permission_analysis.py
+++ b/vibe/core/tools/builtins/_shell_permission_analysis.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+
+from tree_sitter import Language, Node, Parser
+import tree_sitter_bash as tsbash
+
+_SUPPORTED_COMMAND_PARTS = {
+    "command_name",
+    "number",
+    "word",
+    "string",
+    "raw_string",
+    "concatenation",
+}
+
+_REDIRECTION_NODES = {
+    "file_redirect",
+    "heredoc_redirect",
+    "herestring_redirect",
+    "redirected_statement",
+}
+
+# Reasons are noun phrases so they read as a list in the approval prompt.
+_DYNAMIC_NODES = {
+    "ansi_c_string": "ANSI-C quoted arguments",
+    "arithmetic_expansion": "arithmetic expansion",
+    "brace_expression": "brace expansion",
+    "command_substitution": "command substitution",
+    "expansion": "parameter expansion",
+    "process_substitution": "process substitution",
+    "simple_expansion": "variable expansion",
+    "variable_assignment": "environment assignments",
+}
+
+_COMPOUND_NODES = {
+    "case_statement": "case statement",
+    "compound_statement": "command group",
+    "c_style_for_statement": "for loop",
+    "for_statement": "for loop",
+    "function_definition": "function definition",
+    "if_statement": "if statement",
+    "subshell": "subshell",
+    "test_command": "test expression",
+    "while_statement": "while loop",
+}
+
+
+def _zsh_sensitive_word_reason(value: bytes) -> str | None:
+    """Name Zsh word expansions that the Bash grammar treats as literals."""
+    if value.startswith(b"="):
+        return "Zsh equals expansion"
+    if b"==" in value:
+        return "Zsh magic-equals expansion"
+    if value.startswith(b"~") and not (value == b"~" or value.startswith(b"~/")):
+        return "shell-specific named-directory expansion"
+    if b"***" in value:
+        return "Zsh symlink-following glob"
+    return None
+
+
+def _zsh_sensitive_node_reason(node: Node) -> str | None:
+    if node.type not in {"command_name", "word"} or node.text is None:
+        return None
+    return _zsh_sensitive_word_reason(node.text)
+
+
+def _supported_command_part(node: Node) -> str | None:
+    if node.type not in _SUPPORTED_COMMAND_PARTS or node.text is None:
+        return None
+    if _zsh_sensitive_node_reason(node):
+        return None
+    return node.text.decode("utf-8")
+
+
+def _node_approval_reason(node: Node) -> str | None:
+    if node.type in _REDIRECTION_NODES:
+        return "redirection"
+    if reason := _DYNAMIC_NODES.get(node.type):
+        return reason
+    if reason := _zsh_sensitive_node_reason(node):
+        return reason
+    if node.type == "concatenation" and any(
+        child.type == "word" and child.text in {b"{", b"}"} for child in node.children
+    ):
+        return "brace expansion"
+    if compound := _COMPOUND_NODES.get(node.type):
+        return compound
+    return "background execution" if node.type == "&" else None
+
+
+@dataclass(frozen=True)
+class ShellPermissionAnalysis:
+    command_parts: tuple[str, ...]
+    approval_reasons: tuple[str, ...]
+
+    @property
+    def requires_approval(self) -> bool:
+        return bool(self.approval_reasons)
+
+    @property
+    def approval_label(self) -> str:
+        """Prompt text naming what made the command unsafe to auto-approve."""
+        return f"shell syntax requiring approval: {', '.join(self.approval_reasons)}"
+
+
+@lru_cache(maxsize=1)
+def _get_parser() -> Parser:
+    return Parser(Language(tsbash.language()))
+
+
+def analyze_shell_command(command: str) -> ShellPermissionAnalysis:
+    """Extract commands and fail closed on syntax the policy cannot model."""
+    tree = _get_parser().parse(command.encode("utf-8"))
+    commands: list[str] = []
+    approval_reasons: set[str] = set()
+
+    if tree.root_node.has_error:
+        approval_reasons.add("a syntax error")
+
+    def find_commands(node: Node) -> None:
+        if reason := _node_approval_reason(node):
+            approval_reasons.add(reason)
+
+        if node.type == "command":
+            parts: list[str] = []
+            for child in node.children:
+                if part := _supported_command_part(child):
+                    parts.append(part)
+                elif child.type == "ansi_c_string":
+                    # Preserve the token for guardrails such as find's execution
+                    # predicate while requiring approval because shlex does not
+                    # decode Bash ANSI-C quoting.
+                    if child.text is not None:
+                        parts.append(child.text.decode("utf-8"))
+                elif child.type == "variable_assignment":
+                    pass
+                elif (
+                    child.type not in _DYNAMIC_NODES
+                    and not _zsh_sensitive_node_reason(child)
+                ):
+                    # The executor receives the original shell string. If policy
+                    # extraction omits a semantic command child, the two views can
+                    # differ, so the command must not be auto-approved. The node
+                    # type is kept in the reason so an unexpected construct is
+                    # identifiable from the approval prompt alone. Children already
+                    # named by _DYNAMIC_NODES are skipped here because the walk
+                    # records their specific reason when it recurses into them.
+                    approval_reasons.add(f"unsupported syntax ({child.type})")
+
+            # A redirect is a sibling of the command under redirected_statement.
+            # Keep the marker so standalone-command denylist behavior stays intact.
+            if parts and node.parent and node.parent.type == "redirected_statement":
+                parts.append("<redirect>")
+            if parts:
+                commands.append(" ".join(parts))
+
+        for child in node.children:
+            find_commands(child)
+
+    find_commands(tree.root_node)
+    return ShellPermissionAnalysis(
+        command_parts=tuple(commands), approval_reasons=tuple(sorted(approval_reasons))
+    )

--- a/vibe/core/tools/builtins/bash.py
+++ b/vibe/core/tools/builtins/bash.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
-from functools import lru_cache
 from pathlib import Path
 import shlex
 from typing import ClassVar, final
 
 from pydantic import BaseModel, Field, computed_field
-from tree_sitter import Language, Node, Parser
-import tree_sitter_bash as tsbash
 
 from vibe.core.scratchpad import is_scratchpad_path
 from vibe.core.tools.arity import build_session_pattern
@@ -21,6 +18,11 @@ from vibe.core.tools.base import (
     ToolError,
     ToolPermission,
 )
+from vibe.core.tools.builtins._shell_command_policy import (
+    analyze_shell_command_policy,
+    path_candidates,
+)
+from vibe.core.tools.builtins._shell_permission_analysis import analyze_shell_command
 from vibe.core.tools.io_port import ShellCommandRequest
 from vibe.core.tools.permissions import (
     PermissionContext,
@@ -42,42 +44,8 @@ from vibe.utils.paths import normalize_windows_path
 from vibe.utils.tool_presentation import ToolEffectKind
 
 
-@lru_cache(maxsize=1)
-def _get_parser() -> Parser:
-    return Parser(Language(tsbash.language()))
-
-
 def _extract_commands(command: str) -> list[str]:
-    parser = _get_parser()
-    tree = parser.parse(command.encode("utf-8"))
-
-    commands: list[str] = []
-
-    def find_commands(node: Node) -> None:
-        if node.type == "command":
-            parts = []
-            for child in node.children:
-                if (
-                    child.type
-                    in {"command_name", "word", "string", "raw_string", "concatenation"}
-                    and child.text is not None
-                ):
-                    parts.append(child.text.decode("utf-8"))
-            # When a command has a heredoc (or other redirect), tree-sitter
-            # wraps it in a redirected_statement and the redirect is a sibling
-            # of the command node, not a child.  Without this check,
-            # `python3 << 'EOF'` is extracted as bare `python3` and
-            # incorrectly blocked by the standalone denylist.
-            if parts and node.parent and node.parent.type == "redirected_statement":
-                parts.append("<redirect>")
-            if parts:
-                commands.append(" ".join(parts))
-
-        for child in node.children:
-            find_commands(child)
-
-    find_commands(tree.root_node)
-    return commands
+    return list(analyze_shell_command(command).command_parts)
 
 
 _READ_ONLY_COMMANDS_WINDOWS = ["dir", "findstr", "more", "type", "ver", "where"]
@@ -173,8 +141,6 @@ _MUTATING_PATH_COMMANDS = {"cd", "chmod", "chown", "cp", "mkdir", "mv", "rm", "t
 # OUTSIDE_DIRECTORY permission.
 _PATH_COMMANDS = _MUTATING_PATH_COMMANDS | set(_READ_ONLY_COMMANDS_POSIX)
 
-_FIND_EXECUTION_PREDICATES = {"-exec", "-execdir", "-ok", "-okdir"}
-
 
 def _split_command_tokens(command: str) -> list[str]:
     try:
@@ -190,6 +156,53 @@ def _split_command_tokens(command: str) -> list[str]:
         return list(lexer)
     except ValueError:
         return command.split()
+
+
+def _wrapped_guardrail_commands(command: str) -> list[str]:
+    """Extract statically visible commands invoked by shell builtins."""
+    tokens = _split_command_tokens(command)
+    if not tokens:
+        return []
+
+    if tokens[0] == "eval":
+        evaluated = " ".join(tokens[1:])
+        if not evaluated:
+            return []
+        return list(analyze_shell_command(evaluated).command_parts)
+
+    if tokens[0] != "exec":
+        return []
+
+    index = 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token == "-a":
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    if index >= len(tokens):
+        return []
+    return [" ".join(tokens[index:])]
+
+
+def _expand_guardrail_commands(command_parts: list[str]) -> list[str]:
+    expanded: list[str] = []
+    pending = list(command_parts)
+    seen: set[str] = set()
+    while pending:
+        part = pending.pop(0)
+        if part in seen:
+            continue
+        seen.add(part)
+        expanded.append(part)
+        pending.extend(_wrapped_guardrail_commands(part))
+    return expanded
 
 
 def _collect_outside_dirs(
@@ -222,15 +235,11 @@ def _collect_outside_dirs(
     for part in command_parts:
         tokens = _split_command_tokens(part)
         command = tokens[0] if tokens else None
-        if not command or command not in _PATH_COMMANDS:
+        if not command:
             continue
-        for token in tokens[1:]:
-            # Skip CLI flags like -r, --recursive
-            if token.startswith("-"):
-                continue
-            # Skip chmod mode strings like +x, +rwx — they are not file paths
-            if command == "chmod" and token.startswith("+"):
-                continue
+        for token in path_candidates(
+            tokens, inspect_positional_paths=command in _PATH_COMMANDS
+        ):
             # Only consider tokens that look like paths
             if not (
                 token.startswith("/")
@@ -352,13 +361,6 @@ class Bash(
         return "Running command"
 
     @staticmethod
-    def _has_find_execution_predicate(command: str) -> bool:
-        """Defensive check for find -exec, -execdir, -ok, -okdir predicates."""
-        if not _matches_pattern(command, "find"):
-            return False
-        return any(predicate in command for predicate in _FIND_EXECUTION_PREDICATES)
-
-    @staticmethod
     def _build_command_required_permission(
         invocation_pattern: str, session_pattern: str, label: str
     ) -> RequiredPermission:
@@ -410,10 +412,10 @@ class Bash(
     def _resolve_guardrail_permission(
         self, command_parts: list[str]
     ) -> PermissionContext | None:
-        find_execution_required: list[RequiredPermission] = []
-        seen_find_execution: set[str] = set()
+        option_required: list[RequiredPermission] = []
+        seen_option_required: set[str] = set()
 
-        for part in command_parts:
+        for part in _expand_guardrail_commands(command_parts):
             if matched := self._find_denylist_match(part):
                 return PermissionContext(
                     permission=ToolPermission.NEVER,
@@ -424,21 +426,23 @@ class Bash(
                     permission=ToolPermission.NEVER,
                     reason=f"Command denied: '{part}' is not allowed as a standalone command. Do not attempt to run this command.",
                 )
-            if not self._has_find_execution_predicate(part):
+            if not analyze_shell_command_policy(
+                _split_command_tokens(part)
+            ).requires_approval:
                 continue
-            if part in seen_find_execution:
+            if part in seen_option_required:
                 continue
-            seen_find_execution.add(part)
-            find_execution_required.append(
+            seen_option_required.add(part)
+            option_required.append(
                 self._build_command_required_permission(
                     invocation_pattern=part, session_pattern=part, label=part
                 )
             )
 
-        if not find_execution_required:
+        if not option_required:
             return None
         return PermissionContext(
-            permission=ToolPermission.ASK, required_permissions=find_execution_required
+            permission=ToolPermission.ASK, required_permissions=option_required
         )
 
     def _is_unconditionally_allowed(
@@ -500,8 +504,9 @@ class Bash(
         if not uses_posix_shell():
             return None
 
-        command_parts = _extract_commands(args.command)
-        if not command_parts:
+        analysis = analyze_shell_command(args.command)
+        command_parts = list(analysis.command_parts)
+        if not command_parts and not analysis.requires_approval:
             return None
 
         guardrail_permission = self._resolve_guardrail_permission(command_parts)
@@ -516,12 +521,21 @@ class Bash(
         if (
             self._is_unconditionally_allowed(command_parts, outside_dirs)
             and not guardrail_permission
+            and not analysis.requires_approval
         ):
             return PermissionContext(permission=ToolPermission.ALWAYS)
 
         required = self._build_required_permissions(command_parts, outside_dirs)
         if guardrail_permission:
             required.extend(guardrail_permission.required_permissions)
+        if analysis.requires_approval:
+            required.append(
+                self._build_command_required_permission(
+                    invocation_pattern=args.command,
+                    session_pattern=args.command,
+                    label=analysis.approval_label,
+                )
+            )
         if not required:
             return None
 

--- a/vibe/core/tools/builtins/experimental_bash.py
+++ b/vibe/core/tools/builtins/experimental_bash.py
@@ -26,8 +26,6 @@ from pydantic import (
     computed_field,
     model_validator,
 )
-from tree_sitter import Language, Node, Parser
-import tree_sitter_bash as tsbash
 
 from vibe.core.paths import VIBE_HOME
 from vibe.core.scratchpad import is_scratchpad_path
@@ -40,7 +38,12 @@ from vibe.core.tools.base import (
     ToolError,
     ToolPermission,
 )
-from vibe.core.tools.builtins.bash import BashToolConfig
+from vibe.core.tools.builtins._shell_command_policy import (
+    analyze_shell_command_policy,
+    path_candidates,
+)
+from vibe.core.tools.builtins._shell_permission_analysis import analyze_shell_command
+from vibe.core.tools.builtins.bash import BashToolConfig, _expand_guardrail_commands
 from vibe.core.tools.builtins.managed_shell import backend as managed_shell_backend
 from vibe.core.tools.builtins.managed_shell.backend import (
     UNKNOWN_EXIT_CODE,
@@ -176,42 +179,8 @@ class SessionNotFoundError(ManagedShellError):
     pass
 
 
-@functools.lru_cache(maxsize=1)
-def _get_parser() -> Parser:
-    return Parser(Language(tsbash.language()))
-
-
 def _extract_commands(command: str) -> list[str]:
-    parser = _get_parser()
-    tree = parser.parse(command.encode("utf-8"))
-
-    commands: list[str] = []
-
-    def find_commands(node: Node) -> None:
-        if node.type == "command":
-            parts = []
-            for child in node.children:
-                if (
-                    child.type
-                    in {"command_name", "word", "string", "raw_string", "concatenation"}
-                    and child.text is not None
-                ):
-                    parts.append(child.text.decode("utf-8"))
-            # When a command has a heredoc (or other redirect), tree-sitter
-            # wraps it in a redirected_statement and the redirect is a sibling
-            # of the command node, not a child.  Without this check,
-            # `python3 << 'EOF'` is extracted as bare `python3` and
-            # incorrectly blocked by the standalone denylist.
-            if parts and node.parent and node.parent.type == "redirected_statement":
-                parts.append("<redirect>")
-            if parts:
-                commands.append(" ".join(parts))
-
-        for child in node.children:
-            find_commands(child)
-
-    find_commands(tree.root_node)
-    return commands
+    return list(analyze_shell_command(command).command_parts)
 
 
 def _get_shell_executable() -> str | None:
@@ -337,8 +306,6 @@ def _get_default_denylist_standalone() -> list[str]:
 _MUTATING_PATH_COMMANDS = {"cd", "chmod", "chown", "cp", "mkdir", "mv", "rm", "touch"}
 _PATH_COMMANDS = _MUTATING_PATH_COMMANDS | set(_READ_ONLY_COMMANDS_POSIX)
 
-_FIND_EXECUTION_PREDICATES = {"-exec", "-execdir", "-ok", "-okdir"}
-
 
 def _split_command_tokens(
     command: str, *, preserve_backslashes: bool = False
@@ -386,13 +353,9 @@ def _collect_outside_dirs(
         if not command:
             continue
         command_name = command if case_sensitive_commands else command.lower()
-        if command_name not in path_commands:
-            continue
-        for token in tokens[1:]:
-            if token.startswith("-"):
-                continue
-            if command_name == "chmod" and token.startswith("+"):
-                continue
+        for token in path_candidates(
+            tokens, inspect_positional_paths=command_name in path_commands
+        ):
             if not _looks_like_path(token):
                 continue
 
@@ -1454,12 +1417,6 @@ class _BashPermissionMixin[ConfigT: BashToolConfig]:
         scratchpad_dir: Path | None
 
     @staticmethod
-    def _has_find_execution_predicate(command: str) -> bool:
-        if not _matches_pattern(command, "find"):
-            return False
-        return any(predicate in command for predicate in _FIND_EXECUTION_PREDICATES)
-
-    @staticmethod
     def _build_command_required_permission(
         invocation_pattern: str, session_pattern: str, label: str
     ) -> RequiredPermission:
@@ -1516,10 +1473,10 @@ class _BashPermissionMixin[ConfigT: BashToolConfig]:
     def _resolve_guardrail_permission(
         self, command_parts: list[str]
     ) -> PermissionContext | None:
-        find_execution_required: list[RequiredPermission] = []
-        seen_find_execution: set[str] = set()
+        option_required: list[RequiredPermission] = []
+        seen_option_required: set[str] = set()
 
-        for part in command_parts:
+        for part in _expand_guardrail_commands(command_parts):
             if matched := self._find_denylist_match(part):
                 return PermissionContext(
                     permission=ToolPermission.NEVER,
@@ -1530,21 +1487,23 @@ class _BashPermissionMixin[ConfigT: BashToolConfig]:
                     permission=ToolPermission.NEVER,
                     reason=f"Command denied: '{part}' is not allowed as a standalone command. Do not attempt to run this command.",
                 )
-            if not self._has_find_execution_predicate(part):
+            if not analyze_shell_command_policy(
+                _split_command_tokens(part)
+            ).requires_approval:
                 continue
-            if part in seen_find_execution:
+            if part in seen_option_required:
                 continue
-            seen_find_execution.add(part)
-            find_execution_required.append(
+            seen_option_required.add(part)
+            option_required.append(
                 self._build_command_required_permission(
                     invocation_pattern=part, session_pattern=part, label=part
                 )
             )
 
-        if not find_execution_required:
+        if not option_required:
             return None
         return PermissionContext(
-            permission=ToolPermission.ASK, required_permissions=find_execution_required
+            permission=ToolPermission.ASK, required_permissions=option_required
         )
 
     def _is_unconditionally_allowed(
@@ -1618,8 +1577,9 @@ class _BashPermissionMixin[ConfigT: BashToolConfig]:
         cwd: str | None,
         required_context_permissions: list[RequiredPermission] | None = None,
     ) -> PermissionContext | None:
-        command_parts = _extract_commands(command)
-        if not command_parts:
+        analysis = analyze_shell_command(command)
+        command_parts = list(analysis.command_parts)
+        if not command_parts and not analysis.requires_approval:
             return None
 
         guardrail_permission = self._resolve_guardrail_permission(command_parts)
@@ -1642,6 +1602,7 @@ class _BashPermissionMixin[ConfigT: BashToolConfig]:
                 command_parts, outside_dirs, context_required
             )
             and not guardrail_permission
+            and not analysis.requires_approval
         ):
             return PermissionContext(permission=ToolPermission.ALWAYS)
 
@@ -1650,6 +1611,14 @@ class _BashPermissionMixin[ConfigT: BashToolConfig]:
         )
         if guardrail_permission:
             required.extend(guardrail_permission.required_permissions)
+        if analysis.requires_approval:
+            required.append(
+                self._build_command_required_permission(
+                    invocation_pattern=command,
+                    session_pattern=command,
+                    label=analysis.approval_label,
+                )
+            )
         if not required:
             return None
 

--- a/vibe/core/tools/ui.py
+++ b/vibe/core/tools/ui.py
@@ -190,13 +190,5 @@ class ToolUIDataAdapter:
         if self.ui_data_class is not None and event.result is not None:
             projected_output = self.ui_data_class.project_result(event.result)
         return ToolResultPresentation(
-            kind=self.effect_kind,
-            display=ToolResultDisplay(
-                success=display.success,
-                verb=display.verb,
-                message=display.message,
-                warnings=display.warnings,
-                suffix=display.suffix,
-            ),
-            projected_output=projected_output,
+            kind=self.effect_kind, display=display, projected_output=projected_output
         )

--- a/vibe/utils/tool_presentation.py
+++ b/vibe/utils/tool_presentation.py
@@ -48,6 +48,9 @@ class EffectResultDisplay(PresentationModel):
     verb: str = ""
     message: str
     warnings: list[str] = Field(default_factory=list)
+    # Why the call ran without asking (smart approve). Not a warning: the
+    # call succeeded and was authorised, so it must not read as a problem.
+    approval_note: str | None = None
     suffix: str = ""
 
     @property

--- a/vibe/whats_new.md
+++ b/vibe/whats_new.md
@@ -1,6 +1,6 @@
-# What's new in v2.25.3
+# What's new in v2.25.4
 
 - **Queued prompts**: messages you queue while Vibe is working are now sent together in one turn, not one at a time
 - **Stable session models**: resumed conversations keep the model selected for that session
-- **Compact tool call groups**: consecutive tool calls now fold into a one-line summary (e.g. "Running commands" while in progress, "Ran commands" when done). Click to expand the full list, or use Ctrl+O to toggle all groups at once. File edits and writes are included in the fold
+- **Compact tool call groups**: consecutive tool calls now fold into a one-line summary (e.g. "Running commands" while in progress, "Ran commands" when done). Click to expand the full list, or use Ctrl+O to toggle all groups at once. File edits and writes are included in the fold.
 - **Experimental harness**: You can now try our new experimental harness with the --experimental-harness flag.


### PR DESCRIPTION
Release v2.25.4 from dashboard merge f87e4655d83cbac3f8bfa891e3739963e2db6f6c, including the shell-permission security fixes recorded in CHANGELOG.md.

Also includes the cryptography Nix source-build fix from d6f39055d72d66eb40259fe0b574e58331149a8a, adapted for the pinned Nixpkgs SDK. Source builds now receive maturin, the Rust toolchain and vendored crates, OpenSSL, and libiconv; platforms with compatible wheels keep their existing build path.

Validation: Nix evaluation passes for macOS and Linux on both architectures. All public CI checks pass, including the actual Nix macOS Intel source build and its version smoke test. The four prior What’s New bullets are preserved with only the version header updated.
